### PR TITLE
Invalidate reports cache on run completion + shorten list TTL

### DIFF
--- a/frontend/src/app/api/run-analysis/[jobId]/route.ts
+++ b/frontend/src/app/api/run-analysis/[jobId]/route.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
+import { revalidateTag } from "next/cache";
 import { NextResponse } from "next/server";
 
 import { auth } from "@/auth";
@@ -215,6 +216,22 @@ async function reconcileCompletedStatus(status: RunStatusPayload): Promise<RunSt
   return withAttribution;
 }
 
+function revalidateReportsCacheOnce(status: RunStatusPayload): RunStatusPayload {
+  if (status.status !== "completed") return status;
+  if (status.cache_revalidated_at) return status;
+  try {
+    revalidateTag("reports", "max");
+  } catch {
+    // best effort; the listing's short TTL still picks up the new report
+  }
+  const next: RunStatusPayload = {
+    ...status,
+    cache_revalidated_at: new Date().toISOString(),
+  };
+  writeStatusSafe(next);
+  return next;
+}
+
 export async function GET(
   _: Request,
   context: { params: Promise<{ jobId: string }> },
@@ -235,7 +252,8 @@ export async function GET(
   const reconciledStatus = reconcileLegacyPersistenceFailure(status);
   const progress = readProgressLines(reconciledStatus.progress_file || "", 80);
   const completionReconciled = reconcileRunningCompletion(reconciledStatus, progress);
-  const updatedStatus = await reconcileCompletedStatus(completionReconciled);
+  const completedStatus = await reconcileCompletedStatus(completionReconciled);
+  const updatedStatus = revalidateReportsCacheOnce(completedStatus);
   const llmTotal = typeof updatedStatus.llm_total_estimated === "number" ? updatedStatus.llm_total_estimated : 0;
   const llmDone = typeof updatedStatus.llm_completed === "number" ? updatedStatus.llm_completed : 0;
   let llmPct =

--- a/frontend/src/lib/dashboard-server.ts
+++ b/frontend/src/lib/dashboard-server.ts
@@ -97,7 +97,7 @@ async function loadReportsList(): Promise<ReportListItem[]> {
 export const getReportsList = unstable_cache(
   loadReportsList,
   ["reports-list-v1"],
-  { revalidate: 60, tags: ["reports"] },
+  { revalidate: 5, tags: ["reports"] },
 );
 
 async function loadDashboardPayload(

--- a/frontend/src/lib/site-runner.ts
+++ b/frontend/src/lib/site-runner.ts
@@ -25,6 +25,7 @@ export type RunStatusPayload = {
   persistence_error?: string;
   error?: string;
   traceback?: string;
+  cache_revalidated_at?: string | null;
 };
 
 const APP_BOOT_TIME_MS = Date.now();


### PR DESCRIPTION
## Summary
- Listing cache (`unstable_cache` tagged `["reports"]`) had `revalidate: 60` and the dashboard payload `revalidate: 300`, but `revalidateTag("reports")` was never called when a run completed — so newly completed reports were invisible for up to 60s/300s on prod.
- Add a one-shot `revalidateReportsCacheOnce` helper in [frontend/src/app/api/run-analysis/[jobId]/route.ts](frontend/src/app/api/run-analysis/%5BjobId%5D/route.ts) that fires `revalidateTag("reports", "max")` the first time a poller observes `status === "completed"`. A new `cache_revalidated_at` marker on [RunStatusPayload](frontend/src/lib/site-runner.ts) makes it idempotent across pollers.
- Drop `getReportsList` TTL from 60s → 5s in [frontend/src/lib/dashboard-server.ts](frontend/src/lib/dashboard-server.ts) as a backstop for runs that complete outside the Next.js process (CLI/bot writers that hit Neon directly and never poll the status route).
- Dashboard payload TTL stays at 300s — payloads are immutable per `report_id` and the explicit `revalidateTag` covers the rare "latest by ticker" case.

## Test plan
- [ ] Backend-only PR — no preview environment; verified locally via `npx tsc --noEmit` (passes) inside `frontend/`.
- [ ] After merge, kick off a site-run on prod and confirm the report appears on `/reports` within ~1s of completion (was up to 60s).
- [ ] Run the CLI against prod's Neon DB and confirm the new report appears on the listing within ~5s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)