### PR TITLE
Fix run completion gating and hide in-progress site-run reports

### DIFF
--- a/frontend/src/app/api/run-analysis/[jobId]/route.ts
+++ b/frontend/src/app/api/run-analysis/[jobId]/route.ts
@@ -18,6 +18,7 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const RUN_FINALIZED_MARKER = "site run finalized:";
 
 function writeStatusSafe(status: RunStatusPayload): void {
   try {
@@ -119,6 +120,7 @@ function shouldPromoteRunningToCompleted(status: RunStatusPayload, progressLines
   if (!hasCompletionArtifacts(status)) return false;
 
   const joined = progressLines.join("\n").toLowerCase();
+  if (!joined.includes(RUN_FINALIZED_MARKER)) return false;
   const reachedFinalPhase =
     joined.includes("finished technical analysis") || joined.includes("finished valuations");
   const llmPct = typeof status.llm_progress_pct === "number" ? status.llm_progress_pct : 0;

--- a/frontend/src/lib/server-outputs.ts
+++ b/frontend/src/lib/server-outputs.ts
@@ -15,6 +15,10 @@ export type DashboardReportEntry = {
   mtimeMs: number;
 };
 
+type SiteRunStatusPayload = {
+  status?: string;
+};
+
 export function outputsRoot(): string {
   const direct = path.resolve(process.cwd(), "outputs");
   const parent = path.resolve(process.cwd(), "..", "outputs");
@@ -35,6 +39,21 @@ export function outputsRoot(): string {
 function safeStat(filePath: string): fs.Stats | null {
   try {
     return fs.statSync(filePath);
+  } catch {
+    return null;
+  }
+}
+
+function readSiteRunStatus(runId: string): string | null {
+  const cleanRunId = String(runId || "").trim();
+  if (!cleanRunId) return null;
+  const statusPath = path.resolve(outputsRoot(), "_site_runs", cleanRunId, "_status.json");
+  try {
+    if (!fs.existsSync(statusPath)) return null;
+    const raw = fs.readFileSync(statusPath, "utf-8");
+    const parsed = JSON.parse(raw) as SiteRunStatusPayload;
+    const status = String(parsed?.status || "").trim().toLowerCase();
+    return status || null;
   } catch {
     return null;
   }
@@ -159,12 +178,19 @@ export function listDashboardReports(): DashboardReportEntry[] {
       const score = (isNestedTickerArtifact ? 10 : 0) + (isSiteRun ? 2 : 0);
 
       let dedupeKey = `file:${rel}`;
+      let siteRunId = "";
       const parts = rel.split("/").filter(Boolean);
       const siteRunsIdx = parts.findIndex((p) => p.toLowerCase() === "_site_runs");
       if (siteRunsIdx >= 0 && siteRunsIdx + 1 < parts.length) {
-        const runId = String(parts[siteRunsIdx + 1] || "").trim();
-        if (runId) {
-          dedupeKey = `site:${runId}:${ticker}`;
+        siteRunId = String(parts[siteRunsIdx + 1] || "").trim();
+        if (siteRunId) {
+          dedupeKey = `site:${siteRunId}:${ticker}`;
+        }
+      }
+      if (isSiteRun && siteRunId) {
+        const runStatus = readSiteRunStatus(siteRunId);
+        if (runStatus && runStatus !== "completed") {
+          return null;
         }
       }
 

--- a/scripts/site_run.py
+++ b/scripts/site_run.py
@@ -20,6 +20,17 @@ def _write_json(path: Path, payload: Dict[str, Any]) -> None:
     path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
 
 
+def _append_progress_line(progress_file: str, message: str) -> None:
+    try:
+        progress_path = Path(progress_file)
+        progress_path.parent.mkdir(parents=True, exist_ok=True)
+        with progress_path.open("a", encoding="utf-8") as fh:
+            fh.write(f"{str(message).strip()}\n")
+    except Exception:
+        # best-effort diagnostics only
+        pass
+
+
 def _job_id_from_status(existing_status: Dict[str, Any], output_dir: str) -> str:
     from_status = str(existing_status.get("job_id", "") or "").strip()
     if from_status:
@@ -190,11 +201,13 @@ def main() -> int:
                     "error": persistence_error or "DB persistence failed.",
                 }
                 _write_json(status_file, failed_payload)
+                _append_progress_line(progress_file, "Site Run Finalized: failed")
                 legacy_port._deepseek_simple_full = original_full
                 legacy_port.deepseek_simple_text = original_deepseek
                 return 1
 
             _write_json(status_file, completed_with_warning)
+            _append_progress_line(progress_file, "Site Run Finalized: completed")
             legacy_port._deepseek_simple_full = original_full
             legacy_port.deepseek_simple_text = original_deepseek
             return 0
@@ -209,6 +222,7 @@ def main() -> int:
             "report_id": report_id,
         }
         _write_json(status_file, completed_payload)
+        _append_progress_line(progress_file, "Site Run Finalized: completed")
         legacy_port._deepseek_simple_full = original_full
         legacy_port.deepseek_simple_text = original_deepseek
         return 0
@@ -223,6 +237,7 @@ def main() -> int:
             "traceback": traceback.format_exc(limit=6),
         }
         _write_json(status_file, failed_payload)
+        _append_progress_line(progress_file, "Site Run Finalized: failed")
         return 1
 
 


### PR DESCRIPTION
## Summary

- Tightened run completion reconciliation so a unning job is only auto-promoted to completed after an explicit finalization marker is present in progress logs.
- Added explicit finalization progress markers (Site Run Finalized: completed|failed) from scripts/site_run.py when the worker writes terminal status.
- Filtered _site_runs dashboard discovery so in-progress runs are hidden from report lists until _status.json is actually completed.

## Preview

URL: pending workflow comment

## Test plan

- [x] Local controlled run-status checks via /api/run-analysis/[jobId]:
  - no finalization marker => remains unning
  - finalization marker present => transitions to completed
- [x] Local /api/reports check confirms only completed controlled site-run appears; running controlled site-run is excluded
- [x] python -m py_compile scripts/site_run.py

## Notes for reviewer

- This PR fixes the timing/status desync path where reports could surface before final run completion.
- Separate known edge case remains: if DB lookup is unavailable for completed runs lacking eport_id, status hydration can still error independently of this fix.