### PR TITLE
Fix ticker free-text option in new analysis search

### DIFF
--- a/frontend/src/components/shell/ticker-search.tsx
+++ b/frontend/src/components/shell/ticker-search.tsx
@@ -34,6 +34,10 @@ function dedupeBySymbol(entries: TickerEntry[]): TickerEntry[] {
   return out;
 }
 
+type SuggestionItem =
+  | { kind: "entry"; entry: TickerEntry }
+  | { kind: "freeText"; symbol: string };
+
 export function TickerSearch({ value, onChange, disabled, autoFocus }: Props) {
   const [catalog, setCatalog] = useState<TickerEntry[] | null>(null);
   const [query, setQuery] = useState("");
@@ -124,10 +128,24 @@ export function TickerSearch({ value, onChange, disabled, autoFocus }: Props) {
     return dedupeBySymbol([...localResults, ...remoteResults]).slice(0, 10);
   }, [localResults, remoteResults]);
 
+  const normalizedQuery = query.trim().toUpperCase();
+  const hasExactSuggestion = useMemo(
+    () => merged.some((entry) => entry.s.toUpperCase() === normalizedQuery),
+    [merged, normalizedQuery],
+  );
+  const canUseFreeText = Boolean(normalizedQuery) && TICKER_RE.test(normalizedQuery) && !hasExactSuggestion;
+  const suggestionItems = useMemo<SuggestionItem[]>(
+    () => [
+      ...merged.map((entry) => ({ kind: "entry", entry }) as SuggestionItem),
+      ...(canUseFreeText ? [{ kind: "freeText", symbol: normalizedQuery } as SuggestionItem] : []),
+    ],
+    [merged, canUseFreeText, normalizedQuery],
+  );
+
   // Reset highlight when the merged list changes
   useEffect(() => {
     setHighlight(0);
-  }, [merged.length, query]);
+  }, [suggestionItems.length, query]);
 
   function pick(entry: TickerEntry) {
     onChange(entry);
@@ -149,14 +167,17 @@ export function TickerSearch({ value, onChange, disabled, autoFocus }: Props) {
     if (e.key === "ArrowDown") {
       e.preventDefault();
       setOpen(true);
-      setHighlight((h) => Math.min(h + 1, Math.max(0, merged.length - 1)));
+      setHighlight((h) => Math.min(h + 1, Math.max(0, suggestionItems.length - 1)));
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
       setHighlight((h) => Math.max(0, h - 1));
     } else if (e.key === "Enter") {
       e.preventDefault();
-      if (merged[highlight]) {
-        pick(merged[highlight]);
+      const selectedItem = suggestionItems[highlight];
+      if (selectedItem?.kind === "entry") {
+        pick(selectedItem.entry);
+      } else if (selectedItem?.kind === "freeText") {
+        pickFreeText();
       } else if (query.trim()) {
         pickFreeText();
       }
@@ -238,10 +259,31 @@ export function TickerSearch({ value, onChange, disabled, autoFocus }: Props) {
 
       {open && !value && query ? (
         <div className="hib-auth-menu absolute left-0 right-0 top-full z-50 mt-1 rounded-xl p-1.5 shadow-xl">
-          {merged.length ? (
+          {suggestionItems.length ? (
             <ul className="max-h-[280px] overflow-auto" role="listbox">
-              {merged.map((entry, i) => {
+              {suggestionItems.map((item, i) => {
                 const isHi = i === highlight;
+                if (item.kind === "freeText") {
+                  return (
+                    <li key={`free-text-${item.symbol}`}>
+                      <button
+                        type="button"
+                        role="option"
+                        aria-selected={isHi}
+                        onMouseEnter={() => setHighlight(i)}
+                        onClick={() => pickFreeText()}
+                        className={`hib-auth-menu-item flex w-full items-center justify-between gap-3 rounded-lg px-3 py-2 text-left ${
+                          isHi ? "bg-emerald-500/15" : ""
+                        }`}
+                      >
+                        <span className="truncate text-xs text-zinc-300">
+                          Use <span className="font-mono text-sm font-semibold text-zinc-100">{item.symbol}</span> anyway
+                        </span>
+                      </button>
+                    </li>
+                  );
+                }
+                const entry = item.entry;
                 return (
                   <li key={`${entry.s}-${i}`}>
                     <button
@@ -276,15 +318,6 @@ export function TickerSearch({ value, onChange, disabled, autoFocus }: Props) {
           ) : (
             <div className="px-3 py-3 text-xs text-zinc-500">
               {catalog === null ? "Loading tickers..." : "No matches yet."}
-              {TICKER_RE.test(query.trim()) ? (
-                <button
-                  type="button"
-                  onClick={() => pickFreeText()}
-                  className="hib-auth-menu-item mt-2 block w-full rounded-md px-2 py-1.5 text-left text-xs"
-                >
-                  Use <span className="font-mono font-semibold">{query.trim()}</span> anyway
-                </button>
-              ) : null}
             </div>
           )}
         </div>

--- a/src/ai_hedge/legacy_port.py
+++ b/src/ai_hedge/legacy_port.py
@@ -1827,13 +1827,6 @@ def load_text_from_file(file_path: str = "analysis.txt") -> str:
 
 
 from typing import Tuple
-
-ANALYZER_CALIBRATION_SENTENCE = (
-    "Use calibrated language: avoid absolute claims unless directly proven by the provided data; "
-    "when uncertainty exists, state it explicitly with probability-oriented wording "
-    "(for example: likely, may, could)."
-)
-
 def what_it_does_insights_result(info_dict) -> Tuple[str, str]:
     """
     Generate a clear, plain-language explanation of what the company actually does.
@@ -1864,7 +1857,6 @@ Guidelines:
 - Explain who the customers are and what problem the company solves.
 - Translate business jargon into plain, concrete language.
 - If multiple activities exist, explain the main one first and mention others briefly.
-- {ANALYZER_CALIBRATION_SENTENCE}
 
 Write 5-7 short sentences.
 """.strip()
@@ -1924,7 +1916,6 @@ Rules:
 - If valuation implies extreme expectations, articulate them clearly.
 - If governance, ownership, margins, growth, or capital structure stand out, explain the consequences.
 - Connect business model, financials, and market expectations into a single coherent story.
-- {ANALYZER_CALIBRATION_SENTENCE}
 
 Output format:
 - Bullet points only.
@@ -2003,7 +1994,6 @@ Output rules:
 - No headlines, no chronology, no PR language
 - Be concise, sharp, and opinionated
 - Focus on what actually matters for an investor
-- {ANALYZER_CALIBRATION_SENTENCE}
 
 Inputs:
 Company: {info_dict["short_name"]}
@@ -2081,7 +2071,6 @@ What to extract:
 - Whether the stock is treated as a story, growth platform, or cash-flow asset
 - Signals of speculative vs institutional behavior
 - What outcomes the market is overpaying or underpaying for
-- {ANALYZER_CALIBRATION_SENTENCE}
 
 Inputs:
 calls_df:
@@ -2164,7 +2153,6 @@ Output rules:
 - Prioritize depth, judgment, and interpretation
 - Be precise, skeptical, and professional
 - No generic textbook explanations
-- {ANALYZER_CALIBRATION_SENTENCE}
 
 Input:
 Name of company: {name_of_company}
@@ -2296,7 +2284,6 @@ Output rules:
 - Be direct and analytical
 - No generic explanations, no filler
 - If the JSONs are missing key context (e.g., dates, sample size), state how that limits confidence
-- {ANALYZER_CALIBRATION_SENTENCE}
 
 Inputs:
 Price targets:
@@ -2427,7 +2414,6 @@ Output requirements:
 - Focus on insights, not raw numbers
 - Separate ownership structure, institutional behavior, and insider trading insights
 - No generic explanations
-- {ANALYZER_CALIBRATION_SENTENCE}
 
 Your goal is to understand who owns the company, how that is changing, and why it matters.
 """.strip()
@@ -2506,7 +2492,6 @@ Output rules:
 - No raw table repetition
 - No generic explanations
 - Be analytical and opinionated
-- {ANALYZER_CALIBRATION_SENTENCE}
 
 Inputs:
 Company: {company_name}
@@ -2624,7 +2609,6 @@ Output rules:
 - Do not mechanically repeat numbers without interpretation
 - Be direct, analytical, and opinionated
 - Prioritize insight over completeness
-- {ANALYZER_CALIBRATION_SENTENCE}
 
 Inputs:
 Company: {company_name}
@@ -2768,8 +2752,7 @@ def swot_analysis(ticker):
   * Be analytical, not descriptive.
   * Avoid repeating the input text verbatim.
   * Prioritize insight over completeness.
-  * Assume the reader is sophisticated and time-constrained.
-  * {ANALYZER_CALIBRATION_SENTENCE}"""
+  * Assume the reader is sophisticated and time-constrained."""
 
   answer = deepseek_simple_text(
       api_key=DEEPSEEK_API_KEY,
@@ -2855,7 +2838,6 @@ def market_analyst(ticker):
   - Avoid generic market descriptions.
   - Avoid repeating the input text verbatim.
   - Prioritize clarity, depth, and economic relevance over length.
-  - {ANALYZER_CALIBRATION_SENTENCE}
 
   The final output should read as a **decision-grade market characterization**, not a generic industry overview.
   """
@@ -2911,7 +2893,6 @@ def bear_vs_bull_insights(ticker):
   - Be specific, causal, and thoughtful.
   - Write as if presenting to a skeptical investment committee.
   - The goal is not balance, but clarity of scenarios.
-  - {ANALYZER_CALIBRATION_SENTENCE}
 
   Your objective is to define the upside and downside boundaries of reality for this company.
   """
@@ -2995,7 +2976,6 @@ def change_up_anaysis(ticker, change):
 
   Reason step by step and explain your reasoning clearly.
   Deliver a deep analytical narrative, not a summary.
-  {ANALYZER_CALIBRATION_SENTENCE}
   """
   answer = deepseek_simple_text(
       api_key=DEEPSEEK_API_KEY,
@@ -3079,7 +3059,6 @@ def change_down_anaysis(ticker, change):
 
   Reason step by step and explain your reasoning clearly.
   Deliver a rigorous analytical narrative, not a summary.
-  {ANALYZER_CALIBRATION_SENTENCE}
   """
   answer = deepseek_simple_text(
       api_key=DEEPSEEK_API_KEY,
@@ -3127,7 +3106,6 @@ def for_value_insights(financial_dict, ticker):
   Each bullet should reflect a real analytical insight, not a summary or a restatement.
 
   Avoid generic language, boilerplate finance phrases, or mechanical checklists.
-  {ANALYZER_CALIBRATION_SENTENCE}
 
   Do not explain the company. Do not explain valuation methods.
   Just extract the truths that matter most for valuation.
@@ -4179,7 +4157,7 @@ def build_prompt(ticker, financial_dict, instruction, text):
   2) Financial data (structured)
   3) Company Profile Stats (structured)
   4) Explicit output instructions (strict JSON schema)
-  Treat the prepared analysis as analyst opinion, not truth. Structured financial data and primary-source excerpts override it.
+  Treat the prepared analysis as a very professional analyst opinion - very strong and high quality - but not the truth itself.
 
   Analysis document:
   <Analysis_Document>
@@ -7201,6 +7179,7 @@ def main_function(ticker, download_text = False, download_pdf = True, download_p
 
 # ticker = "NICE"
 # final_dict = main_function(ticker, download_text = False, download_pdf = False, download_pptx = False, download_excel = False)
+
 
 
 


### PR DESCRIPTION
## Summary
- keep 'Use <TICKER> anyway' available even when similar suggestions exist
- allow keyboard selection of this free-text option in the dropdown

## Test plan
- open Run a new analysis modal
- type a ticker with similar suggestions
- verify 'Use <TICKER> anyway' is visible and selectable
- confirm Enter can submit that option