### PR TITLE
Fix run progress/cancel UX and unify report-source counts

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8072,6 +8072,111 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.4.tgz",
+      "integrity": "sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.4.tgz",
+      "integrity": "sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.4.tgz",
+      "integrity": "sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.4.tgz",
+      "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.4.tgz",
+      "integrity": "sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.4.tgz",
+      "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.4.tgz",
+      "integrity": "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/frontend/src/app/api/dashboard/[ticker]/summary/route.ts
+++ b/frontend/src/app/api/dashboard/[ticker]/summary/route.ts
@@ -8,7 +8,7 @@ import {
   type SummaryWindow,
 } from "@/lib/ticker-summary-aggregate";
 import { listDashboardsForTicker } from "@/lib/reports-db";
-import { listDashboardFiles, readJson } from "@/lib/server-outputs";
+import { listDashboardReports, readJson } from "@/lib/server-outputs";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -21,36 +21,52 @@ function parseWindow(value: string | null): SummaryWindow {
   return WINDOW_VALUES.has(raw as SummaryWindow) ? (raw as SummaryWindow) : "all";
 }
 
+function siteRunIdFromPathLike(value: string): string | null {
+  const raw = String(value || "").trim();
+  if (!raw) return null;
+  const normalized = raw.replace(/\\/g, "/");
+  const match = normalized.match(/\/_site_runs\/([^/]+)/i);
+  return match?.[1] ? String(match[1]).trim() : null;
+}
+
 async function loadTickerDashboards(ticker: string): Promise<SummarySourceReport[]> {
+  const merged = new Map<string, SummarySourceReport>();
+
   try {
     const dbRows = await listDashboardsForTicker(ticker);
-    if (dbRows.length) {
-      return dbRows
-        .map((r) => ({
-          ticker: String(r.ticker || "").toUpperCase(),
-          generatedAt: new Date(r.generated_at).toISOString(),
-          payload: r.dashboard as DashboardPayload,
-        }))
-        .filter((row) => row.ticker === ticker && Boolean(row.payload));
+    for (const r of dbRows) {
+      const row = {
+        ticker: String(r.ticker || "").toUpperCase(),
+        generatedAt: new Date(r.generated_at).toISOString(),
+        payload: r.dashboard as DashboardPayload,
+      };
+      if (row.ticker !== ticker || !row.payload) continue;
+      const runId = String((r as { source_run_id?: unknown }).source_run_id || "").trim();
+      const key = runId ? `run:${row.ticker}:${runId}` : `db:${row.ticker}:${row.generatedAt}`;
+      merged.set(key, row);
     }
   } catch (err) {
     console.warn("[ticker-summary] DB read failed:", err);
   }
 
-  return listDashboardFiles()
-    .sort((a, b) => b.mtimeMs - a.mtimeMs)
-    .map((item) => {
-      const payload = readJson<DashboardPayload>(item.path);
-      if (!payload) return null;
-      const payloadTicker = String(payload.ticker || "").toUpperCase();
-      if (payloadTicker !== ticker) return null;
-      return {
-        ticker,
-        generatedAt: new Date(item.mtimeMs).toISOString(),
-        payload,
-      } satisfies SummarySourceReport;
-    })
-    .filter((row): row is SummarySourceReport => row !== null);
+  for (const entry of listDashboardReports()) {
+    if (String(entry.ticker || "").toUpperCase() !== ticker) continue;
+    const payload = readJson<DashboardPayload>(entry.path);
+    if (!payload) continue;
+    const generatedAt =
+      typeof payload.generated_at === "string" && payload.generated_at.trim()
+        ? payload.generated_at
+        : new Date(entry.mtimeMs).toISOString();
+    const row: SummarySourceReport = { ticker, generatedAt, payload };
+    const runId = siteRunIdFromPathLike(entry.path);
+    const key = runId ? `run:${ticker}:${runId}` : `file:${entry.path}`;
+    if (merged.has(key)) continue;
+    merged.set(key, row);
+  }
+
+  return Array.from(merged.values()).sort(
+    (a, b) => Date.parse(String(b.generatedAt || "")) - Date.parse(String(a.generatedAt || "")),
+  );
 }
 
 export async function GET(

--- a/frontend/src/app/api/discovery/route.ts
+++ b/frontend/src/app/api/discovery/route.ts
@@ -5,7 +5,7 @@ import { NextResponse } from "next/server";
 import { DashboardPayload, DiscoveryRow } from "@/lib/dashboard-types";
 import { getLiveCurrentPricesBatch } from "@/lib/dashboard-server";
 import { listAllDashboardsForHitRate } from "@/lib/reports-db";
-import { listDashboardFiles, readJson } from "@/lib/server-outputs";
+import { listDashboardReports, readJson } from "@/lib/server-outputs";
 import {
   computeTickerSummaryAggregation,
   filterReportsByWindow,
@@ -94,6 +94,14 @@ function cleanLensKey(value: string | null | undefined): string | null {
   return key ? key : null;
 }
 
+function siteRunIdFromPathLike(value: string): string | null {
+  const raw = String(value || "").trim();
+  if (!raw) return null;
+  const normalized = raw.replace(/\\/g, "/");
+  const match = normalized.match(/\/_site_runs\/([^/]+)/i);
+  return match?.[1] ? String(match[1]).trim() : null;
+}
+
 function resolveLensSelection(
   lensType: DiscoveryLensType,
   lensKey: string | null,
@@ -149,32 +157,49 @@ function resolveLensMetricsForTicker(
 async function loadDashboards(): Promise<
   Array<{ ticker: string; payload: DashboardPayload; updatedAt: string; sourceLabel: string }>
 > {
+  const merged = new Map<string, { ticker: string; payload: DashboardPayload; updatedAt: string; sourceLabel: string }>();
+
   try {
     const dbRows = await listAllDashboardsForHitRate();
-    if (dbRows.length) {
-      return dbRows.map((r) => ({
+    for (const r of dbRows) {
+      const row = {
         ticker: String(r.ticker).toUpperCase(),
         payload: r.dashboard as DashboardPayload,
         updatedAt: new Date(r.generated_at).toISOString(),
         sourceLabel: r.ticker,
-      }));
+      };
+      const runId = String(r.source_run_id || "").trim();
+      const key = runId ? `run:${row.ticker}:${runId}` : `db:${row.ticker}:${row.updatedAt}`;
+      merged.set(key, row);
     }
   } catch (err) {
     console.warn("[discovery] DB read failed:", err);
   }
-  const files = listDashboardFiles().sort((a, b) => b.mtimeMs - a.mtimeMs);
-  return files
-    .map((item) => {
-      const payload = readJson<DashboardPayload>(item.path);
-      if (!payload) return null;
-      return {
-        ticker: String(payload.ticker || "").toUpperCase(),
-        payload,
-        updatedAt: new Date(item.mtimeMs).toISOString(),
-        sourceLabel: item.path,
-      };
-    })
-    .filter((x): x is NonNullable<typeof x> => x !== null);
+
+  for (const entry of listDashboardReports()) {
+    const payload = readJson<DashboardPayload>(entry.path);
+    if (!payload) continue;
+    const ticker = String(payload.ticker || entry.ticker || "").toUpperCase();
+    if (!ticker) continue;
+    const updatedAt =
+      typeof payload.generated_at === "string" && payload.generated_at.trim()
+        ? payload.generated_at
+        : new Date(entry.mtimeMs).toISOString();
+    const row = {
+      ticker,
+      payload,
+      updatedAt,
+      sourceLabel: entry.path,
+    };
+    const runId = siteRunIdFromPathLike(entry.path);
+    const key = runId ? `run:${ticker}:${runId}` : `file:${entry.path}`;
+    if (merged.has(key)) continue;
+    merged.set(key, row);
+  }
+
+  return Array.from(merged.values()).sort(
+    (a, b) => Date.parse(String(b.updatedAt || "")) - Date.parse(String(a.updatedAt || "")),
+  );
 }
 
 export async function GET(request: Request) {

--- a/frontend/src/app/api/hit-rate/route.ts
+++ b/frontend/src/app/api/hit-rate/route.ts
@@ -4,7 +4,7 @@ import type { DashboardPayload } from "@/lib/dashboard-types";
 import { getLiveCurrentPricesBatch } from "@/lib/dashboard-server";
 import { computeHitRateAggregation, type HitRateMode } from "@/lib/hit-rate-aggregate";
 import { listAllDashboardsForHitRate } from "@/lib/reports-db";
-import { listDashboardFiles, readJson } from "@/lib/server-outputs";
+import { listDashboardReports, readJson } from "@/lib/server-outputs";
 
 type LoadedDashboard = {
   ticker: string;
@@ -16,36 +16,53 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
+function siteRunIdFromPathLike(value: string): string | null {
+  const raw = String(value || "").trim();
+  if (!raw) return null;
+  const normalized = raw.replace(/\\/g, "/");
+  const match = normalized.match(/\/_site_runs\/([^/]+)/i);
+  return match?.[1] ? String(match[1]).trim() : null;
+}
+
 async function loadHistoricalDashboards(): Promise<LoadedDashboard[]> {
+  const merged = new Map<string, LoadedDashboard>();
+
   try {
     const dbRows = await listAllDashboardsForHitRate();
-    if (dbRows.length) {
-      return dbRows
-        .map((r) => ({
-          ticker: String(r.ticker || "").toUpperCase(),
-          generatedAt: new Date(r.generated_at).toISOString(),
-          payload: r.dashboard as DashboardPayload,
-        }))
-        .filter((row) => Boolean(row.ticker && row.payload));
+    for (const r of dbRows) {
+      const row = {
+        ticker: String(r.ticker || "").toUpperCase(),
+        generatedAt: new Date(r.generated_at).toISOString(),
+        payload: r.dashboard as DashboardPayload,
+      };
+      if (!row.ticker || !row.payload) continue;
+      const runId = String(r.source_run_id || "").trim();
+      const key = runId ? `run:${row.ticker}:${runId}` : `db:${row.ticker}:${row.generatedAt}`;
+      merged.set(key, row);
     }
   } catch (err) {
     console.warn("[hit-rate] DB read failed:", err);
   }
 
-  const files = listDashboardFiles().sort((a, b) => b.mtimeMs - a.mtimeMs);
-  return files
-    .map((item) => {
-      const payload = readJson<DashboardPayload>(item.path);
-      if (!payload) return null;
-      const ticker = String(payload.ticker || "").toUpperCase();
-      if (!ticker) return null;
-      return {
-        ticker,
-        generatedAt: new Date(item.mtimeMs).toISOString(),
-        payload,
-      };
-    })
-    .filter((x): x is NonNullable<typeof x> => x !== null);
+  for (const entry of listDashboardReports()) {
+    const payload = readJson<DashboardPayload>(entry.path);
+    if (!payload) continue;
+    const ticker = String(payload.ticker || entry.ticker || "").toUpperCase();
+    if (!ticker) continue;
+    const generatedAt =
+      typeof payload.generated_at === "string" && payload.generated_at.trim()
+        ? payload.generated_at
+        : new Date(entry.mtimeMs).toISOString();
+    const row = { ticker, generatedAt, payload };
+    const runId = siteRunIdFromPathLike(entry.path);
+    const key = runId ? `run:${ticker}:${runId}` : `file:${entry.path}`;
+    if (merged.has(key)) continue;
+    merged.set(key, row);
+  }
+
+  return Array.from(merged.values()).sort(
+    (a, b) => Date.parse(String(b.generatedAt || "")) - Date.parse(String(a.generatedAt || "")),
+  );
 }
 
 function parseMode(value: string | null): HitRateMode {

--- a/frontend/src/app/api/run-analysis/[jobId]/route.ts
+++ b/frontend/src/app/api/run-analysis/[jobId]/route.ts
@@ -2,6 +2,8 @@ import fs from "node:fs";
 
 import { NextResponse } from "next/server";
 
+import { auth } from "@/auth";
+import { hostnameFromRequestUrl, shouldBypassAuthForHostname } from "@/lib/auth-bypass";
 import { attributeReportToUser, findReportIdBySourceRunId } from "@/lib/reports-db";
 import {
   reconcileStaleRunsAfterRestart,
@@ -22,6 +24,75 @@ function writeStatusSafe(status: RunStatusPayload): void {
   } catch {
     // best effort
   }
+}
+
+const PERSISTENCE_ONLY_ERROR_RE = /no reports row found for source_run_id/i;
+
+function shouldTreatAsCompleted(status: RunStatusPayload): boolean {
+  if (status.status !== "failed") return false;
+  if (!PERSISTENCE_ONLY_ERROR_RE.test(String(status.persistence_error || status.error || ""))) return false;
+  const result = status.result as Record<string, unknown> | null | undefined;
+  return String(result?.status || "").toLowerCase() === "success";
+}
+
+function reconcileLegacyPersistenceFailure(status: RunStatusPayload): RunStatusPayload {
+  if (!shouldTreatAsCompleted(status)) return status;
+  const next: RunStatusPayload = {
+    ...status,
+    status: "completed",
+    error: "",
+  };
+  writeStatusSafe(next);
+  return next;
+}
+
+function progressPctFromPhaseLines(progressLines: string[]): number {
+  if (!progressLines.length) return 0;
+  const joined = progressLines.join("\n").toLowerCase();
+
+  // Milestone fallback when LLM call counting cannot be observed.
+  const steps = [
+    { pattern: "finished analysis of files and financials", pct: 20 },
+    { pattern: "finished analysis from sec filings", pct: 40 },
+    { pattern: "finished dashboard extraction (pre-valuation)", pct: 60 },
+    { pattern: "finished valuations", pct: 85 },
+    { pattern: "finished technical analysis", pct: 97 },
+  ];
+  let pct = 0;
+  for (const step of steps) {
+    if (joined.includes(step.pattern)) pct = Math.max(pct, step.pct);
+  }
+  return pct;
+}
+
+function parsePid(value: unknown): number | null {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return Math.trunc(n);
+}
+
+function tryTerminatePid(pid: number): boolean {
+  try {
+    // Detached children usually run as their own process group on Linux.
+    process.kill(-pid, "SIGTERM");
+    return true;
+  } catch {
+    try {
+      process.kill(pid, "SIGTERM");
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+function cancelStatus(status: RunStatusPayload, message: string): RunStatusPayload {
+  return {
+    ...status,
+    status: "failed",
+    finished_at: new Date().toISOString(),
+    error: message,
+  };
 }
 
 async function hydrateReportIdIfMissing(status: RunStatusPayload): Promise<RunStatusPayload> {
@@ -84,22 +155,104 @@ export async function GET(
     return NextResponse.json({ error: "Job not found." }, { status: 404 });
   }
 
-  const updatedStatus = await reconcileCompletedStatus(status);
+  const reconciledStatus = reconcileLegacyPersistenceFailure(status);
+  const updatedStatus = await reconcileCompletedStatus(reconciledStatus);
 
   const progress = readProgressLines(updatedStatus.progress_file || "", 80);
   const llmTotal = typeof updatedStatus.llm_total_estimated === "number" ? updatedStatus.llm_total_estimated : 0;
   const llmDone = typeof updatedStatus.llm_completed === "number" ? updatedStatus.llm_completed : 0;
-  const llmPct =
+  let llmPct =
     typeof updatedStatus.llm_progress_pct === "number"
       ? updatedStatus.llm_progress_pct
       : llmTotal > 0
         ? Math.min(100, Number(((llmDone / llmTotal) * 100).toFixed(2)))
         : 0;
+
+  if (llmPct <= 0 && updatedStatus.status === "running") {
+    llmPct = progressPctFromPhaseLines(progress);
+  }
+  if (updatedStatus.status === "completed") {
+    llmPct = Math.max(llmPct, 100);
+  }
+  llmPct = Math.max(0, Math.min(100, Number(llmPct.toFixed(2))));
+
   return NextResponse.json({
     ...updatedStatus,
     llm_total_estimated: llmTotal,
     llm_completed: llmDone,
     llm_progress_pct: llmPct,
     progress,
+  });
+}
+
+export async function DELETE(
+  req: Request,
+  context: { params: Promise<{ jobId: string }> },
+) {
+  reconcileStaleRunsAfterRestart();
+
+  const bypassAuth = shouldBypassAuthForHostname(hostnameFromRequestUrl(req.url));
+  const session = await auth();
+  const userId = session?.user?.id || (bypassAuth ? "local-dev" : "");
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!bypassAuth && session?.user?.isGuest) {
+    return NextResponse.json(
+      {
+        error: "Please sign in with Google before stopping a run.",
+        code: "SIGN_IN_REQUIRED",
+      },
+      { status: 403 },
+    );
+  }
+
+  const { jobId } = await context.params;
+  const cleanJobId = String(jobId || "").trim();
+  if (!cleanJobId) {
+    return NextResponse.json({ error: "Job id is required." }, { status: 400 });
+  }
+
+  const status = readRunStatus(cleanJobId);
+  if (!status) {
+    return NextResponse.json({ error: "Job not found." }, { status: 404 });
+  }
+
+  // Only the run owner can cancel unless local bypass is active.
+  const statusUserId = String(status.user_id || "").trim();
+  if (!bypassAuth && statusUserId && statusUserId !== userId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  if (status.status === "completed" || status.status === "failed") {
+    return NextResponse.json({ ok: true, already_finished: true, status: status.status });
+  }
+
+  const pids = Array.from(
+    new Set(
+      [parsePid(status.worker_pid), parsePid(status.runner_pid)].filter(
+        (pid): pid is number => typeof pid === "number" && pid > 0,
+      ),
+    ),
+  );
+
+  let killedAny = false;
+  for (const pid of pids) {
+    if (tryTerminatePid(pid)) {
+      killedAny = true;
+    }
+  }
+
+  const message = killedAny
+    ? "Run canceled by user."
+    : "Cancellation requested by user. Process termination could not be confirmed.";
+  const canceled = cancelStatus(status, message);
+  writeStatusSafe(canceled);
+
+  return NextResponse.json({
+    ok: true,
+    status: canceled.status,
+    killed: killedAny,
+    message,
   });
 }

--- a/frontend/src/app/api/run-analysis/route.ts
+++ b/frontend/src/app/api/run-analysis/route.ts
@@ -95,6 +95,8 @@ export async function POST(req: Request) {
     progress_file: progressFile,
     user_id: userId,
     attributed: false,
+    runner_pid: null,
+    worker_pid: null,
     llm_total_estimated: 30,
     llm_completed: 0,
     llm_progress_pct: 0,
@@ -140,6 +142,11 @@ export async function POST(req: Request) {
         },
       },
     );
+    const queuedStatus: RunStatusPayload = {
+      ...initialStatus,
+      runner_pid: typeof child.pid === "number" ? child.pid : null,
+    };
+    writeStatus(statusFile, queuedStatus);
     child.unref();
   } catch (err) {
     const failedStatus: RunStatusPayload = {

--- a/frontend/src/components/active-run-indicator.tsx
+++ b/frontend/src/components/active-run-indicator.tsx
@@ -7,6 +7,7 @@ import { CheckCircle2, Loader2, XCircle } from "lucide-react";
 import type { ClientActiveRun } from "@/lib/active-runs";
 import { getProgressStep } from "@/lib/run-progress";
 import {
+  cancelActiveRun,
   getActiveRunsSnapshot,
   subscribeActiveRuns,
   subscribeRunCompletion,
@@ -28,6 +29,7 @@ function safePct(value: number | undefined): number {
 export function ActiveRunIndicator() {
   const [runs, setRuns] = useState<ClientActiveRun[]>(() => getActiveRunsSnapshot());
   const [toasts, setToasts] = useState<Toast[]>([]);
+  const [stoppingJobId, setStoppingJobId] = useState<string>("");
 
   useEffect(() => subscribeActiveRuns(setRuns), []);
 
@@ -62,6 +64,7 @@ export function ActiveRunIndicator() {
   const topRun = activeRuns[0];
   const topPct = safePct(topRun?.llm_progress_pct);
   const topStep = getProgressStep(topPct);
+  const topRunStopping = Boolean(topRun?.job_id && stoppingJobId === topRun.job_id);
 
   return (
     <>
@@ -79,8 +82,32 @@ export function ActiveRunIndicator() {
               </div>
               <div className="mt-1 flex items-center justify-between gap-3">
                 <span className="hib-active-run-text text-[11px] tracking-[0.08em]">{topStep}</span>
-                <div className="h-1.5 w-40 overflow-hidden rounded-full bg-white/10">
-                  <div className="h-full rounded-full bg-emerald-300 transition-all duration-500" style={{ width: `${topPct}%` }} />
+                <div className="flex items-center gap-2">
+                  {topRun ? (
+                    <button
+                      type="button"
+                      disabled={topRunStopping}
+                      onClick={async () => {
+                        const ok = window.confirm(`Stop analysis for ${topRun.ticker}?`);
+                        if (!ok) return;
+                        setStoppingJobId(topRun.job_id);
+                        try {
+                          const res = await cancelActiveRun(topRun.job_id);
+                          if (!res.ok) {
+                            window.alert(res.error || "Failed to stop run.");
+                          }
+                        } finally {
+                          setStoppingJobId("");
+                        }
+                      }}
+                      className="rounded border border-red-400/50 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.08em] text-red-100 hover:bg-red-500/20 disabled:opacity-60"
+                    >
+                      {topRunStopping ? "Stopping..." : "Stop"}
+                    </button>
+                  ) : null}
+                  <div className="h-1.5 w-40 overflow-hidden rounded-full bg-white/10">
+                    <div className="h-full rounded-full bg-emerald-300 transition-all duration-500" style={{ width: `${topPct}%` }} />
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/shell/active-runs-panel.tsx
+++ b/frontend/src/components/shell/active-runs-panel.tsx
@@ -3,11 +3,12 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { Loader2 } from "lucide-react";
-import { subscribeActiveRuns, getActiveRunsSnapshot } from "@/components/shell/active-runs-store";
+import { cancelActiveRun, subscribeActiveRuns, getActiveRunsSnapshot } from "@/components/shell/active-runs-store";
 import type { ClientActiveRun } from "@/lib/active-runs";
 
 export function ActiveRunsPanel({ collapsed = false }: { collapsed?: boolean }) {
   const [runs, setRuns] = useState<ClientActiveRun[]>(() => getActiveRunsSnapshot());
+  const [stoppingJobId, setStoppingJobId] = useState<string>("");
 
   useEffect(() => {
     return subscribeActiveRuns(setRuns);
@@ -33,20 +34,45 @@ export function ActiveRunsPanel({ collapsed = false }: { collapsed?: boolean }) 
       <ul className="space-y-1">
         {active.slice(0, 4).map((run) => {
           const pct = typeof run.llm_progress_pct === "number" ? Math.max(0, Math.min(100, run.llm_progress_pct)) : 0;
+          const isStopping = stoppingJobId === run.job_id;
           return (
             <li key={run.job_id}>
-              <Link
-                href={`/dashboard/${encodeURIComponent(run.ticker)}/summary`}
-                className="block rounded-md px-2 py-1 text-xs text-emerald-50 hover:bg-emerald-500/12"
-              >
+              <div className="rounded-md px-2 py-1 text-xs text-emerald-50 hover:bg-emerald-500/12">
                 <div className="flex items-center justify-between gap-2">
-                  <span className="font-semibold">{run.ticker}</span>
-                  <span className="text-[10px]">{pct.toFixed(0)}%</span>
+                  <Link
+                    href={`/dashboard/${encodeURIComponent(run.ticker)}/summary`}
+                    className="font-semibold hover:underline"
+                  >
+                    {run.ticker}
+                  </Link>
+                  <div className="flex items-center gap-2">
+                    <span className="text-[10px]">{pct.toFixed(0)}%</span>
+                    <button
+                      type="button"
+                      disabled={isStopping}
+                      onClick={async () => {
+                        const ok = window.confirm(`Stop analysis for ${run.ticker}?`);
+                        if (!ok) return;
+                        setStoppingJobId(run.job_id);
+                        try {
+                          const res = await cancelActiveRun(run.job_id);
+                          if (!res.ok) {
+                            window.alert(res.error || "Failed to stop run.");
+                          }
+                        } finally {
+                          setStoppingJobId("");
+                        }
+                      }}
+                      className="rounded border border-red-400/50 px-1.5 py-0.5 text-[10px] font-semibold text-red-100 hover:bg-red-500/20 disabled:opacity-60"
+                    >
+                      {isStopping ? "..." : "Stop"}
+                    </button>
+                  </div>
                 </div>
                 <div className="mt-1 h-1 overflow-hidden rounded-full bg-white/10">
                   <div className="h-full bg-emerald-300 transition-all" style={{ width: `${pct}%` }} />
                 </div>
-              </Link>
+              </div>
             </li>
           );
         })}

--- a/frontend/src/components/shell/active-runs-store.ts
+++ b/frontend/src/components/shell/active-runs-store.ts
@@ -141,3 +141,28 @@ export function nudgeActiveRuns(): void {
   emit();
   if (timer != null) pollOnce();
 }
+
+export async function cancelActiveRun(jobId: string): Promise<{ ok: boolean; message?: string; error?: string }> {
+  const cleanJobId = String(jobId || "").trim();
+  if (!cleanJobId) {
+    return { ok: false, error: "Missing job id." };
+  }
+
+  try {
+    const res = await fetch(`/api/run-analysis/${encodeURIComponent(cleanJobId)}`, {
+      method: "DELETE",
+      cache: "no-store",
+    });
+    const json = (await res.json().catch(() => ({}))) as { ok?: boolean; message?: string; error?: string };
+    if (!res.ok || !json.ok) {
+      return { ok: false, error: String(json.error || "Failed to stop run.") };
+    }
+
+    removeActiveRun(cleanJobId);
+    latestRuns = listActiveRuns();
+    emit();
+    return { ok: true, message: String(json.message || "") };
+  } catch {
+    return { ok: false, error: "Failed to stop run." };
+  }
+}

--- a/frontend/src/components/shell/auth-menu.tsx
+++ b/frontend/src/components/shell/auth-menu.tsx
@@ -5,7 +5,11 @@ import Image from "next/image";
 import { LogIn, LogOut, UserCircle2 } from "lucide-react";
 import { signIn, signOut, useSession } from "next-auth/react";
 
-export function AuthMenu() {
+type AuthMenuProps = {
+  menuDirection?: "down" | "up";
+};
+
+export function AuthMenu({ menuDirection = "down" }: AuthMenuProps) {
   const { data: session, status } = useSession();
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement | null>(null);
@@ -53,6 +57,10 @@ export function AuthMenu() {
 
   const { name, email, image, isGuest } = session.user;
   const display = isGuest ? "Guest" : name || email || "Account";
+  const menuPositionClass =
+    menuDirection === "up"
+      ? "absolute bottom-full right-0 z-50 mb-2 w-64 rounded-xl p-2 shadow-xl"
+      : "absolute right-0 top-full z-50 mt-2 w-64 rounded-xl p-2 shadow-xl";
 
   return (
     <div ref={ref} className="relative">
@@ -80,7 +88,7 @@ export function AuthMenu() {
         </span>
       </button>
       {open ? (
-        <div className="hib-auth-menu absolute right-0 top-full z-50 mt-2 w-64 rounded-xl p-2 shadow-xl">
+        <div className={`hib-auth-menu ${menuPositionClass}`}>
           <div className="px-3 py-2 text-xs">
             <div className="truncate font-medium text-zinc-100">{isGuest ? "Guest session" : name || "Signed in"}</div>
             {email ? <div className="truncate text-zinc-400">{email}</div> : null}

--- a/frontend/src/components/shell/sidebar.tsx
+++ b/frontend/src/components/shell/sidebar.tsx
@@ -159,7 +159,7 @@ export function Sidebar({ collapsed, onToggle, mobile = false, onMobileClose }: 
             {mobile ? (
               <div className="flex items-center gap-2 normal-case tracking-normal">
                 <ThemeToggle className="h-8 px-2 py-1.5" />
-                <AuthMenu />
+                <AuthMenu menuDirection="up" />
               </div>
             ) : null}
           </div>

--- a/frontend/src/lib/dashboard-server.ts
+++ b/frontend/src/lib/dashboard-server.ts
@@ -39,36 +39,59 @@ export type LivePerformance = {
   };
 };
 
+function siteRunIdFromPathLike(value: string): string | null {
+  const raw = String(value || "").trim();
+  if (!raw) return null;
+  const normalized = raw.replace(/\\/g, "/");
+  const match = normalized.match(/\/_site_runs\/([^/]+)/i);
+  return match?.[1] ? String(match[1]).trim() : null;
+}
+
 async function loadReportsList(): Promise<ReportListItem[]> {
+  const merged = new Map<string, ReportListItem>();
+
   try {
     const dbRows = await listAllReports();
-    if (dbRows.length) {
-      return dbRows.map((r) => ({
+    for (const r of dbRows) {
+      const row: ReportListItem = {
         report_id: r.id,
         ticker: r.ticker,
         generated_at: new Date(r.generated_at).toISOString(),
         report_file: r.source_run_id || r.id,
         updated_at: new Date(r.generated_at).toISOString(),
-      }));
+      };
+      const runId = String(r.source_run_id || "").trim();
+      const key = runId ? `run:${String(r.ticker || "").toUpperCase()}:${runId}` : `db:${r.id}`;
+      merged.set(key, row);
     }
   } catch (err) {
     console.warn("[reports] DB read failed:", err);
   }
 
-  const rows: ReportListItem[] = [];
   const reports = listDashboardReports();
   for (const report of reports) {
     const payload = readJson<DashboardPayload>(report.path);
     const generatedAt = String(payload?.generated_at || new Date(report.mtimeMs).toISOString());
-    rows.push({
+    const row: ReportListItem = {
       report_id: report.report_id,
       ticker: report.ticker,
       generated_at: generatedAt,
       report_file: report.path,
       updated_at: new Date(report.mtimeMs).toISOString(),
-    });
+    };
+    const runId = siteRunIdFromPathLike(report.path);
+    const key = runId ? `run:${report.ticker}:${runId}` : `file:${report.path}`;
+    if (merged.has(key)) continue;
+    merged.set(key, row);
   }
-  return rows;
+
+  return Array.from(merged.values()).sort((a, b) => {
+    const aMs = Date.parse(String(a.generated_at || a.updated_at || ""));
+    const bMs = Date.parse(String(b.generated_at || b.updated_at || ""));
+    const safeA = Number.isFinite(aMs) ? aMs : 0;
+    const safeB = Number.isFinite(bMs) ? bMs : 0;
+    return safeB - safeA;
+  });
 }
 
 export const getReportsList = unstable_cache(

--- a/frontend/src/lib/reports-db.ts
+++ b/frontend/src/lib/reports-db.ts
@@ -462,32 +462,32 @@ export async function listDashboardsForDiscovery(): Promise<
  * pages like Hit Rate.
  */
 export async function listAllDashboardsForHitRate(): Promise<
-  { ticker: string; generated_at: string; dashboard: unknown }[]
+  { ticker: string; generated_at: string; dashboard: unknown; source_run_id: string | null }[]
 > {
   const sql = getSql();
   if (!sql) return [];
   const rows = (await sql`
-    SELECT r.ticker, r.generated_at, a.dashboard
+    SELECT r.ticker, r.generated_at, r.source_run_id, a.dashboard
       FROM reports r
       JOIN report_artifacts a ON a.report_id = r.id
      WHERE r.deleted_at IS NULL
      ORDER BY r.generated_at DESC;
-  `) as unknown as { ticker: string; generated_at: string; dashboard: unknown }[];
+  `) as unknown as { ticker: string; generated_at: string; dashboard: unknown; source_run_id: string | null }[];
   return rows;
 }
 
 export async function listDashboardsForTicker(ticker: string): Promise<
-  { ticker: string; generated_at: string; dashboard: unknown }[]
+  { ticker: string; generated_at: string; dashboard: unknown; source_run_id: string | null }[]
 > {
   const sql = getSql();
   if (!sql) return [];
   const rows = (await sql`
-    SELECT r.ticker, r.generated_at, a.dashboard
+    SELECT r.ticker, r.generated_at, r.source_run_id, a.dashboard
       FROM reports r
       JOIN report_artifacts a ON a.report_id = r.id
      WHERE r.deleted_at IS NULL
        AND r.ticker = ${String(ticker || "").toUpperCase()}
      ORDER BY r.generated_at DESC;
-  `) as unknown as { ticker: string; generated_at: string; dashboard: unknown }[];
+  `) as unknown as { ticker: string; generated_at: string; dashboard: unknown; source_run_id: string | null }[];
   return rows;
 }

--- a/frontend/src/lib/site-runner.ts
+++ b/frontend/src/lib/site-runner.ts
@@ -14,6 +14,8 @@ export type RunStatusPayload = {
   progress_file: string;
   user_id?: string | null;
   attributed?: boolean;
+  runner_pid?: number | null;
+  worker_pid?: number | null;
   llm_total_estimated?: number;
   llm_completed?: number;
   llm_progress_pct?: number;

--- a/scripts/site_run.py
+++ b/scripts/site_run.py
@@ -36,6 +36,12 @@ def _estimate_total_llm_calls() -> int:
         return 30
 
 
+def _looks_like_success_result(result: Any) -> bool:
+    if not isinstance(result, dict):
+        return False
+    return str(result.get("status", "") or "").strip().lower() == "success"
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Run a site-triggered valuation job.")
     parser.add_argument("--ticker", required=True, help="Ticker symbol")
@@ -72,6 +78,10 @@ def main() -> int:
         "finished_at": None,
         "output_dir": output_dir,
         "progress_file": progress_file,
+        "user_id": existing_status.get("user_id"),
+        "attributed": bool(existing_status.get("attributed", False)),
+        "runner_pid": existing_status.get("runner_pid"),
+        "worker_pid": os.getpid(),
         "llm_total_estimated": llm_total_estimated,
         "llm_completed": llm_completed,
         "llm_progress_pct": 0.0,
@@ -101,17 +111,21 @@ def main() -> int:
         from ai_hedge.service import run_full_analysis
 
         original_deepseek = legacy_port.deepseek_simple_text
+        original_full = legacy_port._deepseek_simple_full
 
-        def tracked_deepseek(*args, **kwargs):
+        def tracked_full(*args, **kwargs):
             nonlocal llm_completed
             try:
-                return original_deepseek(*args, **kwargs)
+                return original_full(*args, **kwargs)
             finally:
                 with lock:
                     llm_completed += 1
                 _write_running_progress()
 
-        legacy_port.deepseek_simple_text = tracked_deepseek
+        # Track the low-level full wrapper instead of deepseek_simple_text.
+        # obs.install() rebinds deepseek_simple_text, but it still calls
+        # _deepseek_simple_full internally.
+        legacy_port._deepseek_simple_full = tracked_full
 
         result = run_full_analysis(
             ticker=ticker,
@@ -154,19 +168,35 @@ def main() -> int:
             persistence_error = f"DB persistence verification failed: {persist_exc}"
 
         if not report_id:
-            failed_payload = {
+            # The run can still be materially successful for the user even if
+            # DB persistence is temporarily unavailable. Keep this as completed
+            # and surface the persistence issue for diagnostics.
+            completed_with_warning = {
                 **running_payload,
-                "status": "failed",
+                "status": "completed",
                 "finished_at": _utc_now(),
                 "llm_completed": llm_total_estimated if llm_total_estimated > llm_completed else llm_completed,
                 "llm_progress_pct": 100.0,
                 "result": result,
-                "error": persistence_error or "DB persistence failed.",
+                "report_id": None,
                 "persistence_error": persistence_error or "DB persistence failed.",
+                "error": "",
             }
-            _write_json(status_file, failed_payload)
+            if not _looks_like_success_result(result):
+                failed_payload = {
+                    **completed_with_warning,
+                    "status": "failed",
+                    "error": persistence_error or "DB persistence failed.",
+                }
+                _write_json(status_file, failed_payload)
+                legacy_port._deepseek_simple_full = original_full
+                legacy_port.deepseek_simple_text = original_deepseek
+                return 1
+
+            _write_json(status_file, completed_with_warning)
+            legacy_port._deepseek_simple_full = original_full
             legacy_port.deepseek_simple_text = original_deepseek
-            return 1
+            return 0
 
         completed_payload = {
             **running_payload,
@@ -178,6 +208,7 @@ def main() -> int:
             "report_id": report_id,
         }
         _write_json(status_file, completed_payload)
+        legacy_port._deepseek_simple_full = original_full
         legacy_port.deepseek_simple_text = original_deepseek
         return 0
     except Exception as exc:


### PR DESCRIPTION
## Summary
- fix run progress reporting during analysis and add fallback phase-based progress
- add stop-run flow with confirmation and backend cancellation endpoint
- fix mobile user identity menu visibility (open upward in mobile sidebar)
- unify report loading across DB + file-backed site runs with dedupe by run id

## Test plan
- npm run build (frontend)
- python -m py_compile scripts/site_run.py

## Preview
- PR includes frontend changes, so preview deployment should be created automatically by CI.