### PR TITLE
Fix mobile Safari auto-zoom on form controls

### DIFF
--- a/frontend/src/app/(app)/discovery/page.tsx
+++ b/frontend/src/app/(app)/discovery/page.tsx
@@ -292,7 +292,7 @@ export default function DiscoveryPage() {
                     <select
                       value={lensKey}
                       onChange={(e) => setLensKey(String(e.target.value || ""))}
-                      className="w-full min-w-[260px] rounded-lg border border-white/15 bg-zinc-950/80 px-3 py-2 text-sm text-zinc-100 outline-none focus:border-emerald-400/60 sm:w-auto"
+                      className="w-full min-w-[260px] rounded-lg border border-white/15 bg-zinc-950/80 px-3 py-2 text-base text-zinc-100 outline-none focus:border-emerald-400/60 sm:w-auto sm:text-sm"
                     >
                       {selectedOptions.map((option) => (
                         <option key={option} value={option}>

--- a/frontend/src/components/dream-team/persona-card.tsx
+++ b/frontend/src/components/dream-team/persona-card.tsx
@@ -424,7 +424,7 @@ export function PersonaCard({
             <select
               value={activePersona}
               onChange={(e) => onPersonaSwitch(e.target.value)}
-              className="hib-select rounded-full border border-white/20 bg-white/5 px-3 py-1 text-xs outline-none transition hover:border-white/35 focus:border-white/40"
+              className="hib-select rounded-full border border-white/20 bg-white/5 px-3 py-1 text-base outline-none transition hover:border-white/35 focus:border-white/40 sm:text-xs"
             >
               {personas.map((name) => (
                 <option key={name} value={name} className="hib-select-option">

--- a/frontend/src/components/reports/reports-tabs.tsx
+++ b/frontend/src/components/reports/reports-tabs.tsx
@@ -73,7 +73,7 @@ export function ReportsTabs({
         value={query}
         onChange={(e) => setQuery(e.target.value)}
         placeholder="Search ticker or company"
-        className="min-w-[220px] flex-1 rounded-lg border border-white/10 bg-zinc-950/70 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-500 focus:border-emerald-400/60 focus:outline-none"
+        className="min-w-[220px] flex-1 rounded-lg border border-white/10 bg-zinc-950/70 px-3 py-2 text-base text-zinc-100 placeholder:text-zinc-500 focus:border-emerald-400/60 focus:outline-none sm:text-sm"
       />
     </div>
   );

--- a/frontend/src/components/shell/ticker-combobox.tsx
+++ b/frontend/src/components/shell/ticker-combobox.tsx
@@ -137,7 +137,7 @@ export function TickerCombobox({ collapsed = false, onCollapsedClick }: Combobox
               value={query}
               onChange={(e) => setQuery(e.target.value.toUpperCase())}
               placeholder="Type ticker..."
-              className="w-full rounded-md border border-white/10 bg-black/30 py-1.5 pl-7 pr-7 text-sm uppercase tracking-[0.06em] text-zinc-100 outline-none placeholder:text-zinc-500 focus:border-emerald-400/50"
+              className="w-full rounded-md border border-white/10 bg-black/30 py-1.5 pl-7 pr-7 text-base uppercase tracking-[0.06em] text-zinc-100 outline-none placeholder:text-zinc-500 focus:border-emerald-400/50 sm:text-sm"
               onKeyDown={(e) => {
                 if (e.key === "Enter" && filtered[0]) {
                   e.preventDefault();


### PR DESCRIPTION
## Summary
- audited all focusable input/textarea/select controls under frontend/src
- updated controls that rendered below 16px on mobile to use a mobile-safe size pattern (text-base on mobile, existing smaller sizing restored at sm+)
- kept changes narrowly scoped to control font-size classes only

## Key files touched
- frontend/src/components/reports/reports-tabs.tsx
- frontend/src/components/shell/ticker-combobox.tsx
- frontend/src/app/(app)/discovery/page.tsx
- frontend/src/components/dream-team/persona-card.tsx

## Verification
- npm run build (frontend): passed
- npm run lint (frontend): fails due pre-existing repo-wide ESLint issues unrelated to this change set (React hooks/compiler rules in multiple existing files)
- mobile zoom prevention rationale: all previously sub-16px text-entry controls now render at 16px on mobile, which prevents iPhone Safari focus zoom; desktop sizing remains unchanged via responsive sm:text-sm / sm:text-xs
