### PR TITLE
Add copy buttons to dashboard and Dream Team blog sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,127 +1,193 @@
-﻿# AI Hedge Notebook Port (Ticker Valuation)
+# AI_HEDGE_2
 
-This project ports the notebook logic into a runnable modular structure while preserving the original valuation flow and prompts/parsers in `src/ai_hedge/legacy_port.py`.
+AI_HEDGE_2 is an AI-driven equity analysis platform with three active surfaces:
 
-## What it does now
-- Accepts a ticker input
-- Runs the same analysis + valuation pipeline
-- Saves 3 valuation plots:
-  - prices valuation
-  - revenue valuation
-  - net income valuation
-- Optionally generates PDF from analysis text (`--pdf`)
+1. Python valuation engine (`run.py`, `run_lite.py`)
+2. Public web app (`frontend/`, "Hedge in a Box")
+3. Observability admin app (`frontend-obs/`)
 
-## Setup
-1. Install dependencies:
-   ```powershell
-   pip install -r requirements.txt
-   ```
-2. Set API key:
-   ```powershell
-   $env:DEEPSEEK_API_KEY="your_key_here"
-   ```
+The codebase has evolved far beyond a notebook port. This README documents the current project shape.
 
-## Run
+## What The Project Does
+
+- Runs full ticker analysis and valuation from Python
+- Produces analysis artifacts (text, PDF, charts, dashboard JSON)
+- Stores report data in Neon Postgres
+- Serves reports in the Next.js site
+- Exposes Summary filing source links for latest annual and quarterly filings (SEC or MAYA)
+- Tracks LLM run/call telemetry in the observability app
+
+## Repo Layout
+
+- `src/ai_hedge/legacy_port.py`: core valuation and prompt/parsing logic (high sensitivity file)
+- `src/ai_hedge/runner.py`: orchestrates full valuation run and artifact creation
+- `src/ai_hedge/dashboard.py`: dashboard payload generation
+- `src/ai_hedge/service.py`: service layer used by site workflows
+- `src/ai_hedge/maya_reports.py`: MAYA filing fetch for `.TA` tickers
+- `src/ai_hedge/obs/`: observability instrumentation and DB writes
+- `frontend/`: public dashboard site (Next.js)
+- `frontend-obs/`: internal observability admin app (Next.js)
+- `scripts/`: helper scripts used by site APIs (including filing status/PDF generation)
+- `outputs/`: generated local artifacts (gitignored)
+
+## Prerequisites
+
+- Python 3.11 or 3.12
+- Node.js 20+
+- npm
+
+## Environment Setup
+
+1. Copy `.env.example` to `.env`
+2. Fill required values
+
+Minimum for valuation runs:
+
+- `DEEPSEEK_API_KEY`
+
+Common DB/auth variables used across the site and tooling:
+
+- `DATABASE_URL`
+- `DATABASE_URL_UNPOOLED`
+- `AUTH_SECRET`
+- `AUTH_GOOGLE_ID`
+- `AUTH_GOOGLE_SECRET`
+- `AUTH_URL`
+- `OBS_DATABASE_URL`
+
+For frontend local dev, keep app-specific values in:
+
+- `frontend/.env.local`
+- `frontend-obs/.env.local`
+
+## Install Dependencies
+
+Python:
+
 ```powershell
-python run.py --ticker AAPL --pdf
+python -m pip install -r requirements.txt
 ```
 
-Optional flags:
-- `--output-root outputs`
-- `--show-plots`
+Public site:
 
-Valuation flow uses a single combined-context pass (regular text + SEC short when available).
-
-Outputs are saved under `outputs/<TICKER>/`.
-
-## Hedge in a Box Dashboard (Next.js)
-
-The repository now includes a dashboard web app in `frontend/` named **Hedge in a Box**.
-
-### What it reads
-- `outputs/**/<TICKER>_dashboard.json` (preferred)
-- fallback artifact routes for:
-  - `<TICKER>_analysis.pdf`
-  - `<TICKER>_prices_explain.txt`
-  - `<TICKER>_prices_explain.pdf`
-  - `<TICKER>_analysis.txt`
-
-The full valuation runner now attempts to generate:
-- `outputs/<TICKER>/<TICKER>_dashboard.json`
-
-This JSON includes:
-- command-center stats
-- executive summary + key insights + bull/red flags + SWOT (LLM dashboard extraction)
-- valuation block cards and key numeric means
-- consensus/LMIL/CV metrics
-- dream team cards
-- forensic/forecast matrix fields
-
-### Run locally
 ```powershell
 cd frontend
 npm install
+```
+
+Observability site:
+
+```powershell
+cd frontend-obs
+npm install
+```
+
+## Run Locally
+
+### Full valuation run
+
+```powershell
+python run.py --ticker AAPL --no-show-plots
+```
+
+Useful flags:
+
+- `--pdf` / `--no-pdf`
+- `--output-root outputs`
+- `--analysis-workers <n>`
+- `--llm-workers <n>`
+- `--valuation-block-workers <n>`
+
+### Lite/smoke valuation run
+
+```powershell
+python run_lite.py --ticker AAPL --no-show-plots
+```
+
+### Public app
+
+```powershell
+cd frontend
 npm run dev -- --hostname 127.0.0.1 --port 3000
 ```
 
-Open:
-- Dashboard: `http://127.0.0.1:3000`
-- Discovery: `http://127.0.0.1:3000/discovery`
+Open `http://127.0.0.1:3000`
 
-## Easy Fly Deploy
-
-Use these scripts from project root:
+### Observability app
 
 ```powershell
-.\deploy-site.ps1
+cd frontend-obs
+npm run dev -- --hostname 127.0.0.1 --port 3001
 ```
 
-Windows cmd equivalents:
+Open `http://127.0.0.1:3001`
 
-```cmd
-deploy-site.cmd
+## Artifacts Produced Per Ticker
+
+A full run writes to `outputs/<TICKER>/` and typically includes:
+
+- `<TICKER>_analysis.txt`
+- `<TICKER>_analysis.pdf` (if enabled)
+- `<TICKER>_prices_valuation.png`
+- `<TICKER>_revenue_valuation.png`
+- `<TICKER>_net_income_valuation.png`
+- `<TICKER>_prices_explain.txt`
+- `<TICKER>_prices_explain.pdf` (when generated)
+- `<TICKER>_dashboard.json`
+- `<TICKER>_technical_analysis.json`
+
+## Filing Source Links (SEC and MAYA)
+
+Summary page filing actions are source-link first:
+
+- Annual source filing
+- Quarterly source filing
+
+Behavior:
+
+- Uses ticker-level latest annual/latest quarterly filing
+- Supports both SEC and MAYA
+- MAYA relative URLs are normalized before redirecting
+- Status fetch is cached and de-duplicated to reduce repeated upstream cost
+
+## Database CLI Utilities
+
+Use:
+
+```powershell
+python dbcli.py --help
 ```
 
-Unified helper (all actions):
+This includes schema init, Fly snapshot fetch, scan/push/pull helpers, and report stats workflows.
+
+## Deploy
+
+### Manual Fly deploy
 
 ```powershell
 .\deploy_fly.ps1 site
-.\deploy_fly.ps1 status-site
-.\deploy_fly.ps1 logs-site
+.\deploy_fly.ps1 obs
 ```
 
-Optional flags:
-
-- `-NoDepot` adds `--depot=false`
-- `-NoRemote` omits `--remote-only`
-
-## Easy Git Push
-
-Use these scripts from project root:
+Status/logs:
 
 ```powershell
-.\push-git.ps1 -Message "feat: update dashboard"
+.\deploy_fly.ps1 status-site
+.\deploy_fly.ps1 logs-site
+.\deploy_fly.ps1 status-obs
+.\deploy_fly.ps1 logs-obs
 ```
 
-Windows cmd:
+### GitHub Actions
 
-```cmd
-push-git.cmd feat: update dashboard
-```
+- `.github/workflows/deploy-fly.yml`: deploys `site` and `obs` on push to `main`/`master`
+- `.github/workflows/preview-site.yml`: per-PR site previews
+- `.github/workflows/preview-obs.yml`: per-PR obs previews
 
-What it does:
-- `git add -A`
-- `git commit -m "<message>"` (only if there are changes)
-- `git push` (or `git push -u origin <current-branch>` if upstream is missing)
+## Development Notes
 
-## GitHub Auto Deploy (Fly)
+- `src/ai_hedge/legacy_port.py` is intentionally close to notebook behavior. Edit carefully.
+- Do not commit generated files from `outputs/`, `logs/`, or `.env`.
+- Theme/color system for `frontend/` is documented in `frontend/BRAND_COLORS.md`.
+- PR-first workflow is mandatory in this repo (`AGENTS.md`).
 
-This repo includes `.github/workflows/deploy-fly.yml` for automatic deploys on push to:
-- `main`
-- `master`
-
-It deploys the site app:
-- `hedge-in-a-box-site` using `fly.site.toml`
-
-Required GitHub secret:
-- `FLY_API_TOKEN` (Fly API token with access to the site app)

--- a/frontend/src/app/(app)/dashboard/[ticker]/overview/overview-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/overview/overview-client.tsx
@@ -7,7 +7,6 @@ import remarkGfm from "remark-gfm";
 
 import type { DashboardPayload, ReportListItem } from "@/lib/dashboard-types";
 import { ReportChipRow } from "@/components/dashboard-chrome";
-import { VisibilityToggle } from "@/components/reports/visibility-toggle";
 import {
   buildCurrencyContext,
   fmtMoney,
@@ -191,12 +190,6 @@ export function OverviewClient({
           >
             Open Overall Summary <ArrowRight size={12} />
           </Link>
-        </div>
-      ) : null}
-
-      {resolvedReportId ? (
-        <div className="mb-3 flex justify-end">
-          <VisibilityToggle reportId={resolvedReportId} />
         </div>
       ) : null}
 

--- a/frontend/src/app/(app)/dashboard/[ticker]/scenarios/scenarios-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/scenarios/scenarios-client.tsx
@@ -7,6 +7,7 @@ import remarkGfm from "remark-gfm";
 
 import type { DashboardPayload, ReportListItem } from "@/lib/dashboard-types";
 import { ReportChipRow } from "@/components/dashboard-chrome";
+import { SmallCopyButton } from "@/components/hedge-dashboard";
 
 type SwotData = {
   strengths: string[];
@@ -82,19 +83,29 @@ function ScenarioColumn({
   const probClass = tone === "bull" ? "hib-bull-prob-label" : "hib-bear-prob-label";
   const probValueClass = tone === "bull" ? "hib-bull-prob-value" : "hib-bear-prob-value";
   const items = reasons.length ? reasons : doc?.reasons || [];
+  const copyText = [
+    typeof probability === "number"
+      ? `Probability: ${(Math.max(0, Math.min(100, Math.abs(probability) <= 1 ? probability * 100 : probability))).toFixed(1)}%`
+      : "Probability: N/A",
+    "",
+    ...items.map((reason, idx) => `${idx + 1}. ${String(reason || "").replace(/~~/g, "").trim()}`),
+  ].join("\n").trim();
 
   return (
     <section className={`rounded-2xl border p-4 ${borderCls}`}>
       <div className="mb-3 flex items-center justify-between gap-3">
         <h2 className="font-display text-lg">{title}</h2>
-        {typeof probability === "number" ? (
-          <div className="text-right">
-            <p className={`text-[10px] uppercase tracking-[0.18em] ${probClass}`}>Probability</p>
-            <p className={`text-xl font-bold ${probValueClass}`}>
-              {(Math.max(0, Math.min(100, Math.abs(probability) <= 1 ? probability * 100 : probability))).toFixed(1)}%
-            </p>
-          </div>
-        ) : null}
+        <div className="flex items-center gap-2">
+          <SmallCopyButton text={copyText} label={`Copy ${title}`} iconOnly />
+          {typeof probability === "number" ? (
+            <div className="text-right">
+              <p className={`text-[10px] uppercase tracking-[0.18em] ${probClass}`}>Probability</p>
+              <p className={`text-xl font-bold ${probValueClass}`}>
+                {(Math.max(0, Math.min(100, Math.abs(probability) <= 1 ? probability * 100 : probability))).toFixed(1)}%
+              </p>
+            </div>
+          ) : null}
+        </div>
       </div>
       {items.length ? (
         <ul className="space-y-2 text-sm text-zinc-200">

--- a/frontend/src/app/(app)/dashboard/[ticker]/summary/page.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/summary/page.tsx
@@ -60,6 +60,7 @@ type FilingStatusSnippet = {
   source: string;
   form_type: string;
   date: string;
+  source_url: string;
 };
 
 type FilingsStatusPayload = {
@@ -448,12 +449,14 @@ export default function DashboardSummaryPage({
                 source: String(json.filings.annual?.source || ""),
                 form_type: String(json.filings.annual?.form_type || ""),
                 date: String(json.filings.annual?.date || ""),
+                source_url: String(json.filings.annual?.source_url || ""),
               },
               quarterly: {
                 available: Boolean(json.filings.quarterly?.available),
                 source: String(json.filings.quarterly?.source || ""),
                 form_type: String(json.filings.quarterly?.form_type || ""),
                 date: String(json.filings.quarterly?.date || ""),
+                source_url: String(json.filings.quarterly?.source_url || ""),
               },
             });
           }
@@ -548,7 +551,9 @@ export default function DashboardSummaryPage({
             const row = filings?.[kind];
             const label = kind === "annual" ? "Annual Filing PDF" : "Quarterly Filing PDF";
             const href = `/api/dashboard/${encodeURIComponent(upper)}/filings/${kind}/pdf`;
+            const sourceHref = `/api/dashboard/${encodeURIComponent(upper)}/filings/${kind}/source`;
             const available = Boolean(row?.available);
+            const hasSource = Boolean(row?.available && String(row?.source_url || "").trim());
             const meta = filingsLoading && !row
               ? "Checking..."
               : row?.available
@@ -556,22 +561,42 @@ export default function DashboardSummaryPage({
                 : "Not available";
             return (
               <div key={kind} className="min-w-[210px] rounded-lg border border-white/10 bg-black/25 p-2">
-                {available ? (
-                  <a
-                    className="inline-flex items-center gap-2 rounded-lg border border-white/15 bg-white/5 px-3 py-2 text-xs uppercase tracking-[0.14em] text-zinc-200 transition hover:border-white/35 hover:bg-white/10"
-                    href={href}
-                  >
-                    {label}
-                  </a>
-                ) : (
-                  <button
-                    type="button"
-                    disabled
-                    className="inline-flex items-center gap-2 rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-xs uppercase tracking-[0.14em] text-zinc-500 disabled:cursor-not-allowed"
-                  >
-                    {label}
-                  </button>
-                )}
+                <div className="flex flex-wrap items-center gap-2">
+                  {available ? (
+                    <a
+                      className="inline-flex items-center gap-2 rounded-lg border border-white/15 bg-white/5 px-3 py-2 text-xs uppercase tracking-[0.14em] text-zinc-200 transition hover:border-white/35 hover:bg-white/10"
+                      href={href}
+                    >
+                      {label}
+                    </a>
+                  ) : (
+                    <button
+                      type="button"
+                      disabled
+                      className="inline-flex items-center gap-2 rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-xs uppercase tracking-[0.14em] text-zinc-500 disabled:cursor-not-allowed"
+                    >
+                      {label}
+                    </button>
+                  )}
+                  {hasSource ? (
+                    <a
+                      className="inline-flex items-center rounded-lg border border-white/15 bg-white/5 px-2.5 py-2 text-[10px] uppercase tracking-[0.14em] text-zinc-300 transition hover:border-white/35 hover:bg-white/10"
+                      href={sourceHref}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Source Filing
+                    </a>
+                  ) : (
+                    <button
+                      type="button"
+                      disabled
+                      className="inline-flex items-center rounded-lg border border-white/10 bg-white/5 px-2.5 py-2 text-[10px] uppercase tracking-[0.14em] text-zinc-500 disabled:cursor-not-allowed"
+                    >
+                      Source Filing
+                    </button>
+                  )}
+                </div>
                 <p className="mt-1 text-[10px] uppercase tracking-[0.12em] text-zinc-500">{meta}</p>
               </div>
             );

--- a/frontend/src/app/(app)/dashboard/[ticker]/summary/page.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/summary/page.tsx
@@ -97,6 +97,31 @@ function fmtDateTimeNoSeconds(value: string): string {
   });
 }
 
+function escapeRegExp(value: string): string {
+  return String(value || "").replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function fmtFilingDateOnly(value: string): string {
+  const txt = String(value || "").trim();
+  if (!txt) return "";
+  const prefix = txt.slice(0, 10);
+  if (/^\d{4}-\d{2}-\d{2}$/.test(prefix)) return prefix;
+  const dt = new Date(txt);
+  if (!Number.isFinite(dt.getTime())) return txt;
+  return dt.toISOString().slice(0, 10);
+}
+
+function cleanFilingFormLabel(source: string, formType: string): string {
+  let label = String(formType || "").trim().replace(/\s+/g, " ");
+  const sourceLabel = String(source || "").trim();
+  if (!label) return "";
+  if (sourceLabel) {
+    const sourcePrefix = new RegExp(`^${escapeRegExp(sourceLabel)}\\s+`, "i");
+    label = label.replace(sourcePrefix, "").trim();
+  }
+  return label;
+}
+
 function fmtMoney(value: number | null | undefined, ticker: string): string {
   if (typeof value !== "number" || !Number.isFinite(value)) return "N/A";
   const isIsraeliTicker = String(ticker || "").toUpperCase().endsWith(".TA");
@@ -551,10 +576,13 @@ export default function DashboardSummaryPage({
             const row = filings?.[kind];
             const sourceHref = `/api/dashboard/${encodeURIComponent(upper)}/filings/${kind}/source`;
             const hasSource = Boolean(row?.available && String(row?.source_url || "").trim());
+            const sourceLabel = String(row?.source || "").trim();
+            const formLabel = cleanFilingFormLabel(sourceLabel, String(row?.form_type || ""));
+            const dateLabel = fmtFilingDateOnly(String(row?.date || ""));
             const meta = filingsLoading && !row
               ? "Checking..."
               : row?.available
-                ? `${row.source || "N/A"} ${row.form_type || ""} ${row.date || ""}`.trim()
+                ? [sourceLabel || "N/A", formLabel, dateLabel].filter(Boolean).join(" ").trim()
                 : "Not available";
             return (
               <div key={kind} className="min-w-[210px] rounded-lg border border-white/10 bg-black/25 p-2">

--- a/frontend/src/app/(app)/dashboard/[ticker]/summary/page.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/summary/page.tsx
@@ -55,6 +55,24 @@ type ReturnsMap = {
   "5Y"?: number | null;
 };
 
+type FilingStatusSnippet = {
+  available: boolean;
+  source: string;
+  form_type: string;
+  date: string;
+};
+
+type FilingsStatusPayload = {
+  ok?: boolean;
+  ticker?: string;
+  filings?: {
+    annual?: FilingStatusSnippet;
+    quarterly?: FilingStatusSnippet;
+  };
+  context_error?: string;
+  error?: string;
+};
+
 const RETURN_COLUMNS = ["1D", "1W", "1M", "3M", "6M", "1Y", "3Y", "5Y"] as const;
 
 const WINDOW_OPTIONS: Array<{ key: SummaryWindow; label: string }> = [
@@ -343,6 +361,12 @@ export default function DashboardSummaryPage({
   const [refreshToken, setRefreshToken] = useState(0);
   const [data, setData] = useState<SummaryPayload | null>(null);
   const [returnsMap, setReturnsMap] = useState<ReturnsMap | null>(null);
+  const [filingsLoading, setFilingsLoading] = useState(true);
+  const [filingsError, setFilingsError] = useState("");
+  const [filings, setFilings] = useState<{
+    annual: FilingStatusSnippet;
+    quarterly: FilingStatusSnippet;
+  } | null>(null);
 
   const reportId = search?.get("report") || "";
 
@@ -391,6 +415,57 @@ export default function DashboardSummaryPage({
       } finally {
         if (!cancelled) {
           setPerformanceLoading(false);
+        }
+      }
+    }
+    run();
+    return () => {
+      cancelled = true;
+    };
+  }, [upper, refreshToken]);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function run() {
+      setFilingsLoading(true);
+      setFilingsError("");
+      try {
+        const refreshQuery =
+          refreshToken > 0 ? `?refresh=${encodeURIComponent(`${Date.now()}-${refreshToken}`)}` : "";
+        const res = await fetch(
+          `/api/dashboard/${encodeURIComponent(upper)}/filings/status${refreshQuery}`,
+          { cache: "no-store" },
+        );
+        const json = (await res.json()) as FilingsStatusPayload;
+        if (!cancelled) {
+          if (!res.ok || !json?.ok || !json?.filings) {
+            setFilings(null);
+            setFilingsError(String(json?.error || "Failed to load filing availability."));
+          } else {
+            setFilings({
+              annual: {
+                available: Boolean(json.filings.annual?.available),
+                source: String(json.filings.annual?.source || ""),
+                form_type: String(json.filings.annual?.form_type || ""),
+                date: String(json.filings.annual?.date || ""),
+              },
+              quarterly: {
+                available: Boolean(json.filings.quarterly?.available),
+                source: String(json.filings.quarterly?.source || ""),
+                form_type: String(json.filings.quarterly?.form_type || ""),
+                date: String(json.filings.quarterly?.date || ""),
+              },
+            });
+          }
+        }
+      } catch {
+        if (!cancelled) {
+          setFilings(null);
+          setFilingsError("Failed to load filing availability.");
+        }
+      } finally {
+        if (!cancelled) {
+          setFilingsLoading(false);
         }
       }
     }
@@ -461,12 +536,49 @@ export default function DashboardSummaryPage({
             <button
               type="button"
               onClick={() => setRefreshToken((v) => v + 1)}
-              disabled={loading}
+              disabled={loading || filingsLoading}
               className="rounded-lg border border-white/20 bg-white/5 px-3 py-2 text-xs uppercase tracking-[0.14em] text-zinc-200 transition hover:border-white/40 hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-60"
             >
-              {loading ? "Refreshing..." : "Refresh"}
+              {loading || filingsLoading ? "Refreshing..." : "Refresh"}
             </button>
           </div>
+        </div>
+        <div className="mt-3 flex flex-wrap items-start gap-3">
+          {(["annual", "quarterly"] as const).map((kind) => {
+            const row = filings?.[kind];
+            const label = kind === "annual" ? "Annual Filing PDF" : "Quarterly Filing PDF";
+            const href = `/api/dashboard/${encodeURIComponent(upper)}/filings/${kind}/pdf`;
+            const available = Boolean(row?.available);
+            const meta = filingsLoading && !row
+              ? "Checking..."
+              : row?.available
+                ? `${row.source || "N/A"} ${row.form_type || ""} ${row.date || ""}`.trim()
+                : "Not available";
+            return (
+              <div key={kind} className="min-w-[210px] rounded-lg border border-white/10 bg-black/25 p-2">
+                {available ? (
+                  <a
+                    className="inline-flex items-center gap-2 rounded-lg border border-white/15 bg-white/5 px-3 py-2 text-xs uppercase tracking-[0.14em] text-zinc-200 transition hover:border-white/35 hover:bg-white/10"
+                    href={href}
+                  >
+                    {label}
+                  </a>
+                ) : (
+                  <button
+                    type="button"
+                    disabled
+                    className="inline-flex items-center gap-2 rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-xs uppercase tracking-[0.14em] text-zinc-500 disabled:cursor-not-allowed"
+                  >
+                    {label}
+                  </button>
+                )}
+                <p className="mt-1 text-[10px] uppercase tracking-[0.12em] text-zinc-500">{meta}</p>
+              </div>
+            );
+          })}
+          {filingsError ? (
+            <p className="self-center text-xs text-amber-300">{filingsError}</p>
+          ) : null}
         </div>
       </header>
 

--- a/frontend/src/app/(app)/dashboard/[ticker]/summary/page.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/summary/page.tsx
@@ -549,10 +549,7 @@ export default function DashboardSummaryPage({
         <div className="mt-3 flex flex-wrap items-start gap-3">
           {(["annual", "quarterly"] as const).map((kind) => {
             const row = filings?.[kind];
-            const label = kind === "annual" ? "Annual Filing PDF" : "Quarterly Filing PDF";
-            const href = `/api/dashboard/${encodeURIComponent(upper)}/filings/${kind}/pdf`;
             const sourceHref = `/api/dashboard/${encodeURIComponent(upper)}/filings/${kind}/source`;
-            const available = Boolean(row?.available);
             const hasSource = Boolean(row?.available && String(row?.source_url || "").trim());
             const meta = filingsLoading && !row
               ? "Checking..."
@@ -561,26 +558,13 @@ export default function DashboardSummaryPage({
                 : "Not available";
             return (
               <div key={kind} className="min-w-[210px] rounded-lg border border-white/10 bg-black/25 p-2">
+                <p className="mb-1 text-[10px] uppercase tracking-[0.12em] text-zinc-500">
+                  {kind === "annual" ? "Annual" : "Quarterly"}
+                </p>
                 <div className="flex flex-wrap items-center gap-2">
-                  {available ? (
-                    <a
-                      className="inline-flex items-center gap-2 rounded-lg border border-white/15 bg-white/5 px-3 py-2 text-xs uppercase tracking-[0.14em] text-zinc-200 transition hover:border-white/35 hover:bg-white/10"
-                      href={href}
-                    >
-                      {label}
-                    </a>
-                  ) : (
-                    <button
-                      type="button"
-                      disabled
-                      className="inline-flex items-center gap-2 rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-xs uppercase tracking-[0.14em] text-zinc-500 disabled:cursor-not-allowed"
-                    >
-                      {label}
-                    </button>
-                  )}
                   {hasSource ? (
                     <a
-                      className="inline-flex items-center rounded-lg border border-white/15 bg-white/5 px-2.5 py-2 text-[10px] uppercase tracking-[0.14em] text-zinc-300 transition hover:border-white/35 hover:bg-white/10"
+                      className="inline-flex items-center rounded-lg border border-white/15 bg-white/5 px-3 py-2 text-xs uppercase tracking-[0.14em] text-zinc-200 transition hover:border-white/35 hover:bg-white/10"
                       href={sourceHref}
                       target="_blank"
                       rel="noreferrer"
@@ -591,7 +575,7 @@ export default function DashboardSummaryPage({
                     <button
                       type="button"
                       disabled
-                      className="inline-flex items-center rounded-lg border border-white/10 bg-white/5 px-2.5 py-2 text-[10px] uppercase tracking-[0.14em] text-zinc-500 disabled:cursor-not-allowed"
+                      className="inline-flex items-center rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-xs uppercase tracking-[0.14em] text-zinc-500 disabled:cursor-not-allowed"
                     >
                       Source Filing
                     </button>

--- a/frontend/src/app/(app)/reports/actions.ts
+++ b/frontend/src/app/(app)/reports/actions.ts
@@ -16,11 +16,9 @@ export async function loadMoreCommunity(input: {
   limit: number;
   query: string;
 }): Promise<LoadMoreCommunityResult> {
-  const session = await auth();
-  const excludeUserId = session?.user?.id || undefined;
+  await auth();
   try {
     return await listCommunityReportsPaged({
-      excludeUserId,
       query: input.query,
       limit: input.limit,
       offset: input.offset,

--- a/frontend/src/app/(app)/reports/page.tsx
+++ b/frontend/src/app/(app)/reports/page.tsx
@@ -56,7 +56,7 @@ export default async function ReportsPage({
       <ReportsTabs active={tab} signedIn={signedIn} initialQuery={query} />
 
       {tab === "community" ? (
-        <CommunityTabContent query={query} excludeUserId={userId || undefined} />
+        <CommunityTabContent query={query} signedIn={signedIn} />
       ) : (
         <MineTabContent userId={userId} signedIn={signedIn} query={query} />
       )}
@@ -66,16 +66,15 @@ export default async function ReportsPage({
 
 async function CommunityTabContent({
   query,
-  excludeUserId,
+  signedIn,
 }: {
   query: string;
-  excludeUserId: string | undefined;
+  signedIn: boolean;
 }) {
   let rows: DbReportSummary[] = [];
   let hasMore = false;
   try {
     const page = await listCommunityReportsPaged({
-      excludeUserId,
       query,
       limit: COMMUNITY_PAGE_SIZE,
       offset: 0,
@@ -87,7 +86,7 @@ async function CommunityTabContent({
   }
 
   if (!rows.length) {
-    return <EmptyState tab="community" signedIn={Boolean(excludeUserId)} hasQuery={Boolean(query)} />;
+    return <EmptyState tab="community" signedIn={signedIn} hasQuery={Boolean(query)} />;
   }
 
   return <CommunityList initialRows={rows} initialHasMore={hasMore} query={query} />;

--- a/frontend/src/app/(app)/reports/page.tsx
+++ b/frontend/src/app/(app)/reports/page.tsx
@@ -117,7 +117,7 @@ async function MineTabContent({
     <ul className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
       {filtered.map((r) => (
         <li key={r.id} className="h-full">
-          <ReportCard report={r} />
+          <ReportCard report={r} showVisibilityToggle />
         </li>
       ))}
     </ul>

--- a/frontend/src/app/api/dashboard/[ticker]/filings/[kind]/pdf/route.ts
+++ b/frontend/src/app/api/dashboard/[ticker]/filings/[kind]/pdf/route.ts
@@ -1,0 +1,67 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { NextResponse } from "next/server";
+
+import { buildFilingPdf } from "@/lib/filings-engine";
+import { TICKER_RE } from "@/lib/site-runner";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export async function GET(
+  _req: Request,
+  context: { params: Promise<{ ticker: string; kind: string }> },
+) {
+  const { ticker, kind } = await context.params;
+  const tk = String(ticker || "").trim().toUpperCase();
+  const filingKind = String(kind || "").trim().toLowerCase();
+
+  if (!TICKER_RE.test(tk)) {
+    return NextResponse.json({ error: "Invalid ticker format." }, { status: 400 });
+  }
+  if (filingKind !== "annual" && filingKind !== "quarterly") {
+    return NextResponse.json({ error: "Invalid filing kind." }, { status: 400 });
+  }
+
+  let builtPath = "";
+  let fileName = "";
+  try {
+    const built = await buildFilingPdf(tk, filingKind);
+    builtPath = built.filePath;
+    fileName = built.fileName;
+  } catch (err) {
+    const msg = String(err || "");
+    const missing =
+      msg.includes("filing_not_available") ||
+      msg.includes("filing_pdf_not_found");
+    return NextResponse.json(
+      {
+        error: missing
+          ? `${filingKind} filing is not available for ${tk}.`
+          : `Failed to build filing PDF: ${msg}`,
+      },
+      { status: missing ? 404 : 500 },
+    );
+  }
+
+  let buf: Buffer;
+  try {
+    buf = fs.readFileSync(builtPath);
+  } catch {
+    return NextResponse.json({ error: "Failed to read generated filing PDF." }, { status: 500 });
+  } finally {
+    try {
+      fs.rmSync(path.dirname(builtPath), { recursive: true, force: true });
+    } catch {
+      // best effort cleanup
+    }
+  }
+
+  const headers = new Headers();
+  headers.set("Content-Type", "application/pdf");
+  headers.set("Content-Disposition", `attachment; filename="${fileName}"`);
+  return new NextResponse(new Uint8Array(buf), { status: 200, headers });
+}
+

--- a/frontend/src/app/api/dashboard/[ticker]/filings/[kind]/source/route.ts
+++ b/frontend/src/app/api/dashboard/[ticker]/filings/[kind]/source/route.ts
@@ -34,16 +34,15 @@ export async function GET(
     }
     if (!/^https?:\/\//i.test(url)) {
       return NextResponse.json(
-        { error: "Source filing URL is invalid." },
-        { status: 500 },
+        { error: `${filingKind} source filing is not available for ${tk}.` },
+        { status: 404 },
       );
     }
     return NextResponse.redirect(url, 302);
-  } catch (err) {
+  } catch {
     return NextResponse.json(
-      { error: `Failed to resolve source filing URL: ${String(err)}` },
-      { status: 500 },
+      { error: `${filingKind} source filing is not available for ${tk}.` },
+      { status: 404 },
     );
   }
 }
-

--- a/frontend/src/app/api/dashboard/[ticker]/filings/[kind]/source/route.ts
+++ b/frontend/src/app/api/dashboard/[ticker]/filings/[kind]/source/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 
-import { getTickerFilingsStatus } from "@/lib/filings-engine";
+import { getStoredTickerFilingsStatus } from "@/lib/filings-stored";
 import { TICKER_RE } from "@/lib/site-runner";
 
 export const runtime = "nodejs";
@@ -23,7 +23,7 @@ export async function GET(
   }
 
   try {
-    const status = await getTickerFilingsStatus(tk);
+    const status = await getStoredTickerFilingsStatus(tk);
     const filing = filingKind === "annual" ? status.filings.annual : status.filings.quarterly;
     const url = String(filing?.source_url || "").trim();
     if (!filing?.available || !url) {

--- a/frontend/src/app/api/dashboard/[ticker]/filings/[kind]/source/route.ts
+++ b/frontend/src/app/api/dashboard/[ticker]/filings/[kind]/source/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+
+import { getTickerFilingsStatus } from "@/lib/filings-engine";
+import { TICKER_RE } from "@/lib/site-runner";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export async function GET(
+  _req: Request,
+  context: { params: Promise<{ ticker: string; kind: string }> },
+) {
+  const { ticker, kind } = await context.params;
+  const tk = String(ticker || "").trim().toUpperCase();
+  const filingKind = String(kind || "").trim().toLowerCase();
+
+  if (!TICKER_RE.test(tk)) {
+    return NextResponse.json({ error: "Invalid ticker format." }, { status: 400 });
+  }
+  if (filingKind !== "annual" && filingKind !== "quarterly") {
+    return NextResponse.json({ error: "Invalid filing kind." }, { status: 400 });
+  }
+
+  try {
+    const status = await getTickerFilingsStatus(tk);
+    const filing = filingKind === "annual" ? status.filings.annual : status.filings.quarterly;
+    const url = String(filing?.source_url || "").trim();
+    if (!filing?.available || !url) {
+      return NextResponse.json(
+        { error: `${filingKind} source filing is not available for ${tk}.` },
+        { status: 404 },
+      );
+    }
+    if (!/^https?:\/\//i.test(url)) {
+      return NextResponse.json(
+        { error: "Source filing URL is invalid." },
+        { status: 500 },
+      );
+    }
+    return NextResponse.redirect(url, 302);
+  } catch (err) {
+    return NextResponse.json(
+      { error: `Failed to resolve source filing URL: ${String(err)}` },
+      { status: 500 },
+    );
+  }
+}
+

--- a/frontend/src/app/api/dashboard/[ticker]/filings/status/route.ts
+++ b/frontend/src/app/api/dashboard/[ticker]/filings/status/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+
+import { getTickerFilingsStatus } from "@/lib/filings-engine";
+import { TICKER_RE } from "@/lib/site-runner";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export async function GET(
+  req: Request,
+  context: { params: Promise<{ ticker: string }> },
+) {
+  const { ticker } = await context.params;
+  const tk = String(ticker || "").trim().toUpperCase();
+  if (!TICKER_RE.test(tk)) {
+    return NextResponse.json({ error: "Invalid ticker format." }, { status: 400 });
+  }
+
+  const url = new URL(req.url);
+  const forceRefresh = String(url.searchParams.get("refresh") || "").trim().length > 0;
+
+  try {
+    const status = await getTickerFilingsStatus(tk, { forceRefresh });
+    return NextResponse.json({
+      ok: true,
+      ticker: status.ticker,
+      filings: status.filings,
+      context_error: status.context_error || "",
+    });
+  } catch (err) {
+    return NextResponse.json(
+      { error: `Failed to fetch filing status: ${String(err)}` },
+      { status: 500 },
+    );
+  }
+}
+

--- a/frontend/src/app/api/dashboard/[ticker]/filings/status/route.ts
+++ b/frontend/src/app/api/dashboard/[ticker]/filings/status/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 
-import { getTickerFilingsStatus } from "@/lib/filings-engine";
+import { getStoredTickerFilingsStatus } from "@/lib/filings-stored";
 import { TICKER_RE } from "@/lib/site-runner";
 
 export const runtime = "nodejs";
@@ -29,11 +29,10 @@ export async function GET(
     return NextResponse.json({ error: "Invalid ticker format." }, { status: 400 });
   }
 
-  const url = new URL(req.url);
-  const forceRefresh = String(url.searchParams.get("refresh") || "").trim().length > 0;
+  void req;
 
   try {
-    const status = await getTickerFilingsStatus(tk, { forceRefresh });
+    const status = await getStoredTickerFilingsStatus(tk);
     return NextResponse.json({
       ok: true,
       ticker: status.ticker,

--- a/frontend/src/app/api/dashboard/[ticker]/filings/status/route.ts
+++ b/frontend/src/app/api/dashboard/[ticker]/filings/status/route.ts
@@ -7,6 +7,18 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
+function unavailablePayload(ticker: string, contextError = "") {
+  return {
+    ok: true,
+    ticker,
+    filings: {
+      annual: { available: false, source: "", form_type: "", date: "", source_url: "", text: "" },
+      quarterly: { available: false, source: "", form_type: "", date: "", source_url: "", text: "" },
+    },
+    context_error: contextError,
+  };
+}
+
 export async function GET(
   req: Request,
   context: { params: Promise<{ ticker: string }> },
@@ -29,10 +41,6 @@ export async function GET(
       context_error: status.context_error || "",
     });
   } catch (err) {
-    return NextResponse.json(
-      { error: `Failed to fetch filing status: ${String(err)}` },
-      { status: 500 },
-    );
+    return NextResponse.json(unavailablePayload(tk, String(err)));
   }
 }
-

--- a/frontend/src/components/dream-team/persona-card.tsx
+++ b/frontend/src/components/dream-team/persona-card.tsx
@@ -656,7 +656,7 @@ export function PersonaCard({
         {sections.length ? (
           <div className="space-y-7">
             <div className="flex justify-end">
-              <SmallCopyButton text={dreamBlogCopyText} label={`Copy ${member.persona} blog`} />
+              <SmallCopyButton text={dreamBlogCopyText} label={`Copy ${member.persona} blog`} iconOnly />
             </div>
             {sections.map((section, i) => {
               const text = normalizeReasonText(String(section.text || ""));

--- a/frontend/src/components/dream-team/persona-card.tsx
+++ b/frontend/src/components/dream-team/persona-card.tsx
@@ -4,6 +4,7 @@ import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import {
   MarkdownBlock,
+  SmallCopyButton,
   fmtMarketCap,
   fmtMoney,
   normalizeReasonText,
@@ -297,6 +298,14 @@ export function PersonaCard({
   const allocationVerdict = verdictMark(directionOf(allocationPct), actualDirection);
 
   const sections = member.reason_sections.filter((s) => normalizeReasonText(String(s.text || "")));
+  const dreamBlogCopyText = sections
+    .map((section) => {
+      const text = normalizeReasonText(String(section.text || ""));
+      if (!text) return "";
+      return `${prettyReasonLabel(section.label)}\n${text}`;
+    })
+    .filter(Boolean)
+    .join("\n\n");
   const personaPickerRows = personas.map((row) => {
     const target = typeof row.targetPrice === "number" && Number.isFinite(row.targetPrice) ? row.targetPrice : null;
     const isNeutral = typeof currentPrice !== "number" || !Number.isFinite(currentPrice) || target === null || Math.abs(target - currentPrice) < 1e-9;
@@ -646,6 +655,9 @@ export function PersonaCard({
       <div className="dream-team-scroll flex-1 overflow-y-auto px-4 pb-7 pt-5 sm:px-9">
         {sections.length ? (
           <div className="space-y-7">
+            <div className="flex justify-end">
+              <SmallCopyButton text={dreamBlogCopyText} label={`Copy ${member.persona} blog`} />
+            </div>
             {sections.map((section, i) => {
               const text = normalizeReasonText(String(section.text || ""));
               return (

--- a/frontend/src/components/hedge-dashboard.tsx
+++ b/frontend/src/components/hedge-dashboard.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
-import { Check, ChevronDown, Download } from "lucide-react";
+import { Check, ChevronDown, Copy, Download } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
@@ -366,6 +366,78 @@ function Tab({ active, onClick, label }: { active: boolean; onClick: () => void;
       }`}
     >
       {label}
+    </button>
+  );
+}
+
+async function copyTextToClipboard(text: string): Promise<boolean> {
+  const value = String(text || "").trim();
+  if (!value) return false;
+  try {
+    if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(value);
+      return true;
+    }
+  } catch {
+    // Fallback below for browsers that block clipboard API.
+  }
+  try {
+    if (typeof document === "undefined") return false;
+    const textArea = document.createElement("textarea");
+    textArea.value = value;
+    textArea.setAttribute("readonly", "");
+    textArea.style.position = "fixed";
+    textArea.style.opacity = "0";
+    textArea.style.pointerEvents = "none";
+    document.body.appendChild(textArea);
+    textArea.focus();
+    textArea.select();
+    const copied = document.execCommand("copy");
+    document.body.removeChild(textArea);
+    return copied;
+  } catch {
+    return false;
+  }
+}
+
+export function SmallCopyButton({
+  text,
+  label = "Copy text",
+  className = "",
+}: {
+  text: string;
+  label?: string;
+  className?: string;
+}) {
+  const [copied, setCopied] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const hasText = String(text || "").trim().length > 0;
+
+  useEffect(() => {
+    if (!copied) return;
+    const timerId = window.setTimeout(() => setCopied(false), 1400);
+    return () => window.clearTimeout(timerId);
+  }, [copied]);
+
+  const handleCopy = useCallback(async () => {
+    if (!hasText || busy) return;
+    setBusy(true);
+    const ok = await copyTextToClipboard(text);
+    setBusy(false);
+    if (ok) setCopied(true);
+  }, [busy, hasText, text]);
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      disabled={!hasText || busy}
+      title={label}
+      aria-label={label}
+      className={`inline-flex items-center gap-1 rounded-full border border-white/15 bg-white/5 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.12em] text-zinc-300 transition hover:border-white/35 hover:text-zinc-100 disabled:cursor-not-allowed disabled:border-white/10 disabled:text-zinc-500 ${className}`}
+    >
+      {copied ? <Check size={10} /> : <Copy size={10} />}
+      <span>{copied ? "Copied" : "Copy"}</span>
     </button>
   );
 }
@@ -1326,6 +1398,17 @@ export function HedgeDashboard({
 
   const bullProbability = assumptionsByNorm.get(normalizeMetricLabel("Bull Probability"))?.mean ?? null;
   const bearProbability = assumptionsByNorm.get(normalizeMetricLabel("Bear Probability"))?.mean ?? null;
+  const executiveSummaryCopyText = normalizeReasonText(String(data?.analysis_matrix?.executive_summary_markdown || ""));
+  const bullCopyText = [
+    `Bull Probability: ${fmtProbability(bullProbability)}`,
+    "",
+    ...bullReasons.map((item, idx) => `${idx + 1}. ${normalizeReasonText(String(item || ""))}`),
+  ].join("\n").trim();
+  const bearCopyText = [
+    `Bear Probability: ${fmtProbability(bearProbability)}`,
+    "",
+    ...bearReasons.map((item, idx) => `${idx + 1}. ${normalizeReasonText(String(item || ""))}`),
+  ].join("\n").trim();
   const finalCombinedScore =
     typeof data?.decision_card?.combined_score === "number" && Number.isFinite(data.decision_card.combined_score)
       ? Number(data.decision_card.combined_score)
@@ -1694,9 +1777,19 @@ export function HedgeDashboard({
               </section>
             ) : null}
 
-            {mainTab === "executive" ? <section className="mb-6 rounded-2xl border border-white/10 bg-zinc-950/70 p-4"><MarkdownBlock text={data.analysis_matrix.executive_summary_markdown || ""} /></section> : null}
+            {mainTab === "executive" ? (
+              <section className="mb-6 rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
+                <div className="mb-3 flex justify-end">
+                  <SmallCopyButton text={executiveSummaryCopyText} label="Copy execution summary" />
+                </div>
+                <MarkdownBlock text={data.analysis_matrix.executive_summary_markdown || ""} />
+              </section>
+            ) : null}
             {mainTab === "bull" ? (
               <section className="mb-6 rounded-2xl border border-emerald-500/35 bg-emerald-500/10 p-4">
+                <div className="mb-3 flex justify-end">
+                  <SmallCopyButton text={bullCopyText} label="Copy bull dashboard" />
+                </div>
                 <div className="mb-4 rounded-xl border border-emerald-400/35 bg-emerald-400/10 p-3">
                   <p className="hib-bull-prob-label text-xs uppercase tracking-[0.14em]">Bull Probability</p>
                   <p className="hib-bull-prob-value text-2xl font-semibold">{fmtProbability(bullProbability)}</p>
@@ -1706,6 +1799,9 @@ export function HedgeDashboard({
             ) : null}
             {mainTab === "bear" ? (
               <section className="mb-6 rounded-2xl border border-red-500/35 bg-red-500/10 p-4">
+                <div className="mb-3 flex justify-end">
+                  <SmallCopyButton text={bearCopyText} label="Copy bear dashboard" />
+                </div>
                 <div className="mb-4 rounded-xl border border-red-400/35 bg-red-400/10 p-3">
                   <p className="hib-bear-prob-label text-xs uppercase tracking-[0.14em]">Bear Probability</p>
                   <p className="hib-bear-prob-value text-2xl font-semibold">{fmtProbability(bearProbability)}</p>

--- a/frontend/src/components/hedge-dashboard.tsx
+++ b/frontend/src/components/hedge-dashboard.tsx
@@ -404,10 +404,12 @@ export function SmallCopyButton({
   text,
   label = "Copy text",
   className = "",
+  iconOnly = false,
 }: {
   text: string;
   label?: string;
   className?: string;
+  iconOnly?: boolean;
 }) {
   const [copied, setCopied] = useState(false);
   const [busy, setBusy] = useState(false);
@@ -434,10 +436,12 @@ export function SmallCopyButton({
       disabled={!hasText || busy}
       title={label}
       aria-label={label}
-      className={`inline-flex items-center gap-1 rounded-full border border-white/15 bg-white/5 px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.12em] text-zinc-300 transition hover:border-white/35 hover:text-zinc-100 disabled:cursor-not-allowed disabled:border-white/10 disabled:text-zinc-500 ${className}`}
+      className={`inline-flex items-center rounded-full border border-white/15 bg-white/5 text-[10px] font-semibold uppercase tracking-[0.12em] text-zinc-300 transition hover:border-white/35 hover:text-zinc-100 disabled:cursor-not-allowed disabled:border-white/10 disabled:text-zinc-500 ${
+        iconOnly ? "h-7 w-7 justify-center p-0" : "gap-1 px-2 py-1"
+      } ${className}`}
     >
       {copied ? <Check size={10} /> : <Copy size={10} />}
-      <span>{copied ? "Copied" : "Copy"}</span>
+      {iconOnly ? <span className="sr-only">{copied ? "Copied" : "Copy"}</span> : <span>{copied ? "Copied" : "Copy"}</span>}
     </button>
   );
 }

--- a/frontend/src/components/reports/report-card.tsx
+++ b/frontend/src/components/reports/report-card.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 
 import type { DbReportSummary } from "@/lib/reports-db";
 import { FriendlyDate } from "./friendly-date";
+import { VisibilityToggle } from "./visibility-toggle";
 
 // Allowed values: Strong Buy | Buy | Hold | Sell | Strong Sell
 function recommendationTone(rec: string | null): { label: string; cls: string } {
@@ -21,28 +22,38 @@ function recommendationTone(rec: string | null): { label: string; cls: string } 
   }
 }
 
-export function ReportCard({ report }: { report: DbReportSummary }) {
+export function ReportCard({
+  report,
+  showVisibilityToggle = false,
+}: {
+  report: DbReportSummary;
+  showVisibilityToggle?: boolean;
+}) {
   const href = `/dashboard/${encodeURIComponent(report.ticker)}/summary?report=${encodeURIComponent(report.id)}`;
   const rec = recommendationTone(report.recommendation);
   const company = report.company_name || report.ticker;
 
   return (
-    <Link
-      href={href}
-      className="group flex h-full flex-col justify-between rounded-2xl border border-white/10 bg-zinc-950/70 p-5 transition hover:border-emerald-400/50 hover:bg-emerald-500/5"
-    >
-      <div>
-        <p className="font-display text-3xl text-zinc-100">{report.ticker}</p>
-        <p className="mt-1 line-clamp-2 text-sm text-zinc-400">{company}</p>
-      </div>
-      <div className="mt-6 flex items-center justify-between gap-3">
-        <span
-          className={`inline-flex items-center rounded-md border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] ${rec.cls}`}
-        >
-          {rec.label}
-        </span>
-        <FriendlyDate iso={report.generated_at} className="text-xs text-zinc-400" />
-      </div>
-    </Link>
+    <article className="group relative flex h-full flex-col rounded-2xl border border-white/10 bg-zinc-950/70 transition hover:border-emerald-400/50 hover:bg-emerald-500/5">
+      {showVisibilityToggle ? (
+        <div className="absolute right-3 top-3 z-10">
+          <VisibilityToggle reportId={report.id} variant="icon" />
+        </div>
+      ) : null}
+      <Link href={href} className="flex h-full flex-col justify-between p-5">
+        <div>
+          <p className="font-display text-3xl text-zinc-100">{report.ticker}</p>
+          <p className="mt-1 line-clamp-2 text-sm text-zinc-400">{company}</p>
+        </div>
+        <div className="mt-6 flex items-center justify-between gap-3">
+          <span
+            className={`inline-flex items-center rounded-md border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] ${rec.cls}`}
+          >
+            {rec.label}
+          </span>
+          <FriendlyDate iso={report.generated_at} className="text-xs text-zinc-400" />
+        </div>
+      </Link>
+    </article>
   );
 }

--- a/frontend/src/components/reports/visibility-toggle.tsx
+++ b/frontend/src/components/reports/visibility-toggle.tsx
@@ -1,11 +1,17 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Globe, Lock } from "lucide-react";
+import { Lock, LockOpen } from "lucide-react";
 
 type Visibility = "public" | "private" | "unlisted";
 
-export function VisibilityToggle({ reportId }: { reportId: string }) {
+export function VisibilityToggle({
+  reportId,
+  variant = "badge",
+}: {
+  reportId: string;
+  variant?: "badge" | "icon";
+}) {
   const [visibility, setVisibility] = useState<Visibility | null>(null);
   const [ownsThis, setOwnsThis] = useState(false);
   const [busy, setBusy] = useState(false);
@@ -31,7 +37,9 @@ export function VisibilityToggle({ reportId }: { reportId: string }) {
   const next: Visibility = visibility === "public" ? "private" : "public";
   const isPublic = visibility === "public";
 
-  async function flip() {
+  async function flip(event?: React.MouseEvent<HTMLButtonElement>) {
+    event?.preventDefault();
+    event?.stopPropagation();
     setBusy(true);
     try {
       const res = await fetch(`/api/reports/${encodeURIComponent(reportId)}/visibility`, {
@@ -45,20 +53,40 @@ export function VisibilityToggle({ reportId }: { reportId: string }) {
     }
   }
 
+  if (variant === "icon") {
+    return (
+      <button
+        type="button"
+        onClick={(event) => void flip(event)}
+        disabled={busy}
+        title={isPublic ? "Public - anyone can see this report" : "Private - only you can see this"}
+        aria-label={isPublic ? "Set report to private" : "Set report to public"}
+        className={`inline-flex h-7 w-7 items-center justify-center rounded-full border transition disabled:opacity-50 ${
+          isPublic
+            ? "border-emerald-400/50 bg-emerald-500/15 text-emerald-100 hover:bg-emerald-500/25"
+            : "border-white/20 bg-white/10 text-zinc-300 hover:bg-white/15"
+        }`}
+      >
+        {isPublic ? <LockOpen size={13} /> : <Lock size={13} />}
+      </button>
+    );
+  }
+
   return (
     <button
       type="button"
-      onClick={flip}
+      onClick={(event) => void flip(event)}
       disabled={busy}
-      title={isPublic ? "Public — anyone can see this report" : "Private — only you can see this"}
+      title={isPublic ? "Public - anyone can see this report" : "Private - only you can see this"}
       className={`inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.14em] transition disabled:opacity-50 ${
         isPublic
           ? "border-emerald-400/50 bg-emerald-500/15 text-emerald-100 hover:bg-emerald-500/25"
           : "border-white/15 bg-white/5 text-zinc-300 hover:bg-white/10"
       }`}
     >
-      {isPublic ? <Globe size={12} /> : <Lock size={12} />}
+      {isPublic ? <LockOpen size={12} /> : <Lock size={12} />}
       {isPublic ? "Public" : "Private"}
     </button>
   );
 }
+

--- a/frontend/src/lib/dashboard-types.ts
+++ b/frontend/src/lib/dashboard-types.ts
@@ -222,6 +222,22 @@ export type DashboardPayload = {
       confidence_explanation?: string;
     };
   };
+  filings?: {
+    annual?: {
+      available?: boolean;
+      source?: string;
+      form_type?: string;
+      date?: string;
+      source_url?: string;
+    };
+    quarterly?: {
+      available?: boolean;
+      source?: string;
+      form_type?: string;
+      date?: string;
+      source_url?: string;
+    };
+  };
   artifacts: {
     analysis_txt?: string;
     prices_plot?: string;

--- a/frontend/src/lib/filings-engine.ts
+++ b/frontend/src/lib/filings-engine.ts
@@ -55,8 +55,17 @@ const FILINGS_STATUS_INFLIGHT = new Map<string, Promise<FilingsStatus>>();
 const CACHE_TTL_MS = 5 * 60 * 1000;
 const MAYA_BASE_URL = "https://maya.tase.co.il";
 const MAYA_FILES_BASE_URL = "https://mayafiles.tase.co.il";
-const STATUS_TIMEOUT_MS = 45_000;
-const PDF_TIMEOUT_MS = 120_000;
+
+function envMs(name: string, fallbackMs: number): number {
+  const raw = String(process.env[name] || "").trim();
+  if (!raw) return fallbackMs;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallbackMs;
+  return Math.floor(parsed);
+}
+
+const STATUS_TIMEOUT_MS = envMs("FILINGS_STATUS_TIMEOUT_MS", 75_000);
+const PDF_TIMEOUT_MS = envMs("FILINGS_PDF_TIMEOUT_MS", 180_000);
 
 function normalizeSourceUrl(rawUrl: string, source: string): string {
   const url = String(rawUrl || "").trim();

--- a/frontend/src/lib/filings-engine.ts
+++ b/frontend/src/lib/filings-engine.ts
@@ -51,9 +51,12 @@ type CacheEntry = {
 };
 
 const FILINGS_STATUS_CACHE = new Map<string, CacheEntry>();
+const FILINGS_STATUS_INFLIGHT = new Map<string, Promise<FilingsStatus>>();
 const CACHE_TTL_MS = 5 * 60 * 1000;
 const MAYA_BASE_URL = "https://maya.tase.co.il";
 const MAYA_FILES_BASE_URL = "https://mayafiles.tase.co.il";
+const STATUS_TIMEOUT_MS = 45_000;
+const PDF_TIMEOUT_MS = 120_000;
 
 function normalizeSourceUrl(rawUrl: string, source: string): string {
   const url = String(rawUrl || "").trim();
@@ -113,7 +116,11 @@ function ensureTicker(ticker: string): string {
   return tk;
 }
 
-async function runPythonJson(scriptName: string, payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+async function runPythonJson(
+  scriptName: string,
+  payload: Record<string, unknown>,
+  opts?: { timeoutMs?: number },
+): Promise<Record<string, unknown>> {
   const root = repoRoot();
   const scriptPath = path.resolve(root, "scripts", scriptName);
   const pythonExe = process.env.PYTHON_EXECUTABLE || "python";
@@ -130,6 +137,20 @@ async function runPythonJson(scriptName: string, payload: Record<string, unknown
 
     let stdout = "";
     let stderr = "";
+    const timeoutMs = Number(opts?.timeoutMs || 0) > 0 ? Number(opts?.timeoutMs) : 0;
+    let finished = false;
+    const timeoutHandle =
+      timeoutMs > 0
+        ? setTimeout(() => {
+            if (finished) return;
+            try {
+              child.kill();
+            } catch {
+              // no-op
+            }
+            reject(new Error(`${scriptName} timed out after ${timeoutMs}ms`));
+          }, timeoutMs)
+        : null;
 
     child.stdout.on("data", (chunk) => {
       stdout += String(chunk);
@@ -137,8 +158,16 @@ async function runPythonJson(scriptName: string, payload: Record<string, unknown
     child.stderr.on("data", (chunk) => {
       stderr += String(chunk);
     });
-    child.on("error", (err) => reject(err));
+    child.on("error", (err) => {
+      if (finished) return;
+      finished = true;
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+      reject(err);
+    });
     child.on("close", (code) => {
+      if (finished) return;
+      finished = true;
+      if (timeoutHandle) clearTimeout(timeoutHandle);
       if (code !== 0) {
         reject(
           new Error(
@@ -169,28 +198,43 @@ export async function getTickerFilingsStatus(ticker: string, opts?: { forceRefre
   if (!opts?.forceRefresh) {
     const cached = readCache(tk);
     if (cached) return cached;
+    const inflight = FILINGS_STATUS_INFLIGHT.get(tk);
+    if (inflight) return inflight;
   }
 
-  const raw = (await runPythonJson("dream_team_context.py", {
-    ticker: tk,
-    include_annual: true,
-    include_quarterly: true,
-  })) as DreamTeamContextPayload;
+  const fetchPromise = (async () => {
+    const raw = (await runPythonJson(
+      "filings_status.py",
+      {
+        ticker: tk,
+      },
+      { timeoutMs: STATUS_TIMEOUT_MS },
+    )) as DreamTeamContextPayload;
 
-  if (!raw.ok) {
-    throw new Error(String(raw.error || "Failed to fetch filing status."));
+    if (!raw.ok) {
+      throw new Error(String(raw.error || "Failed to fetch filing status."));
+    }
+
+    const out: FilingsStatus = {
+      ticker: tk,
+      filings: {
+        annual: normalizeFiling(raw.filings?.annual),
+        quarterly: normalizeFiling(raw.filings?.quarterly),
+      },
+      context_error: String(raw.context_error || ""),
+    };
+    writeCache(out);
+    return out;
+  })();
+
+  if (!opts?.forceRefresh) {
+    FILINGS_STATUS_INFLIGHT.set(tk, fetchPromise);
   }
-
-  const out: FilingsStatus = {
-    ticker: tk,
-    filings: {
-      annual: normalizeFiling(raw.filings?.annual),
-      quarterly: normalizeFiling(raw.filings?.quarterly),
-    },
-    context_error: String(raw.context_error || ""),
-  };
-  writeCache(out);
-  return out;
+  try {
+    return await fetchPromise;
+  } finally {
+    FILINGS_STATUS_INFLIGHT.delete(tk);
+  }
 }
 
 export async function buildFilingPdf(ticker: string, kind: FilingKind): Promise<{
@@ -203,10 +247,14 @@ export async function buildFilingPdf(ticker: string, kind: FilingKind): Promise<
     throw new Error("Invalid filing kind.");
   }
 
-  const raw = (await runPythonJson("filing_pdf.py", {
-    ticker: tk,
-    kind,
-  })) as FilingPdfPayload;
+  const raw = (await runPythonJson(
+    "filing_pdf.py",
+    {
+      ticker: tk,
+      kind,
+    },
+    { timeoutMs: PDF_TIMEOUT_MS },
+  )) as FilingPdfPayload;
 
   if (!raw.ok) {
     const code = String(raw.error || "filing_pdf_failed");

--- a/frontend/src/lib/filings-engine.ts
+++ b/frontend/src/lib/filings-engine.ts
@@ -12,6 +12,7 @@ export type FilingSnippet = {
   source: string;
   form_type: string;
   date: string;
+  source_url: string;
   text: string;
 };
 
@@ -58,6 +59,7 @@ function normalizeFiling(value: Partial<FilingSnippet> | null | undefined): Fili
     source: String(value?.source || ""),
     form_type: String(value?.form_type || ""),
     date: String(value?.date || ""),
+    source_url: String(value?.source_url || ""),
     text: String(value?.text || ""),
   };
 }
@@ -200,4 +202,3 @@ export async function buildFilingPdf(ticker: string, kind: FilingKind): Promise<
     filing: normalizeFiling(raw.filing),
   };
 }
-

--- a/frontend/src/lib/filings-engine.ts
+++ b/frontend/src/lib/filings-engine.ts
@@ -52,14 +52,36 @@ type CacheEntry = {
 
 const FILINGS_STATUS_CACHE = new Map<string, CacheEntry>();
 const CACHE_TTL_MS = 5 * 60 * 1000;
+const MAYA_BASE_URL = "https://maya.tase.co.il";
+const MAYA_FILES_BASE_URL = "https://mayafiles.tase.co.il";
+
+function normalizeSourceUrl(rawUrl: string, source: string): string {
+  const url = String(rawUrl || "").trim();
+  if (!url) return "";
+  if (/^https?:\/\//i.test(url)) return url;
+  if (url.startsWith("//")) return `https:${url}`;
+
+  const src = String(source || "").trim().toUpperCase();
+  if (src === "MAYA") {
+    if (url.startsWith("/")) {
+      if (url.includes("/reports/") || url.includes("/api/")) return `${MAYA_BASE_URL}${url}`;
+      return `${MAYA_FILES_BASE_URL}${url}`;
+    }
+    return `${MAYA_FILES_BASE_URL}/${url.replace(/^\/+/, "")}`;
+  }
+
+  if (/^[A-Za-z0-9.-]+\.[A-Za-z]{2,}(?:\/|$)/.test(url)) return `https://${url}`;
+  return url;
+}
 
 function normalizeFiling(value: Partial<FilingSnippet> | null | undefined): FilingSnippet {
+  const source = String(value?.source || "");
   return {
     available: Boolean(value?.available),
-    source: String(value?.source || ""),
+    source,
     form_type: String(value?.form_type || ""),
     date: String(value?.date || ""),
-    source_url: String(value?.source_url || ""),
+    source_url: normalizeSourceUrl(String(value?.source_url || ""), source),
     text: String(value?.text || ""),
   };
 }

--- a/frontend/src/lib/filings-engine.ts
+++ b/frontend/src/lib/filings-engine.ts
@@ -1,0 +1,203 @@
+import fs from "node:fs";
+import path from "node:path";
+import { spawn } from "node:child_process";
+
+import { parseJsonObjectFromMixedOutput } from "@/lib/python-json";
+import { repoRoot, TICKER_RE } from "@/lib/site-runner";
+
+export type FilingKind = "annual" | "quarterly";
+
+export type FilingSnippet = {
+  available: boolean;
+  source: string;
+  form_type: string;
+  date: string;
+  text: string;
+};
+
+export type FilingsStatus = {
+  ticker: string;
+  filings: {
+    annual: FilingSnippet;
+    quarterly: FilingSnippet;
+  };
+  context_error?: string;
+};
+
+type DreamTeamContextPayload = {
+  ok?: boolean;
+  error?: string;
+  context_error?: string;
+  filings?: {
+    annual?: Partial<FilingSnippet>;
+    quarterly?: Partial<FilingSnippet>;
+  };
+};
+
+type FilingPdfPayload = {
+  ok?: boolean;
+  error?: string;
+  ticker?: string;
+  kind?: string;
+  pdf_path?: string;
+  file_name?: string;
+  filing?: Partial<FilingSnippet>;
+};
+
+type CacheEntry = {
+  value: FilingsStatus;
+  expiresAt: number;
+};
+
+const FILINGS_STATUS_CACHE = new Map<string, CacheEntry>();
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+function normalizeFiling(value: Partial<FilingSnippet> | null | undefined): FilingSnippet {
+  return {
+    available: Boolean(value?.available),
+    source: String(value?.source || ""),
+    form_type: String(value?.form_type || ""),
+    date: String(value?.date || ""),
+    text: String(value?.text || ""),
+  };
+}
+
+function readCache(ticker: string): FilingsStatus | null {
+  const key = String(ticker || "").toUpperCase();
+  const row = FILINGS_STATUS_CACHE.get(key);
+  if (!row) return null;
+  if (Date.now() > row.expiresAt) {
+    FILINGS_STATUS_CACHE.delete(key);
+    return null;
+  }
+  return row.value;
+}
+
+function writeCache(status: FilingsStatus): void {
+  const key = String(status.ticker || "").toUpperCase();
+  FILINGS_STATUS_CACHE.set(key, {
+    value: status,
+    expiresAt: Date.now() + CACHE_TTL_MS,
+  });
+}
+
+function ensureTicker(ticker: string): string {
+  const tk = String(ticker || "").trim().toUpperCase();
+  if (!TICKER_RE.test(tk)) {
+    throw new Error("Invalid ticker format.");
+  }
+  return tk;
+}
+
+async function runPythonJson(scriptName: string, payload: Record<string, unknown>): Promise<Record<string, unknown>> {
+  const root = repoRoot();
+  const scriptPath = path.resolve(root, "scripts", scriptName);
+  const pythonExe = process.env.PYTHON_EXECUTABLE || "python";
+
+  return await new Promise((resolve, reject) => {
+    const child = spawn(pythonExe, [scriptPath], {
+      cwd: root,
+      env: {
+        ...process.env,
+        PYTHONUNBUFFERED: "1",
+        PYTHONPATH: path.resolve(root, "src"),
+      },
+    });
+
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on("error", (err) => reject(err));
+    child.on("close", (code) => {
+      if (code !== 0) {
+        reject(
+          new Error(
+            `${scriptName} exited with ${code}. stderr=${JSON.stringify(stderr.slice(-1000))} stdout=${JSON.stringify(stdout.slice(-1000))}`,
+          ),
+        );
+        return;
+      }
+      const parsed = parseJsonObjectFromMixedOutput(stdout);
+      if (!parsed) {
+        reject(
+          new Error(
+            `Invalid JSON from ${scriptName}. stderr=${JSON.stringify(stderr.slice(-1000))} stdout=${JSON.stringify(stdout.slice(-1000))}`,
+          ),
+        );
+        return;
+      }
+      resolve(parsed);
+    });
+
+    child.stdin.write(JSON.stringify(payload));
+    child.stdin.end();
+  });
+}
+
+export async function getTickerFilingsStatus(ticker: string, opts?: { forceRefresh?: boolean }): Promise<FilingsStatus> {
+  const tk = ensureTicker(ticker);
+  if (!opts?.forceRefresh) {
+    const cached = readCache(tk);
+    if (cached) return cached;
+  }
+
+  const raw = (await runPythonJson("dream_team_context.py", {
+    ticker: tk,
+    include_annual: true,
+    include_quarterly: true,
+  })) as DreamTeamContextPayload;
+
+  if (!raw.ok) {
+    throw new Error(String(raw.error || "Failed to fetch filing status."));
+  }
+
+  const out: FilingsStatus = {
+    ticker: tk,
+    filings: {
+      annual: normalizeFiling(raw.filings?.annual),
+      quarterly: normalizeFiling(raw.filings?.quarterly),
+    },
+    context_error: String(raw.context_error || ""),
+  };
+  writeCache(out);
+  return out;
+}
+
+export async function buildFilingPdf(ticker: string, kind: FilingKind): Promise<{
+  filePath: string;
+  fileName: string;
+  filing: FilingSnippet;
+}> {
+  const tk = ensureTicker(ticker);
+  if (kind !== "annual" && kind !== "quarterly") {
+    throw new Error("Invalid filing kind.");
+  }
+
+  const raw = (await runPythonJson("filing_pdf.py", {
+    ticker: tk,
+    kind,
+  })) as FilingPdfPayload;
+
+  if (!raw.ok) {
+    const code = String(raw.error || "filing_pdf_failed");
+    throw new Error(code);
+  }
+
+  const filePath = String(raw.pdf_path || "").trim();
+  if (!filePath || !fs.existsSync(filePath)) {
+    throw new Error("filing_pdf_not_found");
+  }
+  const fileName = String(raw.file_name || `${tk}_${kind}_filing.pdf`).trim();
+  return {
+    filePath,
+    fileName,
+    filing: normalizeFiling(raw.filing),
+  };
+}
+

--- a/frontend/src/lib/filings-stored.ts
+++ b/frontend/src/lib/filings-stored.ts
@@ -1,0 +1,88 @@
+import type { DashboardPayload } from "@/lib/dashboard-types";
+import { fetchLatestReport } from "@/lib/reports-db";
+import { listDashboardReports, readJson } from "@/lib/server-outputs";
+
+export type StoredFiling = {
+  available: boolean;
+  source: string;
+  form_type: string;
+  date: string;
+  source_url: string;
+  text: string;
+};
+
+export type StoredFilingsStatus = {
+  ticker: string;
+  filings: {
+    annual: StoredFiling;
+    quarterly: StoredFiling;
+  };
+  context_error?: string;
+};
+
+function emptyFiling(): StoredFiling {
+  return { available: false, source: "", form_type: "", date: "", source_url: "", text: "" };
+}
+
+function normalizeRow(value: unknown): StoredFiling {
+  const row = typeof value === "object" && value ? (value as Record<string, unknown>) : {};
+  const sourceUrl = String(row.source_url || "").trim();
+  return {
+    available: Boolean(row.available) && sourceUrl.length > 0,
+    source: String(row.source || ""),
+    form_type: String(row.form_type || ""),
+    date: String(row.date || ""),
+    source_url: sourceUrl,
+    text: "",
+  };
+}
+
+function extractFromDashboard(payload: DashboardPayload | null | undefined): StoredFilingsStatus["filings"] {
+  return {
+    annual: normalizeRow(payload?.filings?.annual),
+    quarterly: normalizeRow(payload?.filings?.quarterly),
+  };
+}
+
+async function readLatestDashboardPayload(ticker: string): Promise<DashboardPayload | null> {
+  const tk = String(ticker || "").trim().toUpperCase();
+  if (!tk) return null;
+
+  try {
+    const dbRow = await fetchLatestReport(tk);
+    const dashboard = dbRow?.dashboard as DashboardPayload | null | undefined;
+    if (dashboard && typeof dashboard === "object") {
+      return dashboard;
+    }
+  } catch {
+    // Fall through to outputs scan.
+  }
+
+  for (const entry of listDashboardReports()) {
+    if (String(entry.ticker || "").toUpperCase() !== tk) continue;
+    const payload = readJson<DashboardPayload>(entry.path);
+    if (payload) return payload;
+  }
+  return null;
+}
+
+export async function getStoredTickerFilingsStatus(ticker: string): Promise<StoredFilingsStatus> {
+  const tk = String(ticker || "").trim().toUpperCase();
+  const payload = await readLatestDashboardPayload(tk);
+  if (!payload) {
+    return {
+      ticker: tk,
+      filings: {
+        annual: emptyFiling(),
+        quarterly: emptyFiling(),
+      },
+      context_error: "No stored dashboard payload found for ticker.",
+    };
+  }
+  return {
+    ticker: tk,
+    filings: extractFromDashboard(payload),
+    context_error: "",
+  };
+}
+

--- a/frontend/src/lib/reports-db.ts
+++ b/frontend/src/lib/reports-db.ts
@@ -292,13 +292,12 @@ export async function listUserReports(userId: string): Promise<DbReportSummary[]
   return rows;
 }
 
-/** Public reports authored by anyone other than the optional excluded user. */
-export async function listCommunityReports(excludeUserId?: string): Promise<DbReportSummary[]> {
+/** Public reports authored by anyone. */
+export async function listCommunityReports(): Promise<DbReportSummary[]> {
   const sql = getSql();
   if (!sql) return fallbackCommunityReportsFromOutputs();
   try {
-    const rows = excludeUserId
-      ? ((await sql`
+    const rows = ((await sql`
         SELECT r.id::text AS id, r.ticker, r.generated_at,
                r.company_name,
                r.current_price::float8 AS current_price,
@@ -312,23 +311,6 @@ export async function listCommunityReports(excludeUserId?: string): Promise<DbRe
           LEFT JOIN report_artifacts a ON a.report_id = r.id
          WHERE r.visibility = 'public'
            AND r.deleted_at IS NULL
-           AND (r.user_id IS NULL OR r.user_id <> ${excludeUserId}::uuid)
-         ORDER BY r.generated_at DESC;
-      `) as unknown as DbReportSummary[])
-    : ((await sql`
-        SELECT r.id::text AS id, r.ticker, r.generated_at,
-               r.company_name,
-               r.current_price::float8 AS current_price,
-               r.market_cap::float8    AS market_cap,
-               r.currency,
-               COALESCE(NULLIF(r.recommendation, ''), a.dashboard->'decision_card'->>'action') AS recommendation,
-               r.mean_target_price::float8 AS mean_target_price,
-               r.source, r.source_run_id,
-               r.visibility
-          FROM reports r
-          LEFT JOIN report_artifacts a ON a.report_id = r.id
-          WHERE r.visibility = 'public'
-            AND r.deleted_at IS NULL
          ORDER BY r.generated_at DESC;
       `) as unknown as DbReportSummary[]);
     return rows;
@@ -347,7 +329,6 @@ export interface PagedCommunityReports {
  * Returns `limit` rows plus a `hasMore` flag (computed by over-fetching one row).
  */
 export async function listCommunityReportsPaged(opts: {
-  excludeUserId?: string;
   query?: string;
   limit: number;
   offset: number;
@@ -366,31 +347,9 @@ export async function listCommunityReportsPaged(opts: {
   const fetchN = limit + 1;
   const q = String(opts.query || "").trim();
   const like = q ? `%${q}%` : "";
-  const excludeUserId = opts.excludeUserId?.trim() || null;
 
   try {
-    const rows = (excludeUserId
-      ? ((await sql`
-        SELECT r.id::text AS id, r.ticker, r.generated_at,
-               r.company_name,
-               r.current_price::float8 AS current_price,
-               r.market_cap::float8    AS market_cap,
-               r.currency,
-               COALESCE(NULLIF(r.recommendation, ''), a.dashboard->'decision_card'->>'action') AS recommendation,
-               r.mean_target_price::float8 AS mean_target_price,
-               r.source, r.source_run_id,
-               r.visibility
-          FROM reports r
-          LEFT JOIN report_artifacts a ON a.report_id = r.id
-         WHERE r.visibility = 'public'
-           AND r.deleted_at IS NULL
-           AND (r.user_id IS NULL OR r.user_id <> ${excludeUserId}::uuid)
-           AND (${like} = '' OR r.ticker ILIKE ${like} OR COALESCE(r.company_name, '') ILIKE ${like})
-         ORDER BY r.generated_at DESC
-         LIMIT ${fetchN}
-        OFFSET ${offset};
-      `) as unknown as DbReportSummary[])
-    : ((await sql`
+    const rows = ((await sql`
         SELECT r.id::text AS id, r.ticker, r.generated_at,
                r.company_name,
                r.current_price::float8 AS current_price,
@@ -408,7 +367,7 @@ export async function listCommunityReportsPaged(opts: {
          ORDER BY r.generated_at DESC
          LIMIT ${fetchN}
         OFFSET ${offset};
-      `) as unknown as DbReportSummary[]));
+      `) as unknown as DbReportSummary[]);
 
     const hasMore = rows.length > limit;
     return { rows: hasMore ? rows.slice(0, limit) : rows, hasMore };

--- a/scripts/dream_team_context.py
+++ b/scripts/dream_team_context.py
@@ -86,6 +86,7 @@ def _extract_filing_entries(files_dict: Dict[str, Any]) -> List[Dict[str, Any]]:
                 "source": source,
                 "form_type": form_type,
                 "date": str(raw.get("date") or "").strip(),
+                "source_url": str(raw.get("url") or "").strip(),
                 "text": _truncate(text, 220000),
             }
         )
@@ -101,7 +102,7 @@ def _pick_latest(entries: List[Dict[str, Any]], kind: str) -> Optional[Dict[str,
 
 
 def _empty_filing() -> Dict[str, Any]:
-    return {"available": False, "source": "", "form_type": "", "date": "", "text": ""}
+    return {"available": False, "source": "", "form_type": "", "date": "", "source_url": "", "text": ""}
 
 
 def _to_filing_payload(row: Optional[Dict[str, Any]]) -> Dict[str, Any]:
@@ -112,6 +113,7 @@ def _to_filing_payload(row: Optional[Dict[str, Any]]) -> Dict[str, Any]:
         "source": str(row.get("source") or ""),
         "form_type": str(row.get("form_type") or ""),
         "date": str(row.get("date") or ""),
+        "source_url": str(row.get("source_url") or ""),
         "text": str(row.get("text") or ""),
     }
 

--- a/scripts/dream_team_context.py
+++ b/scripts/dream_team_context.py
@@ -9,6 +9,9 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from ai_hedge import legacy_port as legacy
 
+MAYA_BASE_URL = "https://maya.tase.co.il"
+MAYA_FILES_BASE_URL = "https://mayafiles.tase.co.il"
+
 
 def _read_input() -> Dict[str, Any]:
     raw = input()
@@ -36,6 +39,28 @@ def _truncate(text: Any, max_chars: int) -> str:
     if len(out) <= max_chars:
         return out
     return out[:max_chars]
+
+
+def _normalize_source_url(raw_url: Any, source: str) -> str:
+    url = str(raw_url or "").strip()
+    if not url:
+        return ""
+    if url.startswith("//"):
+        return f"https:{url}"
+    if url.lower().startswith(("http://", "https://")):
+        return url
+
+    source_u = str(source or "").strip().upper()
+    if source_u == "MAYA":
+        if url.startswith("/"):
+            if "/reports/" in url or "/api/" in url:
+                return f"{MAYA_BASE_URL}{url}"
+            return f"{MAYA_FILES_BASE_URL}{url}"
+        return f"{MAYA_FILES_BASE_URL}/{url.lstrip('/')}"
+
+    if "." in url and "/" in url:
+        return f"https://{url.lstrip('/')}"
+    return url
 
 
 def _to_jsonable(value: Any, depth: int = 0) -> Any:
@@ -86,7 +111,10 @@ def _extract_filing_entries(files_dict: Dict[str, Any]) -> List[Dict[str, Any]]:
                 "source": source,
                 "form_type": form_type,
                 "date": str(raw.get("date") or "").strip(),
-                "source_url": str(raw.get("url") or "").strip(),
+                "source_url": _normalize_source_url(
+                    raw.get("url") or raw.get("source_url") or raw.get("link") or raw.get("href"),
+                    source,
+                ),
                 "text": _truncate(text, 220000),
             }
         )

--- a/scripts/filing_pdf.py
+++ b/scripts/filing_pdf.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import json
+import re
 import sys
 import tempfile
 from contextlib import redirect_stdout
@@ -79,6 +80,7 @@ def _extract_filing_entries(files_dict: Dict[str, Any]) -> List[Dict[str, Any]]:
                 "source": source,
                 "form_type": form_type,
                 "date": str(raw.get("date") or "").strip(),
+                "source_url": str(raw.get("url") or "").strip(),
                 "text": _truncate(text, 400000),
             }
         )
@@ -93,17 +95,56 @@ def _pick_latest(entries: List[Dict[str, Any]], kind: str) -> Optional[Dict[str,
     return None
 
 
+def _clean_filing_text(text: str) -> str:
+    cleaned = str(text or "")
+    cleaned = cleaned.replace("\r\n", "\n").replace("\r", "\n")
+    cleaned = re.sub(r"https?://\S+", " ", cleaned, flags=re.IGNORECASE)
+    cleaned = re.sub(
+        r"\b(?:us-gaap|dei|xbrli|link|iso4217|xlink|srt|country|tsla):[A-Za-z0-9_.-]+\b",
+        " ",
+        cleaned,
+        flags=re.IGNORECASE,
+    )
+    cleaned = re.sub(r"\b[A-Za-z0-9._:/-]{40,}\b", " ", cleaned)
+
+    lines: List[str] = []
+    for raw_line in cleaned.split("\n"):
+        line = re.sub(r"[ \t]+", " ", raw_line).strip()
+        if not line:
+            continue
+        alpha_count = sum(ch.isalpha() for ch in line)
+        if alpha_count < 3:
+            continue
+        lines.append(line)
+
+    deduped: List[str] = []
+    prev = ""
+    for line in lines:
+        if line == prev:
+            continue
+        deduped.append(line)
+        prev = line
+
+    out = "\n\n".join(deduped)
+    out = re.sub(r"\n{3,}", "\n\n", out).strip()
+    return out
+
+
 def _build_markdown(ticker: str, kind: str, filing: Dict[str, Any]) -> str:
     title = "Annual Filing" if kind == "annual" else "Quarterly Filing"
     source = str(filing.get("source") or "")
     form_type = str(filing.get("form_type") or "")
     date = str(filing.get("date") or "")
-    text = str(filing.get("text") or "")
+    source_url = str(filing.get("source_url") or "")
+    text = _clean_filing_text(str(filing.get("text") or ""))
+    if not text:
+        text = "Filing text could not be cleaned for display."
     return (
         f"# {ticker} {title}\n\n"
         f"- Source: {source or 'N/A'}\n"
         f"- Form Type: {form_type or 'N/A'}\n"
         f"- Date: {date or 'N/A'}\n\n"
+        f"- Source Filing URL: {source_url or 'N/A'}\n\n"
         f"---\n\n"
         f"{text}\n"
     )
@@ -185,6 +226,7 @@ def main() -> int:
                     "source": str(filing.get("source") or ""),
                     "form_type": str(filing.get("form_type") or ""),
                     "date": str(filing.get("date") or ""),
+                    "source_url": str(filing.get("source_url") or ""),
                     "text": str(filing.get("text") or ""),
                 },
                 "context_error": context_error,

--- a/scripts/filing_pdf.py
+++ b/scripts/filing_pdf.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tempfile
+from contextlib import redirect_stdout
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from ai_hedge import legacy_port as legacy
+from ai_hedge.text_to_pdf_check import convert_text_to_pdf
+
+
+def _read_input() -> Dict[str, Any]:
+    raw = ""
+    try:
+        raw = input()
+    except EOFError:
+        raw = ""
+    if not raw:
+        return {}
+    data = json.loads(raw)
+    return data if isinstance(data, dict) else {}
+
+
+def _safe_date(value: Any) -> datetime:
+    txt = str(value or "").strip()
+    if not txt:
+        return datetime.min
+    for fmt in ("%Y-%m-%d", "%Y/%m/%d", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S"):
+        try:
+            return datetime.strptime(txt[:19], fmt)
+        except Exception:
+            continue
+    try:
+        return datetime.fromisoformat(txt.replace("Z", "+00:00"))
+    except Exception:
+        return datetime.min
+
+
+def _truncate(text: Any, max_chars: int) -> str:
+    out = str(text or "")
+    if len(out) <= max_chars:
+        return out
+    return out[:max_chars]
+
+
+def _filing_kind(label: str, payload: Dict[str, Any]) -> str:
+    joined = " ".join(
+        [
+            str(label or ""),
+            str(payload.get("form_type") or ""),
+            str(payload.get("title") or ""),
+            str(payload.get("name") or ""),
+        ]
+    ).upper()
+    if any(x in joined for x in ("10-K", "20-F", "ANNUAL", "MAYA ANNUAL")):
+        return "annual"
+    if any(x in joined for x in ("10-Q", "6-K", "QUARTER", "Q1", "Q2", "Q3", "Q4", "MAYA QUARTERLY")):
+        return "quarterly"
+    return "other"
+
+
+def _extract_filing_entries(files_dict: Dict[str, Any]) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for key, raw in files_dict.items():
+        if not isinstance(raw, dict):
+            continue
+        text = str(raw.get("text") or "").strip()
+        if not text:
+            continue
+        form_type = str(raw.get("form_type") or key or "").strip()
+        source = "MAYA" if "MAYA" in str(key).upper() else "SEC"
+        rows.append(
+            {
+                "kind": _filing_kind(str(key), raw),
+                "source": source,
+                "form_type": form_type,
+                "date": str(raw.get("date") or "").strip(),
+                "text": _truncate(text, 400000),
+            }
+        )
+    rows.sort(key=lambda x: _safe_date(x.get("date")), reverse=True)
+    return rows
+
+
+def _pick_latest(entries: List[Dict[str, Any]], kind: str) -> Optional[Dict[str, Any]]:
+    for row in entries:
+        if row.get("kind") == kind:
+            return row
+    return None
+
+
+def _build_markdown(ticker: str, kind: str, filing: Dict[str, Any]) -> str:
+    title = "Annual Filing" if kind == "annual" else "Quarterly Filing"
+    source = str(filing.get("source") or "")
+    form_type = str(filing.get("form_type") or "")
+    date = str(filing.get("date") or "")
+    text = str(filing.get("text") or "")
+    return (
+        f"# {ticker} {title}\n\n"
+        f"- Source: {source or 'N/A'}\n"
+        f"- Form Type: {form_type or 'N/A'}\n"
+        f"- Date: {date or 'N/A'}\n\n"
+        f"---\n\n"
+        f"{text}\n"
+    )
+
+
+def main() -> int:
+    req = _read_input()
+    ticker = str(req.get("ticker") or "").strip().upper()
+    kind = str(req.get("kind") or "").strip().lower()
+
+    if not ticker:
+        print(json.dumps({"ok": False, "error": "ticker_required"}))
+        return 0
+    if kind not in {"annual", "quarterly"}:
+        print(json.dumps({"ok": False, "error": "invalid_kind"}))
+        return 0
+
+    context_error = ""
+    try:
+        captured_stdout = io.StringIO()
+        with redirect_stdout(captured_stdout):
+            _info_dict, files_dict, _financial_dict, _variables_dict = legacy.get_dicts(ticker)
+        noisy_logs = captured_stdout.getvalue()
+        if noisy_logs.strip():
+            print(noisy_logs, file=sys.stderr, end="")
+    except Exception as exc:
+        files_dict = {}
+        context_error = str(exc)
+
+    files_dict = files_dict if isinstance(files_dict, dict) else {}
+    entries = _extract_filing_entries(files_dict)
+    filing = _pick_latest(entries, kind)
+
+    if not filing:
+        print(
+            json.dumps(
+                {
+                    "ok": False,
+                    "error": "filing_not_available",
+                    "ticker": ticker,
+                    "kind": kind,
+                    "context_error": context_error,
+                }
+            )
+        )
+        return 0
+
+    temp_dir = Path(tempfile.mkdtemp(prefix=f"filing_pdf_{ticker}_{kind}_"))
+    txt_path = temp_dir / f"{ticker}_{kind}_filing.txt"
+    pdf_path = temp_dir / f"{ticker}_{kind}_filing.pdf"
+    html_path = temp_dir / f"{ticker}_{kind}_filing.html"
+
+    txt_path.write_text(_build_markdown(ticker, kind, filing), encoding="utf-8")
+    try:
+        convert_text_to_pdf(txt_path, pdf_path, html_path)
+    except Exception as exc:
+        print(
+            json.dumps(
+                {
+                    "ok": False,
+                    "error": f"pdf_generation_failed:{exc}",
+                    "ticker": ticker,
+                    "kind": kind,
+                }
+            )
+        )
+        return 0
+
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "ticker": ticker,
+                "kind": kind,
+                "file_name": f"{ticker}_{kind}_filing.pdf",
+                "pdf_path": str(pdf_path),
+                "filing": {
+                    "available": True,
+                    "source": str(filing.get("source") or ""),
+                    "form_type": str(filing.get("form_type") or ""),
+                    "date": str(filing.get("date") or ""),
+                    "text": str(filing.get("text") or ""),
+                },
+                "context_error": context_error,
+            },
+            ensure_ascii=False,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/filing_pdf.py
+++ b/scripts/filing_pdf.py
@@ -13,6 +13,9 @@ from typing import Any, Dict, List, Optional
 from ai_hedge import legacy_port as legacy
 from ai_hedge.text_to_pdf_check import convert_text_to_pdf
 
+MAYA_BASE_URL = "https://maya.tase.co.il"
+MAYA_FILES_BASE_URL = "https://mayafiles.tase.co.il"
+
 
 def _read_input() -> Dict[str, Any]:
     raw = ""
@@ -48,6 +51,28 @@ def _truncate(text: Any, max_chars: int) -> str:
     return out[:max_chars]
 
 
+def _normalize_source_url(raw_url: Any, source: str) -> str:
+    url = str(raw_url or "").strip()
+    if not url:
+        return ""
+    if url.startswith("//"):
+        return f"https:{url}"
+    if url.lower().startswith(("http://", "https://")):
+        return url
+
+    source_u = str(source or "").strip().upper()
+    if source_u == "MAYA":
+        if url.startswith("/"):
+            if "/reports/" in url or "/api/" in url:
+                return f"{MAYA_BASE_URL}{url}"
+            return f"{MAYA_FILES_BASE_URL}{url}"
+        return f"{MAYA_FILES_BASE_URL}/{url.lstrip('/')}"
+
+    if "." in url and "/" in url:
+        return f"https://{url.lstrip('/')}"
+    return url
+
+
 def _filing_kind(label: str, payload: Dict[str, Any]) -> str:
     joined = " ".join(
         [
@@ -80,7 +105,10 @@ def _extract_filing_entries(files_dict: Dict[str, Any]) -> List[Dict[str, Any]]:
                 "source": source,
                 "form_type": form_type,
                 "date": str(raw.get("date") or "").strip(),
-                "source_url": str(raw.get("url") or "").strip(),
+                "source_url": _normalize_source_url(
+                    raw.get("url") or raw.get("source_url") or raw.get("link") or raw.get("href"),
+                    source,
+                ),
                 "text": _truncate(text, 400000),
             }
         )

--- a/scripts/filings_status.py
+++ b/scripts/filings_status.py
@@ -2,16 +2,12 @@ from __future__ import annotations
 
 import io
 import json
-import re
 import sys
-import tempfile
 from contextlib import redirect_stdout
 from datetime import datetime
-from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from ai_hedge import legacy_port as legacy
-from ai_hedge.text_to_pdf_check import convert_text_to_pdf
 
 MAYA_BASE_URL = "https://maya.tase.co.il"
 MAYA_FILES_BASE_URL = "https://mayafiles.tase.co.il"
@@ -25,8 +21,11 @@ def _read_input() -> Dict[str, Any]:
         raw = ""
     if not raw:
         return {}
-    data = json.loads(raw)
-    return data if isinstance(data, dict) else {}
+    try:
+        parsed = json.loads(raw)
+    except Exception:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
 
 
 def _safe_date(value: Any) -> datetime:
@@ -80,6 +79,7 @@ def _filing_kind(label: str, payload: Dict[str, Any]) -> str:
             str(payload.get("form_type") or ""),
             str(payload.get("title") or ""),
             str(payload.get("name") or ""),
+            str(payload.get("label") or ""),
         ]
     ).upper()
     if any(x in joined for x in ("10-K", "20-F", "ANNUAL", "MAYA ANNUAL")):
@@ -94,11 +94,14 @@ def _extract_filing_entries(files_dict: Dict[str, Any]) -> List[Dict[str, Any]]:
     for key, raw in files_dict.items():
         if not isinstance(raw, dict):
             continue
+
         text = str(raw.get("text") or "").strip()
         if not text:
             continue
+
         form_type = str(raw.get("form_type") or key or "").strip()
-        source = "MAYA" if "MAYA" in str(key).upper() else "SEC"
+        source_raw = str(raw.get("source") or "")
+        source = source_raw.strip().upper() or ("MAYA" if "MAYA" in str(key).upper() else "SEC")
         rows.append(
             {
                 "kind": _filing_kind(str(key), raw),
@@ -109,7 +112,7 @@ def _extract_filing_entries(files_dict: Dict[str, Any]) -> List[Dict[str, Any]]:
                     raw.get("url") or raw.get("source_url") or raw.get("link") or raw.get("href"),
                     source,
                 ),
-                "text": _truncate(text, 400000),
+                "text": _truncate(text, 220000),
             }
         )
     rows.sort(key=lambda x: _safe_date(x.get("date")), reverse=True)
@@ -123,71 +126,29 @@ def _pick_latest(entries: List[Dict[str, Any]], kind: str) -> Optional[Dict[str,
     return None
 
 
-def _clean_filing_text(text: str) -> str:
-    cleaned = str(text or "")
-    cleaned = cleaned.replace("\r\n", "\n").replace("\r", "\n")
-    cleaned = re.sub(r"https?://\S+", " ", cleaned, flags=re.IGNORECASE)
-    cleaned = re.sub(
-        r"\b(?:us-gaap|dei|xbrli|link|iso4217|xlink|srt|country|tsla):[A-Za-z0-9_.-]+\b",
-        " ",
-        cleaned,
-        flags=re.IGNORECASE,
-    )
-    cleaned = re.sub(r"\b[A-Za-z0-9._:/-]{40,}\b", " ", cleaned)
-
-    lines: List[str] = []
-    for raw_line in cleaned.split("\n"):
-        line = re.sub(r"[ \t]+", " ", raw_line).strip()
-        if not line:
-            continue
-        alpha_count = sum(ch.isalpha() for ch in line)
-        if alpha_count < 3:
-            continue
-        lines.append(line)
-
-    deduped: List[str] = []
-    prev = ""
-    for line in lines:
-        if line == prev:
-            continue
-        deduped.append(line)
-        prev = line
-
-    out = "\n\n".join(deduped)
-    out = re.sub(r"\n{3,}", "\n\n", out).strip()
-    return out
+def _empty_filing() -> Dict[str, Any]:
+    return {"available": False, "source": "", "form_type": "", "date": "", "source_url": "", "text": ""}
 
 
-def _build_markdown(ticker: str, kind: str, filing: Dict[str, Any]) -> str:
-    title = "Annual Filing" if kind == "annual" else "Quarterly Filing"
-    source = str(filing.get("source") or "")
-    form_type = str(filing.get("form_type") or "")
-    date = str(filing.get("date") or "")
-    source_url = str(filing.get("source_url") or "")
-    text = _clean_filing_text(str(filing.get("text") or ""))
-    if not text:
-        text = "Filing text could not be cleaned for display."
-    return (
-        f"# {ticker} {title}\n\n"
-        f"- Source: {source or 'N/A'}\n"
-        f"- Form Type: {form_type or 'N/A'}\n"
-        f"- Date: {date or 'N/A'}\n\n"
-        f"- Source Filing URL: {source_url or 'N/A'}\n\n"
-        f"---\n\n"
-        f"{text}\n"
-    )
+def _to_filing_payload(row: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    if not row:
+        return _empty_filing()
+    return {
+        "available": True,
+        "source": str(row.get("source") or ""),
+        "form_type": str(row.get("form_type") or ""),
+        "date": str(row.get("date") or ""),
+        "source_url": str(row.get("source_url") or ""),
+        "text": str(row.get("text") or ""),
+    }
 
 
 def main() -> int:
     req = _read_input()
     ticker = str(req.get("ticker") or "").strip().upper()
-    kind = str(req.get("kind") or "").strip().lower()
 
     if not ticker:
         print(json.dumps({"ok": False, "error": "ticker_required"}))
-        return 0
-    if kind not in {"annual", "quarterly"}:
-        print(json.dumps({"ok": False, "error": "invalid_kind"}))
         return 0
 
     context_error = ""
@@ -203,59 +164,18 @@ def main() -> int:
         context_error = str(exc)
 
     files_dict = files_dict if isinstance(files_dict, dict) else {}
-    entries = _extract_filing_entries(files_dict)
-    filing = _pick_latest(entries, kind)
-
-    if not filing:
-        print(
-            json.dumps(
-                {
-                    "ok": False,
-                    "error": "filing_not_available",
-                    "ticker": ticker,
-                    "kind": kind,
-                    "context_error": context_error,
-                }
-            )
-        )
-        return 0
-
-    temp_dir = Path(tempfile.mkdtemp(prefix=f"filing_pdf_{ticker}_{kind}_"))
-    txt_path = temp_dir / f"{ticker}_{kind}_filing.txt"
-    pdf_path = temp_dir / f"{ticker}_{kind}_filing.pdf"
-    html_path = temp_dir / f"{ticker}_{kind}_filing.html"
-
-    txt_path.write_text(_build_markdown(ticker, kind, filing), encoding="utf-8")
-    try:
-        convert_text_to_pdf(txt_path, pdf_path, html_path)
-    except Exception as exc:
-        print(
-            json.dumps(
-                {
-                    "ok": False,
-                    "error": f"pdf_generation_failed:{exc}",
-                    "ticker": ticker,
-                    "kind": kind,
-                }
-            )
-        )
-        return 0
+    rows = _extract_filing_entries(files_dict)
+    annual = _pick_latest(rows, "annual")
+    quarterly = _pick_latest(rows, "quarterly")
 
     print(
         json.dumps(
             {
                 "ok": True,
                 "ticker": ticker,
-                "kind": kind,
-                "file_name": f"{ticker}_{kind}_filing.pdf",
-                "pdf_path": str(pdf_path),
-                "filing": {
-                    "available": True,
-                    "source": str(filing.get("source") or ""),
-                    "form_type": str(filing.get("form_type") or ""),
-                    "date": str(filing.get("date") or ""),
-                    "source_url": str(filing.get("source_url") or ""),
-                    "text": str(filing.get("text") or ""),
+                "filings": {
+                    "annual": _to_filing_payload(annual),
+                    "quarterly": _to_filing_payload(quarterly),
                 },
                 "context_error": context_error,
             },
@@ -267,3 +187,4 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
+

--- a/src/ai_hedge/dashboard.py
+++ b/src/ai_hedge/dashboard.py
@@ -1384,6 +1384,7 @@ def build_dashboard_payload(
     technical_analysis: Optional[Dict[str, Any]] = None,
     analysis_duration_minutes: Optional[float] = None,
     qualitative_sections: Optional[Dict[str, Any]] = None,
+    filings: Optional[Dict[str, Any]] = None,
     enable_llm_extractions: bool = True,
 ) -> Dict[str, Any]:
     info = info_dict.get("info", {}) if isinstance(info_dict, dict) else {}
@@ -1638,6 +1639,7 @@ def build_dashboard_payload(
             "rationale": "Signal blends 50% investment vote and 50% target-return, then applies disagreement confidence scaling (with extra disagreement penalty when allocation and target-direction are misaligned).",
         },
         "technical_analysis": technical_analysis if isinstance(technical_analysis, dict) else {},
+        "filings": filings if isinstance(filings, dict) else {},
         "artifacts": artifacts,
     }
 

--- a/src/ai_hedge/runner.py
+++ b/src/ai_hedge/runner.py
@@ -135,6 +135,108 @@ def _filing_source_label(form_type: str, raw: Dict[str, Any]) -> str:
     return "SEC"
 
 
+def _safe_filing_date(value: Any) -> datetime:
+    txt = str(value or "").strip()
+    if not txt:
+        return datetime.min
+    for fmt in ("%Y-%m-%d", "%Y/%m/%d", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S"):
+        try:
+            return datetime.strptime(txt[:19], fmt)
+        except Exception:
+            continue
+    try:
+        return datetime.fromisoformat(txt.replace("Z", "+00:00"))
+    except Exception:
+        return datetime.min
+
+
+def _normalize_filing_source_url(raw_url: Any, source: str) -> str:
+    url = str(raw_url or "").strip()
+    if not url:
+        return ""
+    if url.startswith("//"):
+        return f"https:{url}"
+    if url.lower().startswith(("http://", "https://")):
+        return url
+
+    source_u = str(source or "").strip().upper()
+    if source_u == "MAYA":
+        if url.startswith("/"):
+            if "/reports/" in url or "/api/" in url:
+                return f"https://maya.tase.co.il{url}"
+            return f"https://mayafiles.tase.co.il{url}"
+        return f"https://mayafiles.tase.co.il/{url.lstrip('/')}"
+
+    if "." in url and "/" in url:
+        return f"https://{url.lstrip('/')}"
+    return url
+
+
+def _filing_kind(form_type: str, raw: Dict[str, Any]) -> str:
+    joined = " ".join(
+        [
+            str(form_type or ""),
+            str(raw.get("form_type") or ""),
+            str(raw.get("title") or ""),
+            str(raw.get("name") or ""),
+            str(raw.get("label") or ""),
+        ]
+    ).upper()
+    if any(x in joined for x in ("10-K", "20-F", "ANNUAL", "MAYA ANNUAL")):
+        return "annual"
+    if any(x in joined for x in ("10-Q", "6-K", "QUARTER", "Q1", "Q2", "Q3", "Q4", "MAYA QUARTERLY")):
+        return "quarterly"
+    return "other"
+
+
+def _empty_filing_for_dashboard() -> Dict[str, Any]:
+    return {"available": False, "source": "", "form_type": "", "date": "", "source_url": ""}
+
+
+def _extract_latest_filing_sources(files_dict: Optional[Dict[str, object]]) -> Dict[str, Any]:
+    out = {
+        "annual": _empty_filing_for_dashboard(),
+        "quarterly": _empty_filing_for_dashboard(),
+    }
+    if not isinstance(files_dict, dict):
+        return out
+
+    rows: List[Dict[str, Any]] = []
+    for form_type, raw in files_dict.items():
+        if not isinstance(raw, dict):
+            continue
+        text = str(raw.get("text", "") or "").strip()
+        if not text:
+            continue
+        source = _filing_source_label(str(form_type or ""), raw)
+        rows.append(
+            {
+                "kind": _filing_kind(str(form_type or ""), raw),
+                "source": source,
+                "form_type": str(raw.get("form_type") or form_type or "").strip(),
+                "date": str(raw.get("date") or "").strip(),
+                "source_url": _normalize_filing_source_url(
+                    raw.get("url") or raw.get("source_url") or raw.get("link") or raw.get("href"),
+                    source,
+                ),
+            }
+        )
+
+    rows.sort(key=lambda x: _safe_filing_date(x.get("date")), reverse=True)
+    for kind in ("annual", "quarterly"):
+        picked = next((row for row in rows if row.get("kind") == kind), None)
+        if not picked:
+            continue
+        out[kind] = {
+            "available": True,
+            "source": str(picked.get("source") or ""),
+            "form_type": str(picked.get("form_type") or ""),
+            "date": str(picked.get("date") or ""),
+            "source_url": str(picked.get("source_url") or ""),
+        }
+    return out
+
+
 def _build_sec_sources_footer(files_dict: Optional[Dict[str, object]]) -> str:
     if not _has_filing_text(files_dict):
         return ""
@@ -1402,6 +1504,7 @@ def _run_ticker_valuation_impl(
 
     try:
         analysis_duration_minutes = round((time.perf_counter() - run_started) / 60.0, 2)
+        filing_sources = _extract_latest_filing_sources(files_dict)
         dashboard_payload = build_dashboard_payload(
             ticker=ticker,
             info_dict=info_dict,
@@ -1413,6 +1516,7 @@ def _run_ticker_valuation_impl(
             sec_short_text=sec_short_text,
             qualitative_sections=qualitative_sections,
             technical_analysis=technical_analysis_payload,
+            filings=filing_sources,
             enable_llm_extractions=True,
             analysis_duration_minutes=analysis_duration_minutes,
             artifacts={


### PR DESCRIPTION
## Summary
- add a reusable small copy button component in hedge-dashboard
- add copy buttons to Execution Summary, Bull, and Bear sections
- add a copy button to Dream Team persona blog content in persona-card

## Test plan
- manual UI verification of copy buttons in dashboard and Dream Team pages
- 
pm run lint currently reports pre-existing repo lint errors unrelated to this change