### PR TITLE
Establish PR-first workflow for humans and AI agents

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+<!--
+PR-first workflow — see CLAUDE.md / AGENTS.md "Workflow" section.
+Never push directly to main. Always merge through a PR.
+-->
+
+## Summary
+
+<!-- 1-3 bullets: what changed and why. Link issues/Linear if relevant. -->
+
+-
+
+## Preview
+
+<!--
+For frontend / Dockerfile.site / fly.site.toml changes:
+The site-preview workflow will deploy pr-<N>-hedge-in-a-box-site.fly.dev
+and edit a sticky comment with the URL. Paste it here once it's up.
+
+For backend-only changes (src/, bot/):
+Write "n/a — backend only" and describe how you verified locally.
+-->
+
+URL:
+
+## Test plan
+
+<!-- Checklist of what was verified, on what surface (preview / local / both). -->
+
+- [ ]
+- [ ]
+
+## Notes for reviewer
+
+<!-- Anything subtle, risky, or out of scope worth flagging. Optional. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,37 @@ Guidance for AI coding agents (Codex, etc.) working in this repo.
 
 This file mirrors the most important cross-cutting rules so Codex doesn't have to chase indirections.
 
+## Workflow: PR-first, never push to main
+
+**Never commit or push directly to `main` / `master`.** Every change goes through a pull request — no exceptions unless the user explicitly authorizes a direct push (e.g. recovering a broken `main`).
+
+A merge to `main` triggers a prod deploy. Direct pushes bypass review and the per-PR preview environment, both of which exist precisely to keep prod safe. The PR is the unit of work; treat the branch as scratch.
+
+Concrete flow when starting work:
+
+```bash
+git checkout main && git pull
+git checkout -b <type>/<short-desc>   # feat/, fix/, chore/, refactor/, test/
+# ...edit, commit...
+git push -u origin <branch>
+gh pr create --title "..." --body "..."   # use .github/pull_request_template.md
+```
+
+Then:
+
+- For **frontend / `Dockerfile.site` / `fly.site.toml`** changes, the preview workflow ([.github/workflows/preview-site.yml](.github/workflows/preview-site.yml)) auto-deploys `pr-<N>-hedge-in-a-box-site.fly.dev` and posts the URL in a sticky comment. **Open the URL and verify the change** before declaring the task done; report what you verified in the PR body.
+- For **backend-only changes** (Python under [src/](src/), [bot/](bot/)), there is no preview app — verify locally and document the manual test in the PR's "Test plan" section so reviewers know the coverage.
+
+**Start every task from a clean `main`.** Before making any code change, check where you are: `git branch --show-current` and `git status`. If you're on a feature branch left over from a previous task, **do not pile new work onto it** — that branch belongs to a different PR and mixing changes will pollute its diff and confuse review. Switch to `main`, pull, and branch off:
+
+```bash
+git checkout main && git pull && git checkout -b <type>/<short-desc>
+```
+
+The only exception is when the user explicitly asks you to amend or extend a specific existing PR (e.g. "address review comments on #42") — in that case, check out that PR's branch and continue.
+
+If you find yourself on `main` with uncommitted changes, **stop and switch to a feature branch before committing**. Don't push.
+
 ## Frontend theming
 
 The Next.js app at [frontend/](frontend/) supports light + dark via `html[data-theme]`. Color tokens, contrast rules, and the do/don't list live in [frontend/BRAND_COLORS.md](frontend/BRAND_COLORS.md). **Read it before adding any color, chart, or theme-sensitive component.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,25 @@ Fly scripts at repo root: `deploy-site.ps1`, `deploy-bot.ps1`, or unified `deplo
 
 **Per-PR site previews.** [.github/workflows/preview-site.yml](.github/workflows/preview-site.yml) creates `pr-<N>-hedge-in-a-box-site.fly.dev` for any PR that touches `frontend/**`, `Dockerfile.site`, or `fly.site.toml`. The preview's `/data` volume is forked from the latest prod snapshot at PR open and kept for the life of the PR (staleness accepted). Machines auto-stop when idle. The app + volume are destroyed when the PR closes; [.github/workflows/preview-site-cleanup.yml](.github/workflows/preview-site-cleanup.yml) is a daily safety net that nukes preview apps older than 14 days.
 
+## Workflow (PR-first, no direct pushes to main)
+
+**Hard rule: never commit or push directly to `main`/`master`.** Every change — including agent-driven changes — goes through a pull request. A merge to `main` triggers a prod deploy via [.github/workflows/deploy-fly.yml](.github/workflows/deploy-fly.yml); we don't want that surface lit up by ad-hoc pushes.
+
+The flow:
+
+1. Branch off `main`: `git checkout main && git pull && git checkout -b <type>/<short-desc>` (e.g. `feat/discovery-filters`, `fix/sec-pagination`).
+2. Commit changes on that branch.
+3. Push: `git push -u origin <branch>`.
+4. Open a PR: `gh pr create --title "..." --body "..."`. Use the PR template; fill in the preview URL line if applicable.
+5. For **frontend / `Dockerfile.site` / `fly.site.toml`** PRs, the preview workflow auto-deploys `pr-<N>-hedge-in-a-box-site.fly.dev` and posts a sticky comment with the URL. **Verify the change on the preview** before requesting review.
+6. Merge via squash (keeps `main` history linear). Closing the PR tears down the preview.
+
+**Backend-only PRs** (Python under [src/](src/), [bot/](bot/)) do not get a preview environment. Verify locally — `python run.py --ticker AAPL` for valuation changes, `py bot/telegram_bot.py` against a staging Telegram bot for bot changes. State this in the PR's "Test plan" so the reviewer knows what coverage to expect.
+
+**Branch hygiene — start every task from a clean `main`.** Before making any code change, check the current branch (`git branch --show-current`) and working-tree state (`git status`). If you're sitting on a feature branch from a prior task, do **not** pile the new work onto it — that branch belongs to a different PR and mixing changes will pollute its diff. Always `git checkout main && git pull` and branch off fresh, unless the user explicitly asks you to amend or extend a specific existing PR.
+
+**Exceptions to the no-direct-push rule** are explicit, narrow, and human-authorized: a destructive `main` recovery, a CI-fix that unbreaks the deploy pipeline. Agents must not infer the exception themselves — ask the user first.
+
 ## Conventions
 
 - Python target is 3.11+ (Docker uses 3.12-slim).


### PR DESCRIPTION
## Summary

- Adds a hard "no direct pushes to `main`" rule to [CLAUDE.md](CLAUDE.md) and [AGENTS.md](AGENTS.md), with the exact branch + PR commands so agents (Claude Code, Codex, etc.) stop committing straight to `main`.
- Adds a **branch-hygiene** rule: every task starts from a clean `main`; agents must not pile new work onto a feature branch left over from a previous task.
- Adds [.github/pull_request_template.md](.github/pull_request_template.md) with explicit slots for the preview URL and a test-plan checklist.

## Preview

n/a — docs + template only, no frontend or `Dockerfile.site` changes, so the preview workflow doesn't trigger.

## Test plan

- [ ] After merge, open a fresh PR in any repo clone and confirm GitHub auto-fills the new PR template.
- [ ] Claude Code / Codex sessions in this repo pick up the updated `CLAUDE.md` / `AGENTS.md` on next `init`.

## Notes for reviewer

This codifies the workflow we just bootstrapped (per-PR Fly preview environments, `pr-<N>-hedge-in-a-box-site.fly.dev`). It does **not** by itself prevent direct pushes — that requires turning on **branch protection on `main`** in GitHub settings:

- Require a pull request before merging (≥1 approval).
- Block direct pushes to `main`.
- Optional: require linear history, require a pre-merge CI check.

Without branch protection the rule is honor-system; with it the rule is enforced. Worth doing as a follow-up.