### PR TITLE
Fix report-scoped Analysis PDF downloads

### DIFF
--- a/frontend/src/app/api/artifacts/[ticker]/[kind]/route.ts
+++ b/frontend/src/app/api/artifacts/[ticker]/[kind]/route.ts
@@ -14,6 +14,36 @@ const KIND_TO_FILE: Record<string, { fileName: string; contentType: string }> = 
   "prices-chart": { fileName: "{TICKER}_prices_valuation.png", contentType: "image/png" },
 };
 
+function findInTree(rootDir: string, fileName: string): string | null {
+  const target = fileName.toUpperCase();
+  const stack: string[] = [rootDir];
+
+  while (stack.length) {
+    const dir = String(stack.pop() || "");
+    if (!dir) continue;
+    let entries: fs.Dirent[] = [];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(full);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      if (entry.name.toUpperCase() === target) {
+        return full;
+      }
+    }
+  }
+
+  return null;
+}
+
 export async function GET(
   request: Request,
   context: { params: Promise<{ ticker: string; kind: string }> },
@@ -37,7 +67,16 @@ export async function GET(
       const candidate = path.resolve(path.dirname(reportPath), fileName);
       if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
         foundPath = candidate;
+      } else {
+        foundPath = findInTree(path.dirname(reportPath), fileName) || "";
       }
+    }
+
+    if (!foundPath) {
+      return NextResponse.json(
+        { error: `${fileName} was not found for report_id=${reportId}.` },
+        { status: 404 },
+      );
     }
   }
 

--- a/frontend/src/components/shell/topbar.tsx
+++ b/frontend/src/components/shell/topbar.tsx
@@ -95,6 +95,7 @@ function SectionPills({
   const search = useSearchParams();
   const reportParam = search?.get("report");
   const suffix = reportParam ? `?report=${encodeURIComponent(reportParam)}` : "";
+  const pdfSuffix = reportParam ? `?report_id=${encodeURIComponent(reportParam)}` : "";
 
   return (
     <nav className="-mx-1 flex min-w-0 flex-1 items-center gap-1.5 overflow-x-auto px-1 sm:gap-2">
@@ -118,7 +119,7 @@ function SectionPills({
         );
       })}
       <a
-        href={`/api/artifacts/${encodeURIComponent(activeTicker)}/analysis-pdf`}
+        href={`/api/artifacts/${encodeURIComponent(activeTicker)}/analysis-pdf${pdfSuffix}`}
         className="inline-flex shrink-0 items-center gap-1.5 rounded-lg border border-white/15 bg-white/5 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-zinc-300 transition hover:border-white/30 hover:text-zinc-100"
       >
         <Download size={12} />


### PR DESCRIPTION
## Summary
- pass the selected report id into the topbar Analysis PDF download link
- make artifacts API resolve files inside the selected report folder first
- return a clear 404 when a report-scoped artifact is missing instead of falling back to an unrelated latest file

## Test plan
- run frontend lint (repo currently has pre-existing unrelated lint errors)
- verify code paths in topbar and artifacts API route for report-aware PDF resolution
