### PR TITLE
Trigger site preview on src/ and requirements.txt changes

### DIFF
--- a/.github/workflows/preview-site.yml
+++ b/.github/workflows/preview-site.yml
@@ -5,6 +5,8 @@ on:
     types: [opened, reopened, synchronize, closed]
     paths:
       - 'frontend/**'
+      - 'src/**'
+      - 'requirements.txt'
       - 'Dockerfile.site'
       - 'fly.site.toml'
       - '.github/workflows/preview-site.yml'


### PR DESCRIPTION
## Summary

- Adds `src/**` and `requirements.txt` to the [preview-site.yml](.github/workflows/preview-site.yml) path filter.
- Python pipeline changes (e.g. [dashboard.py](src/ai_hedge/dashboard.py) JSON shape, [runner.py](src/ai_hedge/runner.py), [legacy_port.py](src/ai_hedge/legacy_port.py)) land in the same Docker image the site runs and are exercised when a developer triggers an analysis from the preview UI. Same for `requirements.txt` — version bumps land in the image.

## Preview

n/a — this PR only edits the workflow's `paths:` filter. The trigger only fires once this is on `main`.

## Test plan

- [ ] After merge, open a follow-up PR that touches only `src/ai_hedge/dashboard.py` and confirm `Site Preview / deploy` runs.
- [ ] Open a PR touching only `bot/` and confirm `Site Preview / deploy` does **not** run (bot is intentionally out of scope).

## Notes for reviewer

**Volume staleness still applies.** The preview's `/data` volume is forked from the prod snapshot at PR-open time, so existing `outputs/<TICKER>_dashboard.json` files are the *old* schema. To exercise a new pipeline output end-to-end, trigger a fresh ticker run on the preview UI — that one will produce JSON with the PR's pipeline code.

`bot/`, `run.py`, `run_lite.py` are deliberately excluded: bot has no preview by design, and the `run.py` CLI isn't exercised by the site at runtime.