### PR TITLE
Keep preview machines alive during analysis runs

### DIFF
--- a/.github/workflows/preview-site.yml
+++ b/.github/workflows/preview-site.yml
@@ -171,7 +171,9 @@ jobs:
         run: |
           # Bypass auth on per-PR previews — Google OAuth doesn't permit
           # wildcard redirect URIs for pr-N-* hostnames. Never set on prod.
-          args=("AUTH_BYPASS_PREVIEW=1")
+          # PREVIEW_KEEPALIVE keeps the machine alive during analysis runs so the
+          # detached worker isn't killed by Fly auto-stop (see scripts/site_run.py).
+          args=("AUTH_BYPASS_PREVIEW=1" "PREVIEW_KEEPALIVE=1")
           if [ -z "$DEEPSEEK_API_KEY" ]; then
             echo "::warning::DEEPSEEK_API_KEY secret not set - preview will be missing it."
           else
@@ -271,7 +273,7 @@ jobs:
             - Volume forked from prod on PR open; staleness accepted until close.
             - Site DB is a Neon branch (`${{ env.NEON_BRANCH_NAME }}`) off prod's `${{ env.NEON_PARENT_BRANCH }}` — safe to mutate.
             - **Obs DB is the prod obs DB** (no branching). Pipeline runs from this preview write `obs_runs` / `obs_calls` rows tagged with `source = "preview-pr-${{ github.event.pull_request.number }}"` so they're easy to filter or clean up later.
-            - Machine auto-stops when idle, auto-starts on request.
+            - Machine auto-stops when idle, auto-starts on request. It stays up for the duration of an active analysis run (self-ping keep-alive), then auto-stops — so mid-run analyses survive a closed tab.
             - Tear-down (Fly app + volume + Neon branch) runs automatically when this PR is closed.
 
   teardown:

--- a/frontend/src/app/api/health/route.ts
+++ b/frontend/src/app/api/health/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+
+// Lightweight liveness probe. No auth, no DB, no rendering — cheap to hit.
+// Used by the preview keep-alive self-ping in scripts/site_run.py to keep a
+// Fly preview machine alive while an analysis run is in progress.
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  return new NextResponse("ok", {
+    status: 200,
+    headers: { "cache-control": "no-store" },
+  });
+}

--- a/scripts/site_run.py
+++ b/scripts/site_run.py
@@ -6,13 +6,55 @@ import os
 import sys
 import threading
 import traceback
+import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional, Tuple
 
 
 def _utc_now() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def _maybe_start_preview_keepalive() -> Tuple[Optional[threading.Event], Optional[threading.Thread]]:
+    """Keep a Fly *preview* machine alive while this run executes.
+
+    Preview machines run with ``auto_stop_machines = "stop"`` so they shut down
+    when the Fly edge proxy sees no inbound traffic. A detached run gets killed
+    mid-flight once the browser tab closes and polling stops. To prevent that we
+    self-ping our own *public* hostname every 30s — the request egresses to the
+    Fly proxy and routes back in, resetting the idle timer. Loopback pings do not
+    count (the proxy never sees them), so the public URL is required.
+
+    Gated to previews only: needs ``PREVIEW_KEEPALIVE`` truthy *and* a Fly-injected
+    ``FLY_APP_NAME``. Prod never sets ``PREVIEW_KEEPALIVE``; local dev has no
+    ``FLY_APP_NAME``. Returns ``(None, None)`` when disabled. Best-effort: ping
+    failures are swallowed so they can never affect the run.
+    """
+    flag = str(os.getenv("PREVIEW_KEEPALIVE", "") or "").strip().lower()
+    if flag not in {"1", "true", "yes", "on"}:
+        return (None, None)
+    app = str(os.getenv("FLY_APP_NAME", "") or "").strip()
+    if not app:
+        return (None, None)
+
+    url = f"https://{app}.fly.dev/api/health"
+    stop_event = threading.Event()
+
+    def _loop() -> None:
+        while True:
+            try:
+                with urllib.request.urlopen(url, timeout=10) as resp:
+                    resp.read(0)
+            except Exception:
+                # best-effort: a failed ping must never surface
+                pass
+            if stop_event.wait(30):
+                return
+
+    thread = threading.Thread(target=_loop, name="preview-keepalive", daemon=True)
+    thread.start()
+    return (stop_event, thread)
 
 
 def _write_json(path: Path, payload: Dict[str, Any]) -> None:
@@ -117,6 +159,8 @@ def main() -> int:
             "llm_progress_pct": round(pct, 2),
         }
         _write_json(status_file, payload)
+
+    keepalive_stop, keepalive_thread = _maybe_start_preview_keepalive()
 
     try:
         from ai_hedge import legacy_port
@@ -245,6 +289,13 @@ def main() -> int:
         _write_json(status_file, failed_payload)
         _append_progress_line(progress_file, "Site Run Finalized: failed")
         return 1
+    finally:
+        # Stop the preview keep-alive so the machine can auto-stop once the run
+        # ends. Runs on every return/exception path above.
+        if keepalive_stop is not None:
+            keepalive_stop.set()
+        if keepalive_thread is not None:
+            keepalive_thread.join(timeout=2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

Per-PR site previews (`pr-<N>-hedge-in-a-box-site.fly.dev`) auto-stop **mid-run**, killing long-running analyses and making the analysis pipeline impossible to test on a preview.

**Root cause:** previews run with `auto_stop_machines = "stop"` + `min_machines_running = 0` (the workflow sed-flips prod's always-on config so idle previews cost nothing). A site analysis is a **detached, `unref()`'d** Python worker (`scripts/site_run.py`) that runs ~15-30 min. The only thing keeping the machine alive was the browser polling `/api/run-analysis/[jobId]` every 3s — and only while the tab is open. Close the tab or walk away during the run → no inbound proxy traffic → Fly stops the machine → SIGINT kills the worker → `reconcileStaleRunsAfterRestart()` marks the run "failed" on next boot.

## Fix: run-scoped self-ping keep-alive (cost-optimal)

While a run executes, a daemon thread in `site_run.py` GETs the machine's **own public hostname** `https://$FLY_APP_NAME.fly.dev/api/health` every 30s. The request egresses to the Fly edge proxy and routes back in, resetting the idle timer (loopback pings don't count). The thread is torn down in a `finally`, so the machine auto-stops the moment the run ends — **idle previews still cost \$0**; extra uptime is paid only during an active run.

Considered and rejected as more expensive: blanket-disabling auto-stop on previews (24/7 cost per open PR) and an opt-in PR label (machine on for the whole PR life, not just during runs).

Gated to previews only — requires `PREVIEW_KEEPALIVE=1` (injected by the workflow) **and** a Fly-injected `FLY_APP_NAME`. Prod (`auto_stop_machines = false`) and local dev are unaffected.

## Changes
- `scripts/site_run.py` — `_maybe_start_preview_keepalive()` daemon thread + `finally` teardown.
- `frontend/src/app/api/health/route.ts` — **new** lightweight 200 ping target (no auth/DB/render).
- `.github/workflows/preview-site.yml` — inject `PREVIEW_KEEPALIVE=1`; update sticky comment.

## Test plan
Backend + workflow change — no preview env auto-covers the Python worker. Verified:
- Local: `python3 -m py_compile scripts/site_run.py`; unit-tested the gate — returns `(None, None)` with no env / with flag but no `FLY_APP_NAME`; starts a daemon thread when both set, swallows ping failures against a fake host, and stops promptly on the stop event.
- Frontend: `tsc --noEmit` clean and `eslint` clean on the new health route.
- On this PR's preview (the real check): start an analysis, **close the tab**, confirm `flyctl machines list` shows the machine `started` through the ~20-min run and `/api/health 200` pings ~every 30s in logs; after the run finishes, the machine transitions to `stopped`; reload shows the run `completed` (not auto-failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)