### PR TITLE
Improve dashboard fallback retries and valuation anchors

### DIFF
--- a/frontend/src/components/dream-team/persona-card.tsx
+++ b/frontend/src/components/dream-team/persona-card.tsx
@@ -441,12 +441,21 @@ export function PersonaCard({
             <span className="text-[10px] uppercase tracking-[0.16em] text-zinc-500">Valuator</span>
             <div className="flex flex-wrap gap-2">
               {personaPickerRows.map((row) => {
-                const toneClass =
-                  row.tone === "up"
-                    ? "border-emerald-500/55 bg-emerald-500/20 text-emerald-100"
-                    : row.tone === "down"
-                      ? "border-red-500/55 bg-red-500/20 text-red-100"
-                      : "border-white/20 bg-white/5 text-zinc-200";
+                const toneClass = row.isActive
+                  ? (
+                    row.tone === "up"
+                      ? "border-emerald-500/60 bg-emerald-500/24 text-emerald-100"
+                      : row.tone === "down"
+                        ? "border-red-500/60 bg-red-500/24 text-red-100"
+                        : "border-white/25 bg-white/10 text-zinc-100"
+                  )
+                  : (
+                    row.tone === "up"
+                      ? "border-emerald-500/35 bg-emerald-500/8 text-zinc-300"
+                      : row.tone === "down"
+                        ? "border-red-500/35 bg-red-500/8 text-zinc-300"
+                        : "border-white/20 bg-white/5 text-zinc-300"
+                  );
                 const activeClass = row.isActive
                   ? "ring-2 ring-sky-300/90 ring-offset-1 ring-offset-zinc-950 shadow-[0_0_0_1px_rgba(255,255,255,0.35)]"
                   : "hover:border-white/40";
@@ -558,18 +567,9 @@ export function PersonaCard({
                 </div>
               ))}
             </div>
-          ) : (
-            <div className="hib-dream-chat-transcript mt-4 flex min-h-[170px] items-end rounded-xl border px-4 py-3">
-              <div className="space-y-1">
-                <p className="text-[10px] uppercase tracking-[0.16em] text-zinc-500">Ready to chat</p>
-                <p className="text-sm text-zinc-300">
-                  You are chatting with <span className="font-semibold text-zinc-100">{activePersona}</span>. Ask your first question below.
-                </p>
-              </div>
-            </div>
-          )}
+          ) : null}
 
-          <div className="mt-4 flex flex-col gap-2">
+          <div className={`${chatMessages.length > 0 ? "mt-4" : "mt-8"} flex flex-col gap-2`}>
             <textarea
               value={chatDraft}
               onChange={(e) => onChatDraftChange(e.target.value)}

--- a/frontend/src/components/dream-team/persona-card.tsx
+++ b/frontend/src/components/dream-team/persona-card.tsx
@@ -432,6 +432,10 @@ export function PersonaCard({
               </button>
             </div>
           </div>
+          <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-3 py-1 text-[11px]">
+            <span className="uppercase tracking-[0.14em] text-zinc-500">Talking now</span>
+            <span className="font-semibold text-zinc-100">{activePersona}</span>
+          </div>
 
           <div className="mb-2 flex flex-wrap items-center gap-2">
             <span className="text-[10px] uppercase tracking-[0.16em] text-zinc-500">Valuator</span>
@@ -443,7 +447,9 @@ export function PersonaCard({
                     : row.tone === "down"
                       ? "border-red-500/55 bg-red-500/20 text-red-100"
                       : "border-white/20 bg-white/5 text-zinc-200";
-                const activeClass = row.isActive ? "ring-1 ring-white/40" : "hover:border-white/40";
+                const activeClass = row.isActive
+                  ? "ring-2 ring-sky-300/90 ring-offset-1 ring-offset-zinc-950 shadow-[0_0_0_1px_rgba(255,255,255,0.35)]"
+                  : "hover:border-white/40";
                 return (
                   <button
                     key={row.name}
@@ -452,7 +458,10 @@ export function PersonaCard({
                     className={`rounded-full border px-3 py-1 text-[11px] transition ${toneClass} ${activeClass}`}
                     aria-pressed={row.isActive}
                   >
-                    {row.name}
+                    <span className="inline-flex items-center gap-1">
+                      {row.isActive ? <span className="text-[10px] leading-none text-sky-200">●</span> : null}
+                      <span>{row.name}</span>
+                    </span>
                   </button>
                 );
               })}
@@ -549,9 +558,18 @@ export function PersonaCard({
                 </div>
               ))}
             </div>
-          ) : null}
+          ) : (
+            <div className="hib-dream-chat-transcript mt-4 flex min-h-[170px] items-end rounded-xl border px-4 py-3">
+              <div className="space-y-1">
+                <p className="text-[10px] uppercase tracking-[0.16em] text-zinc-500">Ready to chat</p>
+                <p className="text-sm text-zinc-300">
+                  You are chatting with <span className="font-semibold text-zinc-100">{activePersona}</span>. Ask your first question below.
+                </p>
+              </div>
+            </div>
+          )}
 
-          <div className="mt-3 flex flex-col gap-2">
+          <div className="mt-4 flex flex-col gap-2">
             <textarea
               value={chatDraft}
               onChange={(e) => onChatDraftChange(e.target.value)}

--- a/frontend/src/components/dream-team/persona-card.tsx
+++ b/frontend/src/components/dream-team/persona-card.tsx
@@ -22,6 +22,11 @@ export type PersonaCardData = {
   reason_sections: Array<{ path?: string; label: string; text: string }>;
 };
 
+type PersonaPickerOption = {
+  name: string;
+  targetPrice: number | null;
+};
+
 type PersonaChatMessage = {
   id: string;
   role: "user" | "assistant";
@@ -113,7 +118,7 @@ export function PersonaCard({
 }: {
   member: PersonaCardData;
   ticker: string;
-  personas: string[];
+  personas: PersonaPickerOption[];
   activePersona: string;
   ctx: CurrencyContext;
   currentPrice: number | null | undefined;
@@ -292,6 +297,15 @@ export function PersonaCard({
   const allocationVerdict = verdictMark(directionOf(allocationPct), actualDirection);
 
   const sections = member.reason_sections.filter((s) => normalizeReasonText(String(s.text || "")));
+  const personaPickerRows = personas.map((row) => {
+    const target = typeof row.targetPrice === "number" && Number.isFinite(row.targetPrice) ? row.targetPrice : null;
+    const isNeutral = typeof currentPrice !== "number" || !Number.isFinite(currentPrice) || target === null || Math.abs(target - currentPrice) < 1e-9;
+    return {
+      ...row,
+      isActive: row.name === activePersona,
+      tone: isNeutral ? "neutral" : target > currentPrice ? "up" : "down",
+    };
+  });
   const latestMessage = chatMessages.length ? chatMessages[chatMessages.length - 1] : null;
   const hasStartedAssistantReveal =
     Boolean(latestMessage) &&
@@ -421,17 +435,28 @@ export function PersonaCard({
 
           <div className="mb-2 flex flex-wrap items-center gap-2">
             <span className="text-[10px] uppercase tracking-[0.16em] text-zinc-500">Valuator</span>
-            <select
-              value={activePersona}
-              onChange={(e) => onPersonaSwitch(e.target.value)}
-              className="hib-select rounded-full border border-white/20 bg-white/5 px-3 py-1 text-base outline-none transition hover:border-white/35 focus:border-white/40 sm:text-xs"
-            >
-              {personas.map((name) => (
-                <option key={name} value={name} className="hib-select-option">
-                  {name}
-                </option>
-              ))}
-            </select>
+            <div className="flex flex-wrap gap-2">
+              {personaPickerRows.map((row) => {
+                const toneClass =
+                  row.tone === "up"
+                    ? "border-emerald-500/55 bg-emerald-500/20 text-emerald-100"
+                    : row.tone === "down"
+                      ? "border-red-500/55 bg-red-500/20 text-red-100"
+                      : "border-white/20 bg-white/5 text-zinc-200";
+                const activeClass = row.isActive ? "ring-1 ring-white/40" : "hover:border-white/40";
+                return (
+                  <button
+                    key={row.name}
+                    type="button"
+                    onClick={() => onPersonaSwitch(row.name)}
+                    className={`rounded-full border px-3 py-1 text-[11px] transition ${toneClass} ${activeClass}`}
+                    aria-pressed={row.isActive}
+                  >
+                    {row.name}
+                  </button>
+                );
+              })}
+            </div>
           </div>
 
           <div className="flex flex-wrap gap-2">

--- a/frontend/src/components/dream-team/persona-gallery.tsx
+++ b/frontend/src/components/dream-team/persona-gallery.tsx
@@ -638,7 +638,12 @@ export function PersonaGallery({
               <PersonaCard
                 member={active}
                 ticker={ticker}
-                personas={merged.map((row) => String(row.persona || "").trim()).filter(Boolean)}
+                personas={merged
+                  .map((row) => ({
+                    name: String(row.persona || "").trim(),
+                    targetPrice: typeof row.target_price === "number" && Number.isFinite(row.target_price) ? row.target_price : null,
+                  }))
+                  .filter((row) => row.name)}
                 activePersona={active.persona}
                 ctx={ctx}
                 currentPrice={currentPrice}

--- a/src/ai_hedge/dashboard.py
+++ b/src/ai_hedge/dashboard.py
@@ -863,6 +863,18 @@ def _run_json_extraction_prompt(*, ticker: str, financial_dict: Dict[str, Any], 
     return _parse_json_blob(raw)
 
 
+def _has_exec_summary(doc: Dict[str, Any]) -> bool:
+    if not isinstance(doc, dict):
+        return False
+    return bool(_first_non_empty(doc.get("executive_summary"), doc.get("executive_summary_markdown")))
+
+
+def _has_reasons(doc: Dict[str, Any]) -> bool:
+    if not isinstance(doc, dict):
+        return False
+    return bool(_as_str_list(doc.get("reasons"), max_items=1))
+
+
 def generate_dashboard_sections(
     *,
     ticker: str,
@@ -893,38 +905,69 @@ def generate_dashboard_sections(
             deterministic_red_flags=deterministic_red_flags,
         )
 
+    max_attempts_raw = os.getenv("DASHBOARD_EXTRACTION_ATTEMPTS", "").strip()
     try:
-        exec_doc = _run_json_extraction_prompt(
-            ticker=ticker,
-            financial_dict=financial_dict,
-            text=merged_text,
-            instruction=INSTRUCTION_EXECUTIVE_SUMMARY,
-        )
-        bull_doc = _run_json_extraction_prompt(
-            ticker=ticker,
-            financial_dict=financial_dict,
-            text=merged_text,
-            instruction=INSTRUCTION_BULL_CASE,
-        )
-        bear_doc = _run_json_extraction_prompt(
-            ticker=ticker,
-            financial_dict=financial_dict,
-            text=merged_text,
-            instruction=INSTRUCTION_BEAR_CASE,
-        )
+        max_attempts = int(max_attempts_raw) if max_attempts_raw else 3
     except Exception:
-        return _fallback_qualitative_sections(
-            analysis_text=analysis_text,
-            sec_short_text=sec_short_text,
-            deterministic_red_flags=deterministic_red_flags,
-        )
+        max_attempts = 3
+    max_attempts = max(1, max_attempts)
 
-    if not exec_doc or not bull_doc or not bear_doc:
-        return _fallback_qualitative_sections(
-            analysis_text=analysis_text,
-            sec_short_text=sec_short_text,
-            deterministic_red_flags=deterministic_red_flags,
-        )
+    exec_doc: Dict[str, Any] = {}
+    bull_doc: Dict[str, Any] = {}
+    bear_doc: Dict[str, Any] = {}
+    for _ in range(max_attempts):
+        try:
+            cand_exec = _run_json_extraction_prompt(
+                ticker=ticker,
+                financial_dict=financial_dict,
+                text=merged_text,
+                instruction=INSTRUCTION_EXECUTIVE_SUMMARY,
+            )
+            if _has_exec_summary(cand_exec):
+                exec_doc = cand_exec
+        except Exception:
+            pass
+
+        try:
+            cand_bull = _run_json_extraction_prompt(
+                ticker=ticker,
+                financial_dict=financial_dict,
+                text=merged_text,
+                instruction=INSTRUCTION_BULL_CASE,
+            )
+            if _has_reasons(cand_bull):
+                bull_doc = cand_bull
+        except Exception:
+            pass
+
+        try:
+            cand_bear = _run_json_extraction_prompt(
+                ticker=ticker,
+                financial_dict=financial_dict,
+                text=merged_text,
+                instruction=INSTRUCTION_BEAR_CASE,
+            )
+            if _has_reasons(cand_bear):
+                bear_doc = cand_bear
+        except Exception:
+            pass
+
+        if _has_exec_summary(exec_doc) and _has_reasons(bull_doc) and _has_reasons(bear_doc):
+            break
+
+    fallback = _fallback_qualitative_sections(
+        analysis_text=analysis_text,
+        sec_short_text=sec_short_text,
+        deterministic_red_flags=deterministic_red_flags,
+    )
+    fallback_docs = fallback.get("documents", {}) if isinstance(fallback.get("documents"), dict) else {}
+
+    if not _has_exec_summary(exec_doc):
+        exec_doc = fallback_docs.get("executive_summary", {}) if isinstance(fallback_docs.get("executive_summary"), dict) else {}
+    if not _has_reasons(bull_doc):
+        bull_doc = fallback_docs.get("bull_case", {}) if isinstance(fallback_docs.get("bull_case"), dict) else {}
+    if not _has_reasons(bear_doc):
+        bear_doc = fallback_docs.get("bear_case", {}) if isinstance(fallback_docs.get("bear_case"), dict) else {}
 
     bull_reasons = _as_str_list(bull_doc.get("reasons"), max_items=15)
     bear_reasons = _as_str_list(bear_doc.get("reasons"), max_items=15)
@@ -932,6 +975,10 @@ def generate_dashboard_sections(
     executive_summary = _first_non_empty(exec_doc.get("executive_summary"), exec_doc.get("executive_summary_markdown"))
     if not executive_summary:
         executive_summary = "Executive summary extraction was empty."
+
+    source = "llm"
+    if not (_has_exec_summary(exec_doc) and _has_reasons(bull_doc) and _has_reasons(bear_doc)):
+        source = "mixed_fallback"
 
     return {
         "documents": {
@@ -946,7 +993,7 @@ def generate_dashboard_sections(
         "bull_insights": bull_reasons[:10],
         "red_flags": [],
         "swot": {"strengths": [], "weaknesses": [], "opportunities": [], "threats": []},
-        "source": "llm",
+        "source": source,
     }
 
 

--- a/src/ai_hedge/legacy_port.py
+++ b/src/ai_hedge/legacy_port.py
@@ -3393,6 +3393,7 @@ Output schema (must match exactly):
   "base_rationale": "string",
   "bear": [number, number, number, number, number],
   "bear_rationale": "string",
+  "representative_ev_current": number,
   "investment_amount": number,
   "investment_rationale": "string"
 }
@@ -3404,6 +3405,7 @@ Definitions:
 - probability must be decimal (0..1), not percent string.
 - fcf_next_year must be absolute full units in U.S. dollars.
 - g, WACC, and TERMINAL must be decimal ratios (example: 0.10 for 10%).
+- representative_ev_current must be a single positive full-unit enterprise value (EV) anchor for the company today.
 - investment_amount is capital allocated out of a $100,000 notional budget in [-100000, 100000].
 
 Rules:
@@ -3585,6 +3587,7 @@ Output schema (must match exactly):
   "bear_rationale": "string",
   "ev_sales_multiple": number,
   "ev_sales_rationale": "string",
+  "representative_ev_current": number,
   "investment_amount": number,
   "investment_rationale": "string"
 }
@@ -3594,6 +3597,7 @@ Definitions:
 - probability must be decimal in [0,1], and all scenario probabilities must sum to 1.0 (+/-0.001 tolerance).
 - revenue_3y_normalized must be absolute numeric revenue in full units (not percentages, not K/M abbreviations).
 - ev_sales_multiple must be one shared long-term EV/S multiple used across all scenarios.
+- representative_ev_current must be a single positive full-unit enterprise value (EV) anchor for the company today.
 - "step_by_step_analysis" should justify scenario separation, probability weights, revenue normalization, and multiple discipline.
 - "investment_amount" must be in [-100000, 100000], and "investment_rationale" must explain the position size.
 
@@ -3618,6 +3622,7 @@ Output schema (must match exactly):
   "base_rationale": "string",
   "bear": [number, number, number, number, number, number],
   "bear_rationale": "string",
+  "representative_revenue_current_year": number,
   "investment_amount": number,
   "investment_rationale": "string"
 }
@@ -3630,10 +3635,11 @@ Rules:
 2) growth/margin/tax must be decimal ratios (for example 0.18, not 18).
 3) net_financing_result must be a full absolute numeric value (can be negative).
 4) pe_multiple must be numeric and single-value per scenario.
-5) Keep step_by_step_analysis and rationale fields as single complete strings.
-6) "investment_amount" must be in [-100000, 100000].
-7) Do not output ranges, null/NaN, nested objects, or extra top-level keys.
-8) ZERO POLITENESS: output raw JSON only.
+5) representative_revenue_current_year must be a single positive full-unit revenue number for the current-year anchor used by your own understanding.
+6) Keep step_by_step_analysis and rationale fields as single complete strings.
+7) "investment_amount" must be in [-100000, 100000].
+8) Do not output ranges, null/NaN, nested objects, or extra top-level keys.
+9) ZERO POLITENESS: output raw JSON only.
 """
 
 instructions_sotp_scenario = """Based on the input you receive, produce a probabilistic 3-scenario SOTP valuation (Bull / Base / Bear).
@@ -3789,6 +3795,12 @@ def extract_scenario_dcf_json(text: str) -> Dict[str, Any]:
     if not investment_fields:
         return {}
     investment_amount, investment_rationale = investment_fields
+    representative_ev_raw = data.get("representative_ev_current")
+    representative_ev_current = None
+    if isinstance(representative_ev_raw, (int, float)) and not isinstance(representative_ev_raw, bool):
+        representative_ev_current = float(representative_ev_raw)
+        if representative_ev_current <= 0:
+            representative_ev_current = None
 
     scenarios: Dict[str, Dict[str, float]] = {}
     for scenario_name in ["bull", "base", "bear"]:
@@ -3825,6 +3837,7 @@ def extract_scenario_dcf_json(text: str) -> Dict[str, Any]:
 
     return {
         "scenarios": scenarios,
+        "representative_ev_current": representative_ev_current,
         "investment_amount": investment_amount,
         "investment_rationale": investment_rationale,
     }
@@ -4001,6 +4014,12 @@ def extract_revenue_scenario_json(text: str) -> Dict[str, Any]:
     if not investment_fields:
         return {}
     investment_amount, investment_rationale = investment_fields
+    representative_ev_raw = data.get("representative_ev_current")
+    representative_ev_current = None
+    if isinstance(representative_ev_raw, (int, float)) and not isinstance(representative_ev_raw, bool):
+        representative_ev_current = float(representative_ev_raw)
+        if representative_ev_current <= 0:
+            representative_ev_current = None
 
     if not isinstance(data["ev_sales_multiple"], (int, float)) or isinstance(data["ev_sales_multiple"], bool):
         return {}
@@ -4031,6 +4050,7 @@ def extract_revenue_scenario_json(text: str) -> Dict[str, Any]:
     return {
         "scenarios": scenarios,
         "ev_sales_multiple": ev_sales_multiple,
+        "representative_ev_current": representative_ev_current,
         "investment_amount": investment_amount,
         "investment_rationale": investment_rationale,
     }
@@ -4049,6 +4069,12 @@ def extract_composite_scenario_json(text: str) -> Dict[str, Any]:
     if not investment_fields:
         return {}
     investment_amount, investment_rationale = investment_fields
+    representative_revenue_raw = data.get("representative_revenue_current_year")
+    representative_revenue_current_year = None
+    if isinstance(representative_revenue_raw, (int, float)) and not isinstance(representative_revenue_raw, bool):
+        representative_revenue_current_year = float(representative_revenue_raw)
+        if representative_revenue_current_year <= 0:
+            representative_revenue_current_year = None
 
     scenarios: Dict[str, Dict[str, float]] = {}
     for scenario in ["bull", "base", "bear"]:
@@ -4076,6 +4102,7 @@ def extract_composite_scenario_json(text: str) -> Dict[str, Any]:
 
     return {
         "scenarios": scenarios,
+        "representative_revenue_current_year": representative_revenue_current_year,
         "investment_amount": investment_amount,
         "investment_rationale": investment_rationale,
     }
@@ -4292,9 +4319,14 @@ def build_prompt(ticker, financial_dict, instruction, text):
   return prompt
 
 
-def calculate_dcf(variable_dict, fcf0, wacc, g, terminal_g, years=5):
+def calculate_dcf(variable_dict, fcf0, wacc, g, terminal_g, years=5, representative_ev_current=None):
     shares_outstanding = variable_dict["shares_outstanding"]
-    diff = variable_dict["ev"] - variable_dict["market_cap"]
+    ev_anchor = float(variable_dict.get("ev", 0) or 0)
+    if isinstance(representative_ev_current, (int, float)) and not isinstance(representative_ev_current, bool):
+        candidate_ev = float(representative_ev_current)
+        if candidate_ev > 0:
+            ev_anchor = candidate_ev
+    diff = ev_anchor - variable_dict["market_cap"]
 
     if terminal_g >= wacc:
         return 0
@@ -4326,7 +4358,7 @@ def calculate_dcf(variable_dict, fcf0, wacc, g, terminal_g, years=5):
     return share
 
 
-def calculate_scenario_dcf(variable_dict, scenarios_dict):
+def calculate_scenario_dcf(variable_dict, scenarios_dict, representative_ev_current=None):
     expected_price = 0.0
     weighted_fcf = 0.0
     weighted_g = 0.0
@@ -4342,7 +4374,16 @@ def calculate_scenario_dcf(variable_dict, scenarios_dict):
         wacc = float(payload.get("wacc", 0.0))
         terminal_g = float(payload.get("terminal_g", 0.0))
 
-        scenario_price = float(calculate_dcf(variable_dict, fcf, wacc, g, terminal_g))
+        scenario_price = float(
+            calculate_dcf(
+                variable_dict,
+                fcf,
+                wacc,
+                g,
+                terminal_g,
+                representative_ev_current=representative_ev_current,
+            )
+        )
         per_scenario_prices[scenario_name] = scenario_price
 
         expected_price += p * scenario_price
@@ -4356,6 +4397,11 @@ def calculate_scenario_dcf(variable_dict, scenarios_dict):
 
     return {
         "expected_price": expected_price,
+        "representative_ev_current": (
+            float(representative_ev_current)
+            if isinstance(representative_ev_current, (int, float)) and not isinstance(representative_ev_current, bool) and float(representative_ev_current) > 0
+            else float(variable_dict.get("ev", 0) or 0)
+        ),
         "weighted_fcf_next_year": weighted_fcf,
         "weighted_g": weighted_g,
         "weighted_wacc": weighted_wacc,
@@ -4363,8 +4409,13 @@ def calculate_scenario_dcf(variable_dict, scenarios_dict):
         "per_scenario_prices": per_scenario_prices,
     }
 
-def calculate_ps(variable_dict, ev_sales_multiple, revenue):
-    diff = variable_dict["ev"] - variable_dict["market_cap"]
+def calculate_ps(variable_dict, ev_sales_multiple, revenue, representative_ev_current=None):
+    ev_anchor = float(variable_dict.get("ev", 0) or 0)
+    if isinstance(representative_ev_current, (int, float)) and not isinstance(representative_ev_current, bool):
+        candidate_ev = float(representative_ev_current)
+        if candidate_ev > 0:
+            ev_anchor = candidate_ev
+    diff = ev_anchor - variable_dict["market_cap"]
     ev = ev_sales_multiple * revenue
     fmc = ev - diff
     shares_outstanding = variable_dict["shares_outstanding"]
@@ -4416,27 +4467,32 @@ def calculate_bbb_ni_pe(variable_dict, scenarios_dict, pe_multiple):
     return 0, ni
   return share_price, ni
 
-def calculate_revenue_scenario(variable_dict, scenarios_dict, ev_sales_multiple):
+def calculate_revenue_scenario(variable_dict, scenarios_dict, ev_sales_multiple, representative_ev_current=None):
   expected_revenue = 0.0
   per_scenario_prices: Dict[str, float] = {}
   for scenario_name in ["bear", "base", "bull"]:
     payload = scenarios_dict.get(scenario_name, {})
     prob = float(payload.get("probability", 0.0))
     revenue_3y = float(payload.get("revenue_3y", 0.0))
-    scenario_price = float(calculate_ps(variable_dict, ev_sales_multiple, revenue_3y))
+    scenario_price = float(calculate_ps(variable_dict, ev_sales_multiple, revenue_3y, representative_ev_current=representative_ev_current))
     per_scenario_prices[scenario_name] = scenario_price
     expected_revenue += prob * revenue_3y
-  expected_price = float(calculate_ps(variable_dict, ev_sales_multiple, expected_revenue))
+  expected_price = float(calculate_ps(variable_dict, ev_sales_multiple, expected_revenue, representative_ev_current=representative_ev_current))
   if expected_price < 0:
     expected_price = 0.0
   return {
       "expected_price": expected_price,
       "expected_revenue_3y": expected_revenue,
       "ev_sales_multiple": float(ev_sales_multiple),
+      "representative_ev_current": (
+          float(representative_ev_current)
+          if isinstance(representative_ev_current, (int, float)) and not isinstance(representative_ev_current, bool) and float(representative_ev_current) > 0
+          else float(variable_dict.get("ev", 0) or 0)
+      ),
       "per_scenario_prices": per_scenario_prices,
   }
 
-def calculate_composite_scenario(variable_dict, scenarios_dict):
+def calculate_composite_scenario(variable_dict, scenarios_dict, representative_revenue_current_year=None):
   expected_price = 0.0
   expected_revenue = 0.0
   expected_net_income = 0.0
@@ -4447,6 +4503,11 @@ def calculate_composite_scenario(variable_dict, scenarios_dict):
   weighted_tax = 0.0
   weighted_pe = 0.0
   per_scenario_prices: Dict[str, float] = {}
+  revenue_anchor = float(variable_dict.get("revenue", 0) or 0)
+  if isinstance(representative_revenue_current_year, (int, float)) and not isinstance(representative_revenue_current_year, bool):
+    candidate_anchor = float(representative_revenue_current_year)
+    if candidate_anchor > 0:
+      revenue_anchor = candidate_anchor
 
   for scenario_name in ["bear", "base", "bull"]:
     payload = scenarios_dict.get(scenario_name, {})
@@ -4457,7 +4518,7 @@ def calculate_composite_scenario(variable_dict, scenarios_dict):
     tax_rate = float(payload.get("tax_rate", 0.0))
     pe = float(payload.get("pe_multiple", 0.0))
     scenario_price, scenario_revenue, scenario_ni, _ = calculate_forest_logic(
-        variable_dict, growth, margin, net_financing, tax_rate, pe
+        variable_dict, growth, margin, net_financing, tax_rate, pe, revenue_override=revenue_anchor
     )
     per_scenario_prices[scenario_name] = float(scenario_price)
     expected_price += prob * float(scenario_price)
@@ -4474,6 +4535,7 @@ def calculate_composite_scenario(variable_dict, scenarios_dict):
     expected_price = 0.0
   return {
       "expected_price": expected_price,
+      "representative_revenue_current_year": revenue_anchor,
       "expected_revenue_3y": expected_revenue,
       "expected_net_income_3y": expected_net_income,
       "expected_pe_multiple": expected_pe,
@@ -4529,8 +4591,11 @@ def calculate_sotp_scenario(variable_dict, scenarios_dict):
       "weighted_activity_market_cap": weighted_activity_market_cap,
   }
 
-def calculate_forest_logic(variable_dict, growth, op_margin, net_financing, tax_rate, pe):
-  revenue = variable_dict["revenue"]
+def calculate_forest_logic(variable_dict, growth, op_margin, net_financing, tax_rate, pe, revenue_override=None):
+  if isinstance(revenue_override, (int, float)) and not isinstance(revenue_override, bool):
+    revenue = float(revenue_override)
+  else:
+    revenue = float(variable_dict.get("revenue", 0) or 0)
   if revenue <= 0:
     return 0, 0, 0, 0
   shares_outstanding = variable_dict["shares_outstanding"]
@@ -4563,7 +4628,11 @@ def get_bbb_tp(bbb_tp_json, variables_dict):
     return []
 
 def get_scenario_dcf(scenario_dcf_json, variables_dict):
-  calc = calculate_scenario_dcf(variables_dict, scenario_dcf_json["scenarios"])
+  calc = calculate_scenario_dcf(
+      variables_dict,
+      scenario_dcf_json["scenarios"],
+      scenario_dcf_json.get("representative_ev_current"),
+  )
   expected_price = float(calc["expected_price"])
   if expected_price > 0:
     return [expected_price], calc
@@ -4582,6 +4651,7 @@ def get_revenue_scenario(revenue_scenario_json, variables_dict):
       variables_dict,
       revenue_scenario_json["scenarios"],
       revenue_scenario_json["ev_sales_multiple"],
+      revenue_scenario_json.get("representative_ev_current"),
   )
   expected_price = float(calc["expected_price"])
   expected_revenue = float(calc["expected_revenue_3y"])
@@ -4591,7 +4661,11 @@ def get_revenue_scenario(revenue_scenario_json, variables_dict):
   return [], [ev_sales_multiple], [expected_revenue], calc
 
 def get_composite_scenario(composite_scenario_json, variables_dict):
-  calc = calculate_composite_scenario(variables_dict, composite_scenario_json["scenarios"])
+  calc = calculate_composite_scenario(
+      variables_dict,
+      composite_scenario_json["scenarios"],
+      composite_scenario_json.get("representative_revenue_current_year"),
+  )
   expected_price = float(calc["expected_price"])
   expected_revenue = float(calc["expected_revenue_3y"])
   expected_net_income = float(calc["expected_net_income_3y"])
@@ -5047,6 +5121,7 @@ def scenario_dcf_full(
       raw_for_detail["g"] = [weighted_g, weighted_g]
       raw_for_detail["WACC"] = [weighted_wacc, weighted_wacc]
       raw_for_detail["TERMINAL"] = [weighted_terminal, weighted_terminal]
+      raw_for_detail["representative_ev_current"] = float(calc.get("representative_ev_current", 0.0))
       details.append(
           {
               "target_price": float(prices[0]) if prices else None,
@@ -5243,6 +5318,7 @@ def revenue_scenario_full(
       raw_for_detail["revenue_3y"] = float(calc.get("expected_revenue_3y", 0.0))
       ev_sales_multiple = float(revenue_json.get("ev_sales_multiple", 0.0))
       raw_for_detail["ev_sales_multiple"] = [ev_sales_multiple, ev_sales_multiple]
+      raw_for_detail["representative_ev_current"] = float(calc.get("representative_ev_current", 0.0))
       details.append(
           {
               "target_price": float(price[0]) if price else None,
@@ -5313,6 +5389,9 @@ def composite_scenario_full(
             float(scenario_payload.get("pe_multiple", 0.0)),
         ]
       raw_for_detail["revenue_3y"] = float(calc.get("expected_revenue_3y", 0.0))
+      raw_for_detail["representative_revenue_current_year"] = float(
+          calc.get("representative_revenue_current_year", 0.0)
+      )
       raw_for_detail["net_income_3y"] = float(calc.get("expected_net_income_3y", 0.0))
       raw_for_detail["revenue_growth_3y_avg"] = float(calc.get("weighted_growth", 0.0))
       raw_for_detail["operating_profitability_margin"] = float(calc.get("weighted_margin", 0.0))

--- a/src/ai_hedge/runner.py
+++ b/src/ai_hedge/runner.py
@@ -632,6 +632,7 @@ def _method_specific_numeric_pairs(method_name: str, raw_json: Dict[str, Any]) -
             pairs.append((f"{label} Growth Rate (G)", _numeric_text(_scenario_list_value(raw_json, key, 2), pct=True)))
             pairs.append((f"{label} WACC", _numeric_text(_scenario_list_value(raw_json, key, 3), pct=True)))
             pairs.append((f"{label} Terminal Growth", _numeric_text(_scenario_list_value(raw_json, key, 4), pct=True)))
+        pairs.append(("Representative EV (Current Anchor)", _numeric_text(raw_json.get("representative_ev_current"))))
         pairs.append(("Weighted FCF Next Year", _numeric_text(_range_mid(raw_json.get("fcf_next_year")))))
         pairs.append(("Weighted Growth Rate (G)", _numeric_text(_range_mid(raw_json.get("g")), pct=True)))
         pairs.append(("Weighted WACC", _numeric_text(_range_mid(raw_json.get("WACC")), pct=True)))
@@ -651,6 +652,7 @@ def _method_specific_numeric_pairs(method_name: str, raw_json: Dict[str, Any]) -
         for key, label in scenario_labels:
             pairs.append((f"{label} Probability", _numeric_text(_scenario_list_value(raw_json, key, 0), pct=True)))
             pairs.append((f"{label} Revenue (3Y)", _numeric_text(_scenario_list_value(raw_json, key, 1))))
+        pairs.append(("Representative EV (Current Anchor)", _numeric_text(raw_json.get("representative_ev_current"))))
         pairs.append(("Weighted Revenue (3Y)", _numeric_text(raw_json.get("revenue_3y"))))
         pairs.append(("EV/Sales Multiple", _numeric_text(_range_mid(raw_json.get("ev_sales_multiple")))))
     elif method_name == "Composite Scenario":
@@ -661,6 +663,7 @@ def _method_specific_numeric_pairs(method_name: str, raw_json: Dict[str, Any]) -
             pairs.append((f"{label} Net Financing Result", _numeric_text(_scenario_list_value(raw_json, key, 3))))
             pairs.append((f"{label} Tax Rate", _numeric_text(_scenario_list_value(raw_json, key, 4), pct=True)))
             pairs.append((f"{label} P/E Multiple", _numeric_text(_scenario_list_value(raw_json, key, 5))))
+        pairs.append(("Representative Revenue (Current Year Anchor)", _numeric_text(raw_json.get("representative_revenue_current_year"))))
         pairs.append(("Weighted Revenue (3Y)", _numeric_text(raw_json.get("revenue_3y"))))
         pairs.append(("Weighted Net Income (3Y)", _numeric_text(raw_json.get("net_income_3y"))))
         pairs.append(("Weighted Revenue Growth (3Y Avg)", _numeric_text(raw_json.get("revenue_growth_3y_avg"), pct=True)))


### PR DESCRIPTION
## Summary
- add dashboard extraction retry logic (initial + 2 retries) before falling back
- apply section-level fallback merging so successful sections are preserved
- add representative anchor fields for composite revenue and EV-based valuation methods
- surface representative anchors in prices-explain output

## Test plan
- python -m py_compile src/ai_hedge/dashboard.py src/ai_hedge/legacy_port.py src/ai_hedge/runner.py