### PR TITLE
Fix missing prices_explain section in analysis PDF (define _fmt_pct)

### DIFF
--- a/src/ai_hedge/runner.py
+++ b/src/ai_hedge/runner.py
@@ -236,6 +236,14 @@ def _fmt_signed_pct(value: Any, decimals: int = 2) -> str:
     return f"{num:+.{decimals}f}%"
 
 
+def _fmt_pct(value: Any, decimals: int = 2) -> str:
+    try:
+        num = float(value)
+    except Exception:
+        return "N/A"
+    return f"{num * 100:.{decimals}f}%"
+
+
 def _currency_symbol(currency_code: Any) -> str:
     code = str(currency_code or "").strip().upper()
     if code == "ILS":


### PR DESCRIPTION
## Summary

- `_build_assumptions_pack_text` called `_fmt_pct(value)` to format probabilities and decimal ratios (Bull/Base/Bear probability, Growth Rate G, Terminal Value Growth, WACC), but the helper was never defined. The NameError was swallowed by the try/except wrapping `_build_prices_explain_text` in the runner, so `prices_explain.txt` was never written — which silently dropped the ~20-page prices_explain section from the merged analysis PDF and broke the standalone `<TICKER>_prices_explain.pdf` entirely.
- Add the missing `_fmt_pct` helper next to the other `_fmt_*` formatters. It multiplies decimals by 100 (e.g., 0.05 → "5.00%") to match the assumption-pack labels.

## Root cause trace

1. `_fmt_pct` call site introduced in commit `bc8554c` ("Fix mojibake text and short_answer prompt conflicts" #31) without a corresponding definition.
2. Any ticker with at least one parsable DCF / Scenario DCF output hit the `NameError` on the first `pct`-kind line.
3. Exception caught at [src/ai_hedge/runner.py:982-990](src/ai_hedge/runner.py#L982-L990), noted, and execution continued without writing `prices_explain.txt`.
4. Downstream: prices_explain PDF skipped, merge into `analysis.txt` skipped, `<TICKER>_analysis.pdf` shipped without the section. User-visible symptom matched: ~40 pages of analysis only, missing the ~20 pages of valuations.

## Test plan

- [ ] Backend-only PR — no preview environment.
- [ ] Re-run a fresh valuation (e.g. SNDK) locally with `python run.py --ticker SNDK --pdf` and confirm:
  - `outputs/SNDK/SNDK_prices_explain.txt` exists and contains the Bull/Base/Bear/G/WACC/Terminal lines formatted as "%".
  - `outputs/SNDK/SNDK_prices_explain.pdf` exists.
  - `outputs/SNDK/SNDK_analysis.pdf` contains the `# SNDK Prices Explain` section.
- [ ] Spot-check formatting: 0.05 → "5.00%", 0.30 → "30.00%".

🤖 Generated with [Claude Code](https://claude.com/claude-code)