### PR TITLE
Speed up obs platform (JWT auth cache, slim payloads, streaming, cold-start UX)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ analysis.txt
 *.html
 *.pptx
 
+# Allow specific HTML assets that ship with the obs frontend bundle.
+!frontend-obs/public/warming.html
+
 # OS/IDE
 .DS_Store
 Thumbs.db

--- a/frontend-obs/public/sw.js
+++ b/frontend-obs/public/sw.js
@@ -1,0 +1,116 @@
+// Service worker for the observability admin app.
+//
+// One job: when the user navigates to a page and the Fly machine is
+// asleep, race the origin against a short timeout. If the origin
+// doesn't answer in time, serve a cached "warming" shell that polls
+// /api/health and redirects once the machine is up.
+//
+// Bump SW_VERSION on logic changes so old caches get cleared.
+
+const SW_VERSION = "obs-warming-v1";
+const SHELL_CACHE = `obs-shell-${SW_VERSION}`;
+const WARMING_URL = "/warming.html";
+const ORIGIN_TIMEOUT_MS = 600;
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    caches
+      .open(SHELL_CACHE)
+      .then((cache) => cache.add(new Request(WARMING_URL, { cache: "reload" })))
+      .then(() => self.skipWaiting()),
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter((k) => k.startsWith("obs-shell-") && k !== SHELL_CACHE)
+            .map((k) => caches.delete(k)),
+        ),
+      )
+      .then(() => self.clients.claim()),
+  );
+});
+
+function isNavigation(request) {
+  if (request.mode === "navigate") return true;
+  // Some browsers don't set mode reliably for top-level reloads.
+  const accept = request.headers.get("accept") || "";
+  return request.method === "GET" && accept.includes("text/html");
+}
+
+self.addEventListener("fetch", (event) => {
+  const { request } = event;
+  if (!isNavigation(request)) return;
+
+  const url = new URL(request.url);
+  if (url.origin !== self.location.origin) return;
+  // Don't intercept the warming shell itself, the health probe, or any
+  // sw / api machinery — those need to bypass for the polling to work.
+  if (url.pathname === WARMING_URL) return;
+  if (url.pathname === "/api/health") return;
+  if (url.pathname === "/sw.js") return;
+
+  event.respondWith(
+    new Promise((resolve) => {
+      let settled = false;
+      const finish = (response) => {
+        if (settled) return;
+        settled = true;
+        resolve(response);
+      };
+
+      const timeoutId = setTimeout(async () => {
+        const cache = await caches.open(SHELL_CACHE);
+        const cached = await cache.match(WARMING_URL);
+        if (cached) {
+          // Preserve the user's original destination so the shell can
+          // redirect them after the machine wakes.
+          const next = encodeURIComponent(url.pathname + url.search);
+          // Rewrite the response so the warming shell's URL bar still
+          // shows the original destination — we can't change the
+          // displayed URL, but we can pass `next` via a response
+          // header that the shell reads from window.location.search.
+          // Simpler: just serve the shell as-is and let it use
+          // document.referrer / a query param the shell reads.
+          // We pass `next` via a Set-Cookie-style approach using a
+          // custom response with the URL embedded.
+          const body = await cached.text();
+          const withNext = body.replace(
+            "var next = params.get(\"next\") || \"/\";",
+            `var next = params.get("next") || decodeURIComponent("${next}") || "/";`,
+          );
+          finish(
+            new Response(withNext, {
+              status: 200,
+              headers: {
+                "content-type": "text/html; charset=utf-8",
+                "cache-control": "no-store",
+              },
+            }),
+          );
+        } else {
+          // No cached shell yet — let the request continue.
+          fetch(request).then(finish).catch(() => finish(Response.error()));
+        }
+      }, ORIGIN_TIMEOUT_MS);
+
+      fetch(request)
+        .then((response) => {
+          clearTimeout(timeoutId);
+          finish(response);
+        })
+        .catch(async () => {
+          clearTimeout(timeoutId);
+          // Network failure — try the warming shell as a last resort.
+          const cache = await caches.open(SHELL_CACHE);
+          const cached = await cache.match(WARMING_URL);
+          finish(cached || Response.error());
+        });
+    }),
+  );
+});

--- a/frontend-obs/public/warming.html
+++ b/frontend-obs/public/warming.html
@@ -1,0 +1,146 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
+    <title>Waking up…</title>
+    <style>
+      :root {
+        --bg: #0b1220;
+        --fg: #e2e8f0;
+        --muted: rgba(148, 163, 184, 0.7);
+        --accent: #60a5fa;
+        --border: rgba(148, 163, 184, 0.18);
+      }
+      @media (prefers-color-scheme: light) {
+        :root {
+          --bg: #f8fafc;
+          --fg: #0f172a;
+          --muted: rgba(15, 23, 42, 0.6);
+          --accent: #2563eb;
+          --border: rgba(15, 23, 42, 0.12);
+        }
+      }
+      * { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; height: 100%; }
+      body {
+        background: var(--bg);
+        color: var(--fg);
+        font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        display: flex;
+        flex-direction: column;
+        min-height: 100vh;
+      }
+      header {
+        padding: 14px 24px;
+        border-bottom: 1px solid var(--border);
+        font-weight: 600;
+        font-size: 14px;
+        letter-spacing: 0.2px;
+      }
+      main {
+        flex: 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 24px;
+      }
+      .card {
+        text-align: center;
+        max-width: 380px;
+        width: 100%;
+      }
+      h1 {
+        font-size: 18px;
+        font-weight: 600;
+        margin: 0 0 8px;
+      }
+      p {
+        margin: 0 0 20px;
+        color: var(--muted);
+        font-size: 13px;
+        line-height: 1.5;
+      }
+      .bar {
+        height: 3px;
+        width: 100%;
+        background: var(--border);
+        border-radius: 999px;
+        overflow: hidden;
+        position: relative;
+      }
+      .bar::before {
+        content: "";
+        position: absolute;
+        top: 0;
+        left: 0;
+        height: 100%;
+        width: 35%;
+        background: linear-gradient(90deg, transparent 0%, var(--accent) 50%, transparent 100%);
+        animation: slide 1.1s ease-in-out infinite;
+      }
+      @keyframes slide {
+        0%   { transform: translateX(-100%); }
+        100% { transform: translateX(350%); }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .bar::before { animation-duration: 2.5s; }
+      }
+      .hint {
+        margin-top: 18px;
+        font-size: 11px;
+        color: var(--muted);
+        opacity: 0.75;
+      }
+    </style>
+  </head>
+  <body>
+    <header>Observability</header>
+    <main>
+      <div class="card">
+        <h1>Waking up the server…</h1>
+        <p>The obs app scales to zero when idle. This usually takes a few seconds.</p>
+        <div class="bar" role="progressbar" aria-label="Server warming up" aria-busy="true"></div>
+        <div class="hint" id="hint">Checking…</div>
+      </div>
+    </main>
+    <script>
+      (function () {
+        var params = new URLSearchParams(window.location.search);
+        var next = params.get("next") || "/";
+        // Only redirect to same-origin paths.
+        if (!next.startsWith("/") || next.startsWith("//")) next = "/";
+
+        var pollMs = 300;
+        var timeoutMs = 45000;
+        var started = Date.now();
+        var hint = document.getElementById("hint");
+
+        function tick() {
+          var elapsed = Date.now() - started;
+          if (elapsed > timeoutMs) {
+            if (hint) hint.textContent = "Still warming up. Trying anyway…";
+            window.location.replace(next);
+            return;
+          }
+          if (hint && elapsed > 4000) {
+            hint.textContent = "Still booting (" + Math.floor(elapsed / 1000) + "s)…";
+          }
+          fetch("/api/health", { cache: "no-store", credentials: "same-origin" })
+            .then(function (r) {
+              if (r && r.ok) {
+                window.location.replace(next);
+              } else {
+                setTimeout(tick, pollMs);
+              }
+            })
+            .catch(function () {
+              setTimeout(tick, pollMs);
+            });
+        }
+        tick();
+      })();
+    </script>
+  </body>
+</html>

--- a/frontend-obs/src/app/(authed)/dashboard/page.tsx
+++ b/frontend-obs/src/app/(authed)/dashboard/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import Link from "next/link";
 
 import { SpendTreemap } from "@/components/spend-treemap";
@@ -50,59 +51,117 @@ export default async function DashboardPage({
     );
   }
 
-  const [summary, stages, models, daily, spend] = await Promise.all([
-    getDashboardSummary(days),
-    getStageBreakdown(days),
-    getModelBreakdown(days),
-    getDailySeries(days),
-    getSpendBreakdown(days),
-  ]);
-
-  const successRate =
-    summary.run_count > 0 ? (summary.success_count / summary.run_count) * 100 : 0;
-
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 24 }}>
-      <div
-        style={{
-          display: "flex",
-          alignItems: "baseline",
-          justifyContent: "space-between",
-          flexWrap: "wrap",
-          gap: 12,
-        }}
-      >
-        <div>
-          <h1 style={{ fontSize: 24, marginBottom: 2 }}>Dashboard</h1>
-          <div style={{ opacity: 0.6, fontSize: 13 }}>
-            Pipeline activity over the last {days} days
-          </div>
-        </div>
-        <div className="range-tabs">
-          {ALLOWED_DAYS.map((d) => (
-            <Link
-              key={d}
-              href={`/dashboard?days=${d}`}
-              className={d === days ? "is-active" : ""}
-              prefetch={false}
-            >
-              {d}d
-            </Link>
-          ))}
-        </div>
-      </div>
+      <DashboardHeader days={days} />
 
-      <SummaryTiles summary={summary} successRate={successRate} />
+      <Suspense key={`tiles-${days}`} fallback={<TilesSkeleton />}>
+        <SummaryTilesAsync days={days} />
+      </Suspense>
 
-      <DailyActivityCard rows={daily} days={days} />
+      <Suspense key={`daily-${days}`} fallback={<CardSkeleton height={120} />}>
+        <DailyActivityAsync days={days} />
+      </Suspense>
 
-      <SpendTreemap rows={spend} />
+      <Suspense key={`spend-${days}`} fallback={<CardSkeleton height={220} />}>
+        <SpendAsync days={days} />
+      </Suspense>
 
-      <StageTable rows={stages} />
+      <Suspense key={`stage-${days}`} fallback={<CardSkeleton height={180} />}>
+        <StageTableAsync days={days} />
+      </Suspense>
 
-      <ModelTable rows={models} />
+      <Suspense key={`model-${days}`} fallback={<CardSkeleton height={140} />}>
+        <ModelTableAsync days={days} />
+      </Suspense>
     </div>
   );
+}
+
+function DashboardHeader({ days }: { days: number }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "baseline",
+        justifyContent: "space-between",
+        flexWrap: "wrap",
+        gap: 12,
+      }}
+    >
+      <div>
+        <h1 style={{ fontSize: 24, marginBottom: 2 }}>Dashboard</h1>
+        <div style={{ opacity: 0.6, fontSize: 13 }}>
+          Pipeline activity over the last {days} days
+        </div>
+      </div>
+      <div className="range-tabs">
+        {ALLOWED_DAYS.map((d) => (
+          <Link
+            key={d}
+            href={`/dashboard?days=${d}`}
+            className={d === days ? "is-active" : ""}
+            prefetch={false}
+          >
+            {d}d
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function CardSkeleton({ height }: { height: number }) {
+  return (
+    <div
+      className="card"
+      style={{ padding: 16, height, display: "flex", alignItems: "center", justifyContent: "center" }}
+      aria-busy="true"
+    >
+      <div style={{ opacity: 0.45, fontSize: 12 }}>Loading…</div>
+    </div>
+  );
+}
+
+function TilesSkeleton() {
+  return (
+    <div className="tiles" aria-busy="true">
+      {[0, 1, 2, 3].map((i) => (
+        <div key={i} className="tile" style={{ opacity: 0.5 }}>
+          <div className="tile__label">&nbsp;</div>
+          <div className="tile__value" style={{ opacity: 0.4 }}>—</div>
+          <div className="tile__hint">&nbsp;</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+async function SummaryTilesAsync({ days }: { days: number }) {
+  const summary = await getDashboardSummary(days);
+  const successRate =
+    summary.run_count > 0 ? (summary.success_count / summary.run_count) * 100 : 0;
+  return <SummaryTiles summary={summary} successRate={successRate} />;
+}
+
+async function DailyActivityAsync({ days }: { days: number }) {
+  const daily = await getDailySeries(days);
+  return <DailyActivityCard rows={daily} days={days} />;
+}
+
+async function SpendAsync({ days }: { days: number }) {
+  const spend = await getSpendBreakdown(days);
+  return <SpendTreemap rows={spend} />;
+}
+
+async function StageTableAsync({ days }: { days: number }) {
+  const stages = await getStageBreakdown(days);
+  return <StageTable rows={stages} />;
+}
+
+async function ModelTableAsync({ days }: { days: number }) {
+  const models = await getModelBreakdown(days);
+  return <ModelTable rows={models} />;
 }
 
 function SummaryTiles({

--- a/frontend-obs/src/app/(authed)/layout.tsx
+++ b/frontend-obs/src/app/(authed)/layout.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from "react";
 
 import { signOut } from "@/auth";
 import { AppHeader } from "@/components/app-header";
+import { SwRegister } from "@/components/sw-register";
 import { AdminForbiddenError, requireAdmin } from "@/lib/auth-helpers";
 
 export const dynamic = "force-dynamic";
@@ -32,6 +33,7 @@ export default async function AuthedLayout({ children }: { children: ReactNode }
 
   return (
     <div style={{ minHeight: "100vh" }}>
+      <SwRegister />
       <AppHeader email={email} signOutSlot={signOutSlot} />
       <main className="app-main">{children}</main>
     </div>

--- a/frontend-obs/src/app/(authed)/loading.tsx
+++ b/frontend-obs/src/app/(authed)/loading.tsx
@@ -1,0 +1,24 @@
+export default function Loading() {
+  return (
+    <>
+      <div className="route-progress" aria-hidden />
+      <div
+        className="card"
+        style={{
+          padding: 24,
+          opacity: 0.7,
+          fontSize: 13,
+          textAlign: "center",
+          minHeight: 200,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+        role="status"
+        aria-live="polite"
+      >
+        Loading…
+      </div>
+    </>
+  );
+}

--- a/frontend-obs/src/app/(authed)/runs/[runId]/call-panel.tsx
+++ b/frontend-obs/src/app/(authed)/runs/[runId]/call-panel.tsx
@@ -5,7 +5,7 @@ import { StatusPill } from "@/components/status-pill";
 import {
   getCall,
   listChildCalls,
-  type ObsCallRow,
+  type ObsCallSummaryRow,
 } from "@/lib/obs-db";
 import {
   formatCost,
@@ -156,8 +156,8 @@ function PanelHierarchy({
   children,
 }: {
   runId: string;
-  parent: ObsCallRow | null;
-  children: ObsCallRow[];
+  parent: ObsCallSummaryRow | null;
+  children: ObsCallSummaryRow[];
 }) {
   if (!parent && children.length === 0) return null;
   return (
@@ -204,7 +204,7 @@ function PanelHierarchy({
   );
 }
 
-function PanelCallSummary({ call }: { call: ObsCallRow }) {
+function PanelCallSummary({ call }: { call: ObsCallSummaryRow }) {
   const color = stageColor(call.stage);
   const title = callTitle(call);
   return (

--- a/frontend-obs/src/app/(authed)/runs/[runId]/call-tree.tsx
+++ b/frontend-obs/src/app/(authed)/runs/[runId]/call-tree.tsx
@@ -3,13 +3,13 @@
 import Link from "next/link";
 
 import { StatusPill } from "@/components/status-pill";
-import type { ObsCallRow } from "@/lib/obs-db";
+import type { ObsCallSummaryRow } from "@/lib/obs-db";
 import { formatCost, formatLatency, formatTokens } from "@/lib/obs-format";
 import { callLabel, callTitle } from "@/lib/obs-labels";
 import { stageColor } from "@/lib/obs-styles";
 
 export type TreeNode = {
-  call: ObsCallRow;
+  call: ObsCallSummaryRow;
   children: TreeNode[];
 };
 
@@ -53,7 +53,7 @@ function CallRow({
   active,
 }: {
   runId: string;
-  call: ObsCallRow;
+  call: ObsCallSummaryRow;
   active: boolean;
 }) {
   const color = stageColor(call.stage);
@@ -116,7 +116,7 @@ function CallRow({
   );
 }
 
-export function buildTree(calls: ObsCallRow[]): TreeNode[] {
+export function buildTree(calls: ObsCallSummaryRow[]): TreeNode[] {
   const ids = new Set(calls.map((c) => c.id));
   const map = new Map<string, TreeNode>();
   for (const c of calls) map.set(c.id, { call: c, children: [] });

--- a/frontend-obs/src/app/(authed)/runs/[runId]/calls/[callId]/page.tsx
+++ b/frontend-obs/src/app/(authed)/runs/[runId]/calls/[callId]/page.tsx
@@ -7,7 +7,7 @@ import {
   getCall,
   getRun,
   listChildCalls,
-  type ObsCallRow,
+  type ObsCallSummaryRow,
 } from "@/lib/obs-db";
 import {
   formatCost,
@@ -170,8 +170,8 @@ function CallContext({
   backView,
 }: {
   runId: string;
-  parent: ObsCallRow | null;
-  children: ObsCallRow[];
+  parent: ObsCallSummaryRow | null;
+  children: ObsCallSummaryRow[];
   backView: "flow" | "hierarchy";
 }) {
   if (!parent && children.length === 0) return null;
@@ -207,7 +207,7 @@ function CallContext({
   );
 }
 
-function CallSummary({ call }: { call: ObsCallRow }) {
+function CallSummary({ call }: { call: ObsCallSummaryRow }) {
   const color = stageColor(call.stage);
   const title = callTitle(call);
   return (

--- a/frontend-obs/src/app/(authed)/runs/[runId]/page.tsx
+++ b/frontend-obs/src/app/(authed)/runs/[runId]/page.tsx
@@ -1,7 +1,8 @@
+import { Suspense } from "react";
 import Link from "next/link";
 
 import { ResizablePanel } from "@/components/resizable-panel";
-import { getRun, listCallsForRun } from "@/lib/obs-db";
+import { getRun, listCallsForRun, type ObsRunRow } from "@/lib/obs-db";
 import { formatCost, formatDuration, formatTokens } from "@/lib/obs-format";
 import { callTitle } from "@/lib/obs-labels";
 
@@ -24,7 +25,7 @@ export default async function RunDetailPage({
   const view: "flow" | "hierarchy" = sp.view === "flow" ? "flow" : "hierarchy";
   const activeCallId = sp.call ?? null;
 
-  const [run, calls] = await Promise.all([getRun(runId), listCallsForRun(runId)]);
+  const run = await getRun(runId);
 
   if (!run) {
     return (
@@ -40,73 +41,114 @@ export default async function RunDetailPage({
 
   return (
     <div>
-      <div style={{ marginBottom: 16 }}>
-        <Link href="/runs" style={{ fontSize: 14 }}>
-          ← All runs
-        </Link>
-        <h1 style={{ fontSize: 24, marginTop: 8 }}>
-          {run.ticker}{" "}
-          <span style={{ opacity: 0.5, fontSize: 14, fontWeight: 400 }}>
-            · {new Date(run.started_at).toLocaleString()}
-          </span>
-        </h1>
-        <div style={{ display: "flex", gap: 24, fontSize: 13, opacity: 0.8, marginTop: 8, flexWrap: "wrap" }}>
-          <span>Status: <strong>{run.status}</strong></span>
-          <span>Calls: <strong>{run.total_calls}</strong></span>
-          <span>Tokens: <strong>{formatTokens(run.total_tokens_in)}↑ / {formatTokens(run.total_tokens_out)}↓</strong></span>
-          <span>Cost: <strong>{formatCost(run.total_cost_usd)}</strong></span>
-          <span>Duration: <strong>{formatDuration(run.duration_ms)}</strong></span>
-        </div>
-        {run.error_message && (
-          <pre
-            style={{
-              marginTop: 8,
-              padding: 12,
-              background: "rgba(239,68,68,0.08)",
-              border: "1px solid rgba(239,68,68,0.3)",
-              borderRadius: 6,
-              fontSize: 12,
-              whiteSpace: "pre-wrap",
-              maxHeight: 120,
-              overflow: "auto",
-            }}
-          >
-            {run.error_message}
-          </pre>
-        )}
-      </div>
-
+      <RunHeader run={run} />
       <RunTabs activeView={view} />
+      <Suspense
+        key={`${runId}-${view}-${activeCallId ?? ""}`}
+        fallback={<RunBodySkeleton />}
+      >
+        <RunBodyAsync runId={runId} view={view} activeCallId={activeCallId} />
+      </Suspense>
+    </div>
+  );
+}
 
-      <div className="run-layout">
-        <div className="run-layout__main">
-          {view === "flow" ? (
-            <RunFlowClient runId={runId} calls={calls} />
-          ) : (
-            <RunHierarchy runId={runId} calls={calls} activeCallId={activeCallId} />
-          )}
-        </div>
+function RunHeader({ run }: { run: ObsRunRow }) {
+  return (
+    <div style={{ marginBottom: 16 }}>
+      <Link href="/runs" style={{ fontSize: 14 }}>
+        ← All runs
+      </Link>
+      <h1 style={{ fontSize: 24, marginTop: 8 }}>
+        {run.ticker}{" "}
+        <span style={{ opacity: 0.5, fontSize: 14, fontWeight: 400 }}>
+          · {new Date(run.started_at).toLocaleString()}
+        </span>
+      </h1>
+      <div style={{ display: "flex", gap: 24, fontSize: 13, opacity: 0.8, marginTop: 8, flexWrap: "wrap" }}>
+        <span>Status: <strong>{run.status}</strong></span>
+        <span>Calls: <strong>{run.total_calls}</strong></span>
+        <span>Tokens: <strong>{formatTokens(run.total_tokens_in)}↑ / {formatTokens(run.total_tokens_out)}↓</strong></span>
+        <span>Cost: <strong>{formatCost(run.total_cost_usd)}</strong></span>
+        <span>Duration: <strong>{formatDuration(run.duration_ms)}</strong></span>
+      </div>
+      {run.error_message && (
+        <pre
+          style={{
+            marginTop: 8,
+            padding: 12,
+            background: "rgba(239,68,68,0.08)",
+            border: "1px solid rgba(239,68,68,0.3)",
+            borderRadius: 6,
+            fontSize: 12,
+            whiteSpace: "pre-wrap",
+            maxHeight: 120,
+            overflow: "auto",
+          }}
+        >
+          {run.error_message}
+        </pre>
+      )}
+    </div>
+  );
+}
 
-        {activeCallId && (
-          <ResizablePanel
-            closeHref={`/runs/${runId}${view === "flow" ? "?view=flow" : ""}`}
-            title={
-              <PanelTitle
-                label={
-                  calls.find((c) => c.id === activeCallId)
-                    ? callTitle(calls.find((c) => c.id === activeCallId)!)
-                    : "Call"
-                }
-                stage={
-                  calls.find((c) => c.id === activeCallId)?.stage ?? "unknown"
-                }
-              />
-            }
-          >
-            <CallPanelContent runId={runId} callId={activeCallId} />
-          </ResizablePanel>
+function RunBodySkeleton() {
+  return (
+    <div
+      className="card"
+      style={{
+        padding: 32,
+        opacity: 0.6,
+        fontSize: 13,
+        textAlign: "center",
+        minHeight: 240,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+      aria-busy="true"
+    >
+      Loading calls…
+    </div>
+  );
+}
+
+async function RunBodyAsync({
+  runId,
+  view,
+  activeCallId,
+}: {
+  runId: string;
+  view: "flow" | "hierarchy";
+  activeCallId: string | null;
+}) {
+  const calls = await listCallsForRun(runId);
+  const activeCall = activeCallId ? calls.find((c) => c.id === activeCallId) : null;
+
+  return (
+    <div className="run-layout">
+      <div className="run-layout__main">
+        {view === "flow" ? (
+          <RunFlowClient runId={runId} calls={calls} />
+        ) : (
+          <RunHierarchy runId={runId} calls={calls} activeCallId={activeCallId} />
         )}
       </div>
+
+      {activeCallId && (
+        <ResizablePanel
+          closeHref={`/runs/${runId}${view === "flow" ? "?view=flow" : ""}`}
+          title={
+            <PanelTitle
+              label={activeCall ? callTitle(activeCall) : "Call"}
+              stage={activeCall?.stage ?? "unknown"}
+            />
+          }
+        >
+          <CallPanelContent runId={runId} callId={activeCallId} />
+        </ResizablePanel>
+      )}
     </div>
   );
 }

--- a/frontend-obs/src/app/(authed)/runs/[runId]/run-flow-client.tsx
+++ b/frontend-obs/src/app/(authed)/runs/[runId]/run-flow-client.tsx
@@ -18,7 +18,7 @@ import {
   useReactFlow,
 } from "@xyflow/react";
 
-import type { ObsCallRow } from "@/lib/obs-db";
+import type { ObsCallSummaryRow } from "@/lib/obs-db";
 import { formatCost, formatLatency } from "@/lib/obs-format";
 import { stageColor } from "@/lib/obs-styles";
 
@@ -33,7 +33,7 @@ type Direction = "TB" | "LR";
 
 type LaidOut = { nodes: Node[]; edges: Edge[] };
 
-function buildGraph(calls: ObsCallRow[], dir: Direction): LaidOut {
+function buildGraph(calls: ObsCallSummaryRow[], dir: Direction): LaidOut {
   const ids = new Set(calls.map((c) => c.id));
   const hasRoots = calls.some((c) => !c.parent_id || !ids.has(c.parent_id));
   const multipleRoots =
@@ -216,7 +216,7 @@ function readSavedDir(): Direction {
   return raw === "LR" ? "LR" : "TB";
 }
 
-function FlowInner({ runId, calls }: { runId: string; calls: ObsCallRow[] }) {
+function FlowInner({ runId, calls }: { runId: string; calls: ObsCallSummaryRow[] }) {
   const router = useRouter();
   const [dir, setDir] = useState<Direction>("TB");
   useEffect(() => {
@@ -320,7 +320,7 @@ export default function RunFlowClient({
   calls,
 }: {
   runId: string;
-  calls: ObsCallRow[];
+  calls: ObsCallSummaryRow[];
 }) {
   return (
     <ReactFlowProvider>

--- a/frontend-obs/src/app/(authed)/runs/[runId]/run-hierarchy.tsx
+++ b/frontend-obs/src/app/(authed)/runs/[runId]/run-hierarchy.tsx
@@ -2,12 +2,12 @@
 
 import { useMemo } from "react";
 
-import type { ObsCallRow } from "@/lib/obs-db";
+import type { ObsCallSummaryRow } from "@/lib/obs-db";
 import { STAGE_ORDER } from "@/lib/obs-styles";
 
 import { StageSection, type StageGroup } from "./stage-section";
 
-function groupByStage(calls: ObsCallRow[]): StageGroup[] {
+function groupByStage(calls: ObsCallSummaryRow[]): StageGroup[] {
   const map = new Map<string, StageGroup>();
   for (const c of calls) {
     const key = c.stage || "unknown";
@@ -39,7 +39,7 @@ export function RunHierarchy({
   activeCallId,
 }: {
   runId: string;
-  calls: ObsCallRow[];
+  calls: ObsCallSummaryRow[];
   activeCallId?: string | null;
 }) {
   const groups = useMemo(() => groupByStage(calls), [calls]);

--- a/frontend-obs/src/app/(authed)/runs/[runId]/stage-section.tsx
+++ b/frontend-obs/src/app/(authed)/runs/[runId]/stage-section.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 
-import type { ObsCallRow } from "@/lib/obs-db";
+import type { ObsCallSummaryRow } from "@/lib/obs-db";
 import { formatCost, formatTokens } from "@/lib/obs-format";
 import { stageDisplayName } from "@/lib/obs-labels";
 import { stageColor } from "@/lib/obs-styles";
@@ -11,7 +11,7 @@ import { buildTree, CallTree } from "./call-tree";
 
 export type StageGroup = {
   stage: string;
-  calls: ObsCallRow[];
+  calls: ObsCallSummaryRow[];
   totalTokens: number;
   totalCost: number;
   hasError: boolean;

--- a/frontend-obs/src/app/api/health/route.ts
+++ b/frontend-obs/src/app/api/health/route.ts
@@ -1,0 +1,16 @@
+// Cheap warming probe for the service worker. No DB, no auth — its only
+// job is to return 200 once the Fly machine has finished booting and the
+// Next.js server can answer requests.
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export function GET() {
+  return new Response("ok", {
+    status: 200,
+    headers: {
+      "content-type": "text/plain; charset=utf-8",
+      "cache-control": "no-store",
+    },
+  });
+}

--- a/frontend-obs/src/app/globals.css
+++ b/frontend-obs/src/app/globals.css
@@ -609,3 +609,42 @@ body::-webkit-scrollbar,
   .tiles { grid-template-columns: 1fr; }
   .tile__value { font-size: 17px; }
 }
+
+/* Top-of-page route progress bar — shown by loading.tsx during navigation
+ * and by the warming shell during a Fly cold-boot. */
+.route-progress {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: transparent;
+  z-index: 100;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.route-progress::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 40%;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    var(--color-accent) 50%,
+    transparent 100%
+  );
+  animation: route-progress-slide 1.1s ease-in-out infinite;
+}
+
+@keyframes route-progress-slide {
+  0%   { transform: translateX(-100%); }
+  100% { transform: translateX(350%); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .route-progress::before { animation-duration: 2.5s; }
+}

--- a/frontend-obs/src/auth.ts
+++ b/frontend-obs/src/auth.ts
@@ -1,7 +1,10 @@
 import NextAuth from "next-auth";
 import Google from "next-auth/providers/google";
 
+import { isAdmin, isSuper } from "@/lib/admin-db";
 import { shouldBypassAuthForHostname } from "@/lib/auth-bypass";
+
+const ADMIN_TTL_MS = 10 * 60 * 1000;
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
   providers: [Google],
@@ -24,6 +27,27 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     async signIn({ account, user }) {
       if (account?.provider !== "google") return false;
       return Boolean(user.email);
+    },
+    async jwt({ token, trigger }) {
+      const email = (token.email || "").toLowerCase();
+      const checkedAt = typeof token.adminCheckedAt === "number" ? token.adminCheckedAt : 0;
+      const stale = Date.now() - checkedAt > ADMIN_TTL_MS;
+      const force = trigger === "signIn" || trigger === "signUp" || trigger === "update";
+
+      if (email && (force || stale || token.isAdmin === undefined)) {
+        const [adminFlag, superFlag] = await Promise.all([isAdmin(email), isSuper(email)]);
+        token.isAdmin = adminFlag;
+        token.isSuper = superFlag;
+        token.adminCheckedAt = Date.now();
+      }
+      return token;
+    },
+    async session({ session, token }) {
+      if (session.user) {
+        session.user.isAdmin = Boolean(token.isAdmin);
+        session.user.isSuper = Boolean(token.isSuper);
+      }
+      return session;
     },
   },
 });

--- a/frontend-obs/src/components/sw-register.tsx
+++ b/frontend-obs/src/components/sw-register.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useEffect } from "react";
+
+// Registers the cold-boot warming service worker. Production only —
+// keeping it off in dev avoids dev-server reload weirdness, and previews
+// don't need the warming UX since they're not the prod cold-start path.
+export function SwRegister() {
+  useEffect(() => {
+    if (process.env.NODE_ENV !== "production") return;
+    if (typeof window === "undefined") return;
+    if (!("serviceWorker" in navigator)) return;
+
+    const url = "/sw.js";
+    navigator.serviceWorker.register(url).catch(() => {
+      // Registration failures are non-fatal — the app still works,
+      // cold starts just hang as they did before.
+    });
+  }, []);
+
+  return null;
+}

--- a/frontend-obs/src/lib/auth-helpers.ts
+++ b/frontend-obs/src/lib/auth-helpers.ts
@@ -1,7 +1,6 @@
 import { headers } from "next/headers";
 
 import { auth } from "@/auth";
-import { isAdmin } from "@/lib/admin-db";
 
 const LOCAL_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1"]);
 
@@ -49,6 +48,6 @@ export async function requireAdmin(): Promise<{ email: string }> {
   const session = await auth();
   const email = (session?.user?.email || "").toLowerCase();
   if (!email) throw new AdminForbiddenError("");
-  if (!(await isAdmin(email))) throw new AdminForbiddenError(email);
+  if (!session?.user?.isAdmin) throw new AdminForbiddenError(email);
   return { email };
 }

--- a/frontend-obs/src/lib/obs-db.ts
+++ b/frontend-obs/src/lib/obs-db.ts
@@ -1,4 +1,12 @@
+import { unstable_cache } from "next/cache";
 import { neon, NeonQueryFunction } from "@neondatabase/serverless";
+
+// Short TTL on dashboard / runs-list aggregations: invisible to admins,
+// but turns repeat dashboard hits from "5 sequential Neon HTTP fetches"
+// into "served from the data cache". Revalidate via tag if a fresh-now
+// button is ever needed.
+const OBS_CACHE_TTL_S = 30;
+const OBS_CACHE_TAGS = ["obs-data"];
 
 let cached: NeonQueryFunction<false, false> | null = null;
 
@@ -63,7 +71,13 @@ export type ObsCallRow = {
   ended_at: string;
 };
 
-export async function listRecentRuns(limit = 50): Promise<ObsRunRow[]> {
+// Slim row for list/DAG/hierarchy views: drops `response` and `reasoning`
+// entirely (often multi-KB each) and ships only a 4 KB prefix of `prompt`
+// (callTitle/derivePromptTitle/classifyPrompt all read at most ~4 KB).
+// Full bodies are fetched on-demand via getCall() when a call panel opens.
+export type ObsCallSummaryRow = Omit<ObsCallRow, "response" | "reasoning">;
+
+async function _listRecentRuns(limit: number): Promise<ObsRunRow[]> {
   const sql = getObsSql();
   if (!sql) return [];
   const rows = (await sql`
@@ -76,6 +90,16 @@ export async function listRecentRuns(limit = 50): Promise<ObsRunRow[]> {
      LIMIT ${limit}
   `) as unknown as ObsRunRow[];
   return rows;
+}
+
+const _listRecentRunsCached = unstable_cache(
+  _listRecentRuns,
+  ["obs-list-recent-runs"],
+  { revalidate: OBS_CACHE_TTL_S, tags: OBS_CACHE_TAGS },
+);
+
+export function listRecentRuns(limit = 50): Promise<ObsRunRow[]> {
+  return _listRecentRunsCached(limit);
 }
 
 export async function getRun(runId: string): Promise<ObsRunRow | null> {
@@ -92,14 +116,14 @@ export async function getRun(runId: string): Promise<ObsRunRow | null> {
   return rows[0] ?? null;
 }
 
-export async function listCallsForRun(runId: string): Promise<ObsCallRow[]> {
+export async function listCallsForRun(runId: string): Promise<ObsCallSummaryRow[]> {
   const sql = getObsSql();
   if (!sql) return [];
   const rows = (await sql`
     SELECT id::text, run_id::text, parent_id::text, sequence,
            stage, persona, call_site,
            model_requested, model_actual, temperature::text AS temperature,
-           prompt, response, reasoning,
+           substr(prompt, 1, 4000) AS prompt,
            tokens_in, tokens_out, tokens_total,
            cost_usd::text AS cost_usd,
            latency_ms, retries, status, error_class, error_message,
@@ -107,7 +131,7 @@ export async function listCallsForRun(runId: string): Promise<ObsCallRow[]> {
       FROM obs_calls
      WHERE run_id = ${runId}::uuid
      ORDER BY sequence
-  `) as unknown as ObsCallRow[];
+  `) as unknown as ObsCallSummaryRow[];
   return rows;
 }
 
@@ -171,7 +195,7 @@ export type SpendBreakdownRow = {
   cost_usd: string;
 };
 
-export async function getSpendBreakdown(days: number): Promise<SpendBreakdownRow[]> {
+async function _getSpendBreakdown(days: number): Promise<SpendBreakdownRow[]> {
   const sql = getObsSql();
   if (!sql) return [];
   const rows = (await sql`
@@ -191,7 +215,17 @@ export async function getSpendBreakdown(days: number): Promise<SpendBreakdownRow
   return rows;
 }
 
-export async function getDashboardSummary(days: number): Promise<DashboardSummary> {
+const _getSpendBreakdownCached = unstable_cache(
+  _getSpendBreakdown,
+  ["obs-spend-breakdown"],
+  { revalidate: OBS_CACHE_TTL_S, tags: OBS_CACHE_TAGS },
+);
+
+export function getSpendBreakdown(days: number): Promise<SpendBreakdownRow[]> {
+  return _getSpendBreakdownCached(days);
+}
+
+async function _getDashboardSummary(days: number): Promise<DashboardSummary> {
   const sql = getObsSql();
   const empty: DashboardSummary = {
     run_count: 0,
@@ -220,7 +254,17 @@ export async function getDashboardSummary(days: number): Promise<DashboardSummar
   return rows[0] ?? empty;
 }
 
-export async function getStageBreakdown(days: number): Promise<StageBreakdownRow[]> {
+const _getDashboardSummaryCached = unstable_cache(
+  _getDashboardSummary,
+  ["obs-dashboard-summary"],
+  { revalidate: OBS_CACHE_TTL_S, tags: OBS_CACHE_TAGS },
+);
+
+export function getDashboardSummary(days: number): Promise<DashboardSummary> {
+  return _getDashboardSummaryCached(days);
+}
+
+async function _getStageBreakdown(days: number): Promise<StageBreakdownRow[]> {
   const sql = getObsSql();
   if (!sql) return [];
   const rows = (await sql`
@@ -241,7 +285,17 @@ export async function getStageBreakdown(days: number): Promise<StageBreakdownRow
   return rows;
 }
 
-export async function getModelBreakdown(days: number): Promise<ModelBreakdownRow[]> {
+const _getStageBreakdownCached = unstable_cache(
+  _getStageBreakdown,
+  ["obs-stage-breakdown"],
+  { revalidate: OBS_CACHE_TTL_S, tags: OBS_CACHE_TAGS },
+);
+
+export function getStageBreakdown(days: number): Promise<StageBreakdownRow[]> {
+  return _getStageBreakdownCached(days);
+}
+
+async function _getModelBreakdown(days: number): Promise<ModelBreakdownRow[]> {
   const sql = getObsSql();
   if (!sql) return [];
   const rows = (await sql`
@@ -260,7 +314,17 @@ export async function getModelBreakdown(days: number): Promise<ModelBreakdownRow
   return rows;
 }
 
-export async function getDailySeries(days: number): Promise<DailySeriesRow[]> {
+const _getModelBreakdownCached = unstable_cache(
+  _getModelBreakdown,
+  ["obs-model-breakdown"],
+  { revalidate: OBS_CACHE_TTL_S, tags: OBS_CACHE_TAGS },
+);
+
+export function getModelBreakdown(days: number): Promise<ModelBreakdownRow[]> {
+  return _getModelBreakdownCached(days);
+}
+
+async function _getDailySeries(days: number): Promise<DailySeriesRow[]> {
   const sql = getObsSql();
   if (!sql) return [];
   const rows = (await sql`
@@ -276,14 +340,24 @@ export async function getDailySeries(days: number): Promise<DailySeriesRow[]> {
   return rows;
 }
 
-export async function listChildCalls(parentId: string): Promise<ObsCallRow[]> {
+const _getDailySeriesCached = unstable_cache(
+  _getDailySeries,
+  ["obs-daily-series"],
+  { revalidate: OBS_CACHE_TTL_S, tags: OBS_CACHE_TAGS },
+);
+
+export function getDailySeries(days: number): Promise<DailySeriesRow[]> {
+  return _getDailySeriesCached(days);
+}
+
+export async function listChildCalls(parentId: string): Promise<ObsCallSummaryRow[]> {
   const sql = getObsSql();
   if (!sql) return [];
   const rows = (await sql`
     SELECT id::text, run_id::text, parent_id::text, sequence,
            stage, persona, call_site,
            model_requested, model_actual, temperature::text AS temperature,
-           prompt, response, reasoning,
+           substr(prompt, 1, 4000) AS prompt,
            tokens_in, tokens_out, tokens_total,
            cost_usd::text AS cost_usd,
            latency_ms, retries, status, error_class, error_message,
@@ -291,6 +365,6 @@ export async function listChildCalls(parentId: string): Promise<ObsCallRow[]> {
       FROM obs_calls
      WHERE parent_id = ${parentId}::uuid
      ORDER BY sequence
-  `) as unknown as ObsCallRow[];
+  `) as unknown as ObsCallSummaryRow[];
   return rows;
 }

--- a/frontend-obs/src/lib/obs-labels.ts
+++ b/frontend-obs/src/lib/obs-labels.ts
@@ -1,6 +1,6 @@
-import type { ObsCallRow } from "@/lib/obs-db";
+import type { ObsCallSummaryRow } from "@/lib/obs-db";
 
-export function callLabel(call: ObsCallRow): string {
+export function callLabel(call: ObsCallSummaryRow): string {
   if (call.call_site) return call.call_site;
   if (call.persona) return call.persona;
   return `${call.stage} #${call.sequence}`;
@@ -178,7 +178,7 @@ export function classifyPrompt(
 
 /** Preferred display name for a call: domain classifier first, then prompt heading,
  * then first-sentence extraction, then the technical callLabel. */
-export function callTitle(call: ObsCallRow): string {
+export function callTitle(call: ObsCallSummaryRow): string {
   const classified = classifyPrompt(call.stage, call.prompt);
   if (classified) return classified;
   const fromPrompt = derivePromptTitle(call.prompt);

--- a/frontend-obs/src/types/next-auth.d.ts
+++ b/frontend-obs/src/types/next-auth.d.ts
@@ -1,0 +1,22 @@
+import "next-auth";
+import "next-auth/jwt";
+
+declare module "next-auth" {
+  interface Session {
+    user: {
+      name?: string | null;
+      email?: string | null;
+      image?: string | null;
+      isAdmin?: boolean;
+      isSuper?: boolean;
+    };
+  }
+}
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    isAdmin?: boolean;
+    isSuper?: boolean;
+    adminCheckedAt?: number;
+  }
+}


### PR DESCRIPTION
## Summary

Targets the \"every load is sluggish\" feel of the obs admin app by cutting per-request DB hits and shipped payload, caching dashboard aggregations, streaming the heavy bits, and giving admins a visible warming UI during a Fly cold-boot. Scale-to-zero stays.

## What changed

**Stop paying obs_admins on every page**
- `frontend-obs/src/auth.ts` — `jwt` and `session` callbacks cache `isAdmin` / `isSuper` on the JWT with a 10-min TTL.
- `frontend-obs/src/lib/auth-helpers.ts` — `requireAdmin` reads `session.user.isAdmin` instead of querying the DB. One DB hit at sign-in / on TTL refresh, zero per page.

**Stop shipping LLM bodies the page doesn't render**
- `listCallsForRun` and `listChildCalls` drop `response` and `reasoning` and truncate `prompt` to 4 KB — `callTitle` only reads the first ~4 KB. Big runs go from multi-MB SSR payloads to KB-scale.
- New `ObsCallSummaryRow` type for list/DAG/hierarchy consumers; `ObsCallRow` (full bodies) stays for `getCall` / call-panel / call-detail page where bodies are actually rendered.

**Cache the dashboard**
- Wrap `getDashboardSummary`, `getStageBreakdown`, `getModelBreakdown`, `getDailySeries`, `getSpendBreakdown`, `listRecentRuns` with `unstable_cache(fn, key, { revalidate: 30, tags: [\"obs-data\"] })`. Repeat dashboard visits served from the data cache.

**Stream instead of block**
- Dashboard split into per-block async server components inside `<Suspense>`; shell renders immediately and tiles / activity / treemap / stage / model stream as their queries resolve.
- Run detail: header renders after the fast `getRun`; hierarchy / DAG / call panel stream once `listCallsForRun` returns.

**Loading UX during navigation + cold-boot**
- New `(authed)/loading.tsx` with a top progress bar (CSS keyframes, no JS lib) for warm-but-slow navigations.
- New `public/warming.html` — minimal static shell with a progress bar that polls `/api/health` and redirects once the origin is up.
- New `public/sw.js` — on navigation, races origin vs a 600 ms timeout; on timeout, serves the cached warming shell with a `next` query param so the shell can redirect once the machine wakes. Cache versioned, old caches cleared on activate.
- New `/api/health` — cheap 200 OK, no DB, no auth. Just the warming probe.
- New `<SwRegister />` mounted from the authed layout, registers `/sw.js` in production only.

## What did **not** change
- No Fly config touched — scale-to-zero stays.
- No new DB indexes (current indexes already cover the hot queries).
- No new dependencies.

## Step 5 follow-up (not in this PR)
Run `flyctl secrets list -a hedge-in-a-box-obs` and inspect the `OBS_DATABASE_URL` host. If Neon is in `us-*`, the dashboard's queries are paying transatlantic RTT and we should move the Neon project to `eu-central-1` (or move Fly to match). Free latency on the table if they're already aligned.

## Test plan

- [ ] `npm run build` clean — TypeScript passes.
- [ ] On preview: hard-reload `/dashboard`, watch metric blocks stream in.
- [ ] On preview: load a run-detail with many calls; document size should be KB, not MB. Open a call panel — `prompt` / `response` / `reasoning` still load on demand.
- [ ] On preview: navigate between `/dashboard` ↔ `/runs` ↔ a run-detail; top bar appears immediately on each click.
- [ ] On preview: visit once to register the SW. Then `flyctl machine stop -a pr-65-hedge-in-a-box-obs` (preview) and reload — warming shell should appear within ~600 ms with the progress bar, then redirect once `/api/health` returns 200.
- [ ] Sign in fresh — admin status should populate on first load. Removing yourself from `/users` should still take effect within 10 min (TTL refresh) without needing to clear cookies.
- [ ] No regression in `/users` add/remove flow (still uses `isSuper` DB call for the destructive path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)