### PR TITLE
Fix signin page build by importing next/image

### DIFF
--- a/frontend/src/app/auth/signin/page.tsx
+++ b/frontend/src/app/auth/signin/page.tsx
@@ -1,4 +1,4 @@
-import { BrandLogo } from "@/components/brand-logo";
+import Image from "next/image";
 import { SignInButton } from "@/components/auth/signin-button";
 
 type SearchParams = Promise<{ callbackUrl?: string; error?: string }>;


### PR DESCRIPTION
## Summary
- The Fly deploy of `hedge-in-a-box-site` failed on `npm run build` with `Type error: JSX element class does not support attributes because it does not have a 'props' property` at [src/app/auth/signin/page.tsx:30](frontend/src/app/auth/signin/page.tsx#L30).
- Root cause: commit 0a3fb38 added two `<Image>` tags to the signin page but forgot to add `import Image from "next/image";`. TypeScript treated `<Image>` as an unknown intrinsic JSX tag.
- Fix: add the missing `next/image` import; remove the now-unused `BrandLogo` import (the dual-`<Image>` + CSS-toggle pattern in `globals.css` is intentional — avoids the `useEffect` flash that `BrandLogo` would cause).

## Test plan
- [ ] CI / Site Preview workflow builds successfully (this is what failed on `main`).
- [ ] Visit `pr-<N>-hedge-in-a-box-site.fly.dev/auth/signin` and confirm the brand logo renders correctly in both light and dark themes.