### PR TITLE
Fix prod DB persistence + migration runner + backfill orphaned runs

### DIFF
--- a/fly.site.toml
+++ b/fly.site.toml
@@ -6,6 +6,11 @@ kill_timeout = "1m0s"
 [build]
   dockerfile = "Dockerfile.site"
 
+[deploy]
+  # Apply any pending SQL migrations before traffic is shifted to the new image.
+  # Runs in a one-off ephemeral machine; idempotent — see scripts/migrate.py.
+  release_command = "python3 /app/scripts/migrate.py"
+
 [env]
   NEXT_TELEMETRY_DISABLED = "1"
   NODE_ENV = "production"

--- a/scripts/backfill_orphaned_site_runs.py
+++ b/scripts/backfill_orphaned_site_runs.py
@@ -1,0 +1,202 @@
+"""
+Backfill `reports` rows for site runs whose artifacts exist on the volume
+but whose DB row was never inserted (e.g. due to schema drift or transient
+DB failures).
+
+For each `<jobId>/` dir under --root:
+- Read `_status.json`.
+- Skip unless `result.status` is "success" or "partial_success" — mirrors
+  the success gate in scripts/site_run.py so we don't promote a genuinely
+  failed run.
+- Resolve the inner `<TICKER>/` dir.
+- If a row already exists for source_run_id=<jobId>, skip (idempotent).
+- Otherwise call write_run_to_db() and, on success, rewrite `_status.json`:
+    status=completed, report_id=<id>, persistence_error="", and clear the
+    legacy persistence-failure error string if present.
+
+Run:
+    python scripts/backfill_orphaned_site_runs.py
+    python scripts/backfill_orphaned_site_runs.py --root /data/outputs/_site_runs
+    python scripts/backfill_orphaned_site_runs.py --dry-run
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+try:
+    from dotenv import load_dotenv  # type: ignore[import-not-found]
+
+    load_dotenv(ROOT / ".env")
+except ImportError:
+    pass
+
+from ai_hedge.db.connection import DatabaseUrlMissing, resolve_db_url  # noqa: E402
+from ai_hedge.db.writer import (  # noqa: E402
+    find_report_id_by_source_run_id,
+    write_run_to_db,
+)
+
+
+_LEGACY_PERSISTENCE_RE = "no reports row found for source_run_id"
+_MATERIAL_SUCCESS = {"success", "partial_success"}
+
+
+def _looks_like_material_success(result: object) -> bool:
+    if not isinstance(result, dict):
+        return False
+    return str(result.get("status", "")).strip().lower() in _MATERIAL_SUCCESS
+
+
+def _is_legacy_persistence_text(text: object) -> bool:
+    return _LEGACY_PERSISTENCE_RE in str(text or "").lower()
+
+
+def _rewrite_status_after_backfill(
+    status_path: Path, status: dict, report_id: str
+) -> None:
+    next_status = dict(status)
+    next_status["report_id"] = report_id
+    next_status["persistence_error"] = ""
+    if next_status.get("status") == "failed" and _is_legacy_persistence_text(
+        status.get("persistence_error") or status.get("error")
+    ):
+        next_status["status"] = "completed"
+    if _is_legacy_persistence_text(next_status.get("error")):
+        next_status["error"] = ""
+    status_path.write_text(
+        json.dumps(next_status, indent=2), encoding="utf-8"
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        default="/data/outputs/_site_runs",
+        help="Path to the _site_runs directory (default: /data/outputs/_site_runs).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report which runs would be backfilled without touching the DB or status files.",
+    )
+    args = parser.parse_args()
+
+    try:
+        resolve_db_url()
+    except DatabaseUrlMissing as exc:
+        print(f"[backfill] error: {exc}", file=sys.stderr)
+        return 2
+
+    root = Path(args.root)
+    if not root.exists():
+        print(f"[backfill] error: --root does not exist: {root}", file=sys.stderr)
+        return 2
+
+    counts = {
+        "inserted": 0,
+        "would_insert": 0,
+        "already_present": 0,
+        "skipped_no_status": 0,
+        "skipped_unsuccessful": 0,
+        "skipped_no_dir": 0,
+        "failed": 0,
+    }
+
+    for entry in sorted(root.iterdir()):
+        if not entry.is_dir() or entry.name.startswith("_"):
+            continue
+        job_id = entry.name
+        status_path = entry / "_status.json"
+        if not status_path.exists():
+            counts["skipped_no_status"] += 1
+            continue
+        try:
+            status = json.loads(status_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            print(
+                f"[backfill] {job_id}: cannot read status ({exc})",
+                file=sys.stderr,
+            )
+            counts["failed"] += 1
+            continue
+
+        if not _looks_like_material_success(status.get("result")):
+            counts["skipped_unsuccessful"] += 1
+            continue
+
+        ticker = str(status.get("ticker") or "").strip().upper()
+        if not ticker:
+            counts["skipped_no_dir"] += 1
+            continue
+
+        ticker_dir = entry / ticker
+        if not ticker_dir.is_dir():
+            print(
+                f"[backfill] {job_id}: missing ticker dir {ticker_dir}",
+                file=sys.stderr,
+            )
+            counts["skipped_no_dir"] += 1
+            continue
+
+        existing = find_report_id_by_source_run_id(
+            source_run_id=job_id, source="site", ticker=ticker
+        )
+        if existing:
+            counts["already_present"] += 1
+            print(f"[backfill] {job_id} ({ticker}): already in db ({existing})")
+            continue
+
+        if args.dry_run:
+            counts["would_insert"] += 1
+            print(f"[backfill] {job_id} ({ticker}): would insert (dry-run)")
+            continue
+
+        report_id, write_err = write_run_to_db(
+            ticker_dir,
+            source="site",
+            max_attempts=3,
+            retry_backoff_seconds=1.5,
+        )
+        if not report_id:
+            # write_run_to_db returns None on dedup races too; double-check.
+            report_id = find_report_id_by_source_run_id(
+                source_run_id=job_id, source="site", ticker=ticker
+            )
+        if not report_id:
+            counts["failed"] += 1
+            err = write_err or "no row returned"
+            print(
+                f"[backfill] {job_id} ({ticker}): write failed ({err})",
+                file=sys.stderr,
+            )
+            continue
+
+        try:
+            _rewrite_status_after_backfill(status_path, status, report_id)
+        except OSError as exc:
+            # DB row landed; status rewrite is the cosmetic half. Don't fail the run.
+            print(
+                f"[backfill] {job_id} ({ticker}): inserted {report_id}, "
+                f"but status rewrite failed: {exc}",
+                file=sys.stderr,
+            )
+        counts["inserted"] += 1
+        print(f"[backfill] {job_id} ({ticker}): inserted {report_id}")
+
+    total = sum(counts.values())
+    print()
+    print(f"[backfill] processed {total} dirs:")
+    for key, value in counts.items():
+        print(f"  {key}: {value}")
+    return 0 if counts["failed"] == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -1,0 +1,78 @@
+"""
+Apply any pending SQL migrations under src/ai_hedge/db/migrations/.
+
+Run:
+    python scripts/migrate.py            # apply pending
+    python scripts/migrate.py --dry-run  # show what would run, no changes
+
+Wired into prod via fly.site.toml's [deploy] release_command, so every
+site deploy reconciles the schema before traffic is shifted to the new
+image. Safe to re-run; tracks applied filenames in schema_migrations.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+try:
+    from dotenv import load_dotenv  # type: ignore[import-not-found]
+
+    load_dotenv(ROOT / ".env")
+except ImportError:
+    # Production runs without python-dotenv; secrets come from the env directly.
+    pass
+
+from ai_hedge.db.connection import DatabaseUrlMissing, get_conn  # noqa: E402
+from ai_hedge.db.migrate import (  # noqa: E402
+    apply_pending_migrations,
+    list_applied,
+    list_pending,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db-url", default=None)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        conn = get_conn(args.db_url)
+    except DatabaseUrlMissing as exc:
+        print(f"[migrate] error: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        if args.dry_run:
+            pending = list_pending(conn)
+            applied = list_applied(conn)
+            if not pending:
+                print(f"[migrate] up to date ({len(applied)} applied, 0 pending)")
+            else:
+                print(
+                    f"[migrate] would apply {len(pending)} migration(s) "
+                    f"({len(applied)} already applied):"
+                )
+                for name in pending:
+                    print(f"  - {name}")
+            return 0
+
+        newly = apply_pending_migrations(conn)
+        if not newly:
+            applied = list_applied(conn)
+            print(f"[migrate] up to date ({len(applied)} applied)")
+        else:
+            for name in newly:
+                print(f"[migrate] applied {name}")
+            print(f"[migrate] applied {len(newly)} new migration(s)")
+        return 0
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/site_run.py
+++ b/scripts/site_run.py
@@ -148,6 +148,7 @@ def main() -> int:
         # Ensure DB persistence before marking run as completed.
         report_id = None
         persistence_error = ""
+        write_err: str | None = None
         try:
             from ai_hedge.db.writer import (
                 find_report_id_by_source_run_id,
@@ -160,7 +161,7 @@ def main() -> int:
                 ticker=ticker,
             )
             if not report_id:
-                write_run_to_db(
+                _, write_err = write_run_to_db(
                     Path(output_dir).resolve() / ticker,
                     source="site",
                     max_attempts=5,
@@ -172,9 +173,14 @@ def main() -> int:
                     ticker=ticker,
                 )
             if not report_id:
-                persistence_error = (
+                base_msg = (
                     "Run artifacts were generated but DB report persistence failed. "
                     "No reports row found for source_run_id."
+                )
+                persistence_error = (
+                    f"{base_msg} Last writer error: {write_err}"
+                    if write_err
+                    else base_msg
                 )
         except Exception as persist_exc:  # noqa: BLE001
             persistence_error = f"DB persistence verification failed: {persist_exc}"

--- a/src/ai_hedge/db/migrate.py
+++ b/src/ai_hedge/db/migrate.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import psycopg
+
+MIGRATIONS_DIR = Path(__file__).with_name("migrations")
+
+_CREATE_TRACKING_TABLE = """
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    filename   text PRIMARY KEY,
+    applied_at timestamptz NOT NULL DEFAULT now()
+);
+"""
+
+
+def _list_files(migrations_dir: Path) -> list[Path]:
+    return sorted(p for p in migrations_dir.glob("*.sql") if p.is_file())
+
+
+def list_applied(conn: psycopg.Connection) -> set[str]:
+    """Return the set of migration filenames already recorded in schema_migrations.
+
+    Returns an empty set if the tracking table does not exist yet.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT to_regclass('public.schema_migrations') IS NOT NULL;"
+        )
+        row = cur.fetchone()
+    if not row or not row[0]:
+        return set()
+    with conn.cursor() as cur:
+        cur.execute("SELECT filename FROM schema_migrations;")
+        return {r[0] for r in cur.fetchall()}
+
+
+def list_pending(
+    conn: psycopg.Connection,
+    *,
+    migrations_dir: Path = MIGRATIONS_DIR,
+) -> list[str]:
+    """Filenames present on disk but not yet recorded in schema_migrations."""
+    applied = list_applied(conn)
+    return [p.name for p in _list_files(migrations_dir) if p.name not in applied]
+
+
+def apply_pending_migrations(
+    conn: psycopg.Connection,
+    *,
+    migrations_dir: Path = MIGRATIONS_DIR,
+) -> list[str]:
+    """Apply every migration not yet recorded, in lexical order.
+
+    Each migration runs together with its tracking-row insert in a single
+    transaction. A failed migration leaves schema_migrations untouched, so the
+    next run retries the same file. The tracking table itself is created on
+    first call.
+
+    Returns the list of newly-applied filenames (empty if up to date).
+    """
+    with conn.cursor() as cur:
+        cur.execute(_CREATE_TRACKING_TABLE)
+    conn.commit()
+
+    applied = list_applied(conn)
+    newly_applied: list[str] = []
+    for path in _list_files(migrations_dir):
+        if path.name in applied:
+            continue
+        sql = path.read_text(encoding="utf-8")
+        try:
+            with conn.cursor() as cur:
+                cur.execute(sql)
+                cur.execute(
+                    "INSERT INTO schema_migrations (filename) VALUES (%s);",
+                    (path.name,),
+                )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        newly_applied.append(path.name)
+    return newly_applied

--- a/src/ai_hedge/db/writer.py
+++ b/src/ai_hedge/db/writer.py
@@ -53,43 +53,48 @@ def write_run_to_db(
     max_attempts: int = 1,
     retry_backoff_seconds: float = 1.5,
     r2_keys: dict | None = None,
-) -> str | None:
+) -> tuple[str | None, str | None]:
     """
     Best-effort DB write at the end of a successful run.
 
-    - No-op (returns None) if DATABASE_URL_UNPOOLED / DATABASE_URL is unset.
-    - Catches and logs all errors so DB problems don't kill a successful run.
-    - Returns the inserted report_id on success, or None.
-    - `r2_keys`, when provided, is persisted onto report_artifacts.r2_keys.
-      Used by the runner to record the ArtifactStore's returned keys when an
-      R2-backed store is active. Disk-only backfill paths leave it None.
+    Returns ``(report_id, error_message)``:
+
+    - Success: ``(id, None)``
+    - No-op (no DATABASE_URL, missing dashboard, etc.): ``(None, None)``
+    - Insert failure: ``(None, "<exc-type>: <exc-msg>")`` carrying the last
+      attempt's exception text so the caller can surface it to operators.
+
+    Stderr printing is preserved for log-aggregation continuity. The
+    swallowing pattern (best-effort, never kill a successful run) is
+    unchanged; only the return shape is richer.
+
+    ``r2_keys`` is persisted onto ``report_artifacts.r2_keys`` when provided.
     """
     if not (os.environ.get("DATABASE_URL_UNPOOLED") or os.environ.get("DATABASE_URL")):
-        return None
+        return (None, None)
 
     try:
         from ai_hedge.db.connection import get_conn
         from ai_hedge.db.repository import insert_report, upsert_ticker
         from ai_hedge.db.transform import ticker_dir_to_row
     except ImportError as exc:
-        print(f"[db.writer] skipping (import failed): {exc}", file=sys.stderr)
-        return None
+        msg = f"import failed: {exc}"
+        print(f"[db.writer] skipping ({msg})", file=sys.stderr)
+        return (None, msg)
 
     try:
         bundle = ticker_dir_to_row(Path(output_dir), source=source)
     except Exception as exc:  # noqa: BLE001
-        print(
-            f"[db.writer] skipping ({type(exc).__name__}: {exc})",
-            file=sys.stderr,
-        )
-        return None
+        msg = f"{type(exc).__name__}: {exc}"
+        print(f"[db.writer] skipping ({msg})", file=sys.stderr)
+        return (None, msg)
 
     if bundle is None:
         print(
             f"[db.writer] skipping {output_dir}: no dashboard/analysis found",
             file=sys.stderr,
         )
-        return None
+        return (None, None)
 
     if r2_keys is not None:
         bundle["artifact_row"]["r2_keys"] = r2_keys
@@ -109,7 +114,7 @@ def write_run_to_db(
                 f"[db.writer] {state} {bundle['report_row']['ticker']} -> {report_id}",
                 file=sys.stderr,
             )
-            return report_id
+            return (report_id, None)
         except Exception as exc:  # noqa: BLE001
             last_exc = exc
             print(
@@ -123,10 +128,12 @@ def write_run_to_db(
                 continue
             break
 
+    err_msg: str | None = None
     if last_exc is not None:
+        err_msg = f"{type(last_exc).__name__}: {last_exc}"
         print(
-            f"[db.writer] DB write failed permanently for {bundle['report_row']['ticker']}: "
-            f"{type(last_exc).__name__}: {last_exc}",
+            f"[db.writer] DB write failed permanently for "
+            f"{bundle['report_row']['ticker']}: {err_msg}",
             file=sys.stderr,
         )
-    return None
+    return (None, err_msg)

--- a/src/ai_hedge/runner.py
+++ b/src/ai_hedge/runner.py
@@ -1186,13 +1186,15 @@ def _run_ticker_valuation_impl(
 
     try:
         from ai_hedge.db.writer import write_run_to_db
-        write_run_to_db(
+        _rid, _db_err = write_run_to_db(
             out_dir.resolve(),
             source=run_source,
             max_attempts=3,
             retry_backoff_seconds=1.5,
             r2_keys=r2_keys,
         )
+        if _db_err:
+            print(f"[runner] DB write failed: {_db_err}", file=sys.stderr)
     except Exception as _db_exc:  # noqa: BLE001
         print(f"[runner] DB write skipped: {_db_exc}", file=sys.stderr)
 


### PR DESCRIPTION
## Summary

Prod stopped surfacing new reports on **2026-05-05 16:22 UTC** despite ~16 successful runs landing on the Fly volume since then. Root cause: PR #51 (`migration/phase-0-1-artifact-store`) introduced code that writes to `report_artifacts.r2_keys`, but the matching migration [src/ai_hedge/db/migrations/004_report_artifacts_r2_keys.sql](src/ai_hedge/db/migrations/004_report_artifacts_r2_keys.sql) was never applied to prod's Neon DB. Every INSERT crashed with `UndefinedColumn: column "r2_keys" of relation "report_artifacts" does not exist`. The writer swallows DB exceptions to stderr and stamps a generic `persistence_error: "...No reports row found for source_run_id."` on the run's `_status.json`, which obscured the actual exception for four days.

This PR closes the gaps that allowed it to hide:

1. **Migration runner.** New `src/ai_hedge/db/migrate.py` walks `src/ai_hedge/db/migrations/*.sql` in lex order and tracks applied filenames in a new `schema_migrations` table. Each migration runs in its own transaction; failures leave the tracking row unwritten so the next run retries. Wired into prod via `[deploy] release_command = "python3 /app/scripts/migrate.py"` in [fly.site.toml](fly.site.toml). All four existing migrations are already idempotent (`CREATE TABLE IF NOT EXISTS`, `ADD COLUMN IF NOT EXISTS`, etc.), so the first run on prod will re-execute them harmlessly and seed the tracking table.

2. **Backfill.** New `scripts/backfill_orphaned_site_runs.py` walks `/data/outputs/_site_runs`, picks dirs with `result.status ∈ {success, partial_success}`, calls `write_run_to_db()` on each that doesn't already have a DB row, and rewrites `_status.json` to clear the legacy persistence error and flip `failed → completed` where appropriate. Idempotent — safe to re-run; supports `--dry-run`.

3. **Diagnosability.** `write_run_to_db` now returns `(report_id, error_message)` instead of just `report_id`. Callers in [scripts/site_run.py](scripts/site_run.py) and [src/ai_hedge/runner.py](src/ai_hedge/runner.py) embed the last writer error into `persistence_error` / log it. Stderr printing and the best-effort swallowing pattern are preserved.

PR #66 (cache invalidation) stays open separately — complementary fix, not part of this incident.

## Operational steps after merge (touch prod)

These run on prod and are NOT automated by this PR:

```bash
# 1. Apply migration 004 (the new release_command will keep things in sync going forward).
flyctl ssh console -a hedge-in-a-box-site -C "python3 /app/scripts/migrate.py"

# 2. Dry-run the backfill to see what would land.
flyctl ssh console -a hedge-in-a-box-site -C "python3 /app/scripts/backfill_orphaned_site_runs.py --dry-run"

# 3. Run the backfill for real.
flyctl ssh console -a hedge-in-a-box-site -C "python3 /app/scripts/backfill_orphaned_site_runs.py"
```

After step 3, `/api/reports` on prod should surface the recovered tickers (SNDK, AMD, STRS.TA, IONQ, AZRG.TA, WIX, RKLB, NICE, ASTS, SYM, OKLO, AAPL, INMD, NKE, NVDA, etc.).

## Test plan

- [x] Backend-only PR, no preview environment for site logic. Verified locally with `py_compile` across all 7 touched files; `migrate.py` discovers all 4 migrations; `backfill_orphaned_site_runs.py --help` renders; `migrate.py --dry-run` connects + fails loudly on bad URLs (intended for deploy-gate use).
- [ ] On preview deploy of this PR, the new `release_command` runs against the Neon branch — confirm workflow logs show `[migrate] applied 001..004` (preview branches inherit prod's pre-migrate-runner schema; first run will record everything, subsequent deploys are idempotent).
- [ ] After merge: run the operational steps above and confirm prod listing shows recent tickers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)