### PR TITLE
Fix ticker validation and MAYA filing identity checks

### DIFF
--- a/frontend/src/lib/yahoo-lookup.ts
+++ b/frontend/src/lib/yahoo-lookup.ts
@@ -77,7 +77,7 @@ function pickExchange(quote: Record<string, unknown>): string {
 // Yahoo's URL form. If the part after the last dot looks like an exchange code,
 // keep the dot; otherwise treat it as a share-class suffix and convert to dash.
 const KNOWN_EXCHANGE_SUFFIXES = new Set([
-  "TA", "L", "TO", "V", "CN", "NEO", "NE",
+  "TA", "L", "IL", "TO", "V", "CN", "NEO", "NE",
   "PA", "AS", "DE", "F", "MU", "HM", "HA", "DU", "BE", "SG", "MI", "MC", "BR", "VI", "VS", "ST", "OL", "HE", "CO", "IC", "IR",
   "SW", "PRA", "WA", "BD", "AT", "MX", "SA", "BA", "CL", "ME", "TI", "TWN",
   "AX", "NZ", "JK", "BK", "KS", "KQ", "T", "HK", "SS", "SZ", "NS", "BO", "KL",

--- a/src/ai_hedge/legacy_port.py
+++ b/src/ai_hedge/legacy_port.py
@@ -954,7 +954,7 @@ def _latest_filing_full_text_sec(ticker: str) -> dict:
         return files_dict
 
 
-def latest_filing_full_text(ticker: str) -> dict:
+def latest_filing_full_text(ticker: str, company_info: Optional[Dict[str, Any]] = None) -> dict:
     """
     Routing wrapper:
     - `.TA` tickers -> MAYA financial reports (annual + quarterly when available)
@@ -965,7 +965,7 @@ def latest_filing_full_text(ticker: str) -> dict:
         try:
             from .maya_reports import fetch_latest_maya_reports
 
-            maya_files = fetch_latest_maya_reports(ticker_u)
+            maya_files = fetch_latest_maya_reports(ticker_u, company_info=company_info)
             if isinstance(maya_files, dict):
                 return maya_files
             return {}
@@ -1141,7 +1141,8 @@ DEEPSEEK_API_KEY = os.getenv("DEEPSEEK_API_KEY", "")
 
 def get_dicts(ticker):
     info_dict = get_info_data(ticker)
-    files_dict = latest_filing_full_text(ticker)
+    info_payload = info_dict.get("info") if isinstance(info_dict, dict) else {}
+    files_dict = latest_filing_full_text(ticker, company_info=info_payload if isinstance(info_payload, dict) else {})
     financial_dict = get_financial_data(ticker, info_dict["info"], info_dict["financials"])
     variables_dict = get_variables(ticker, info_dict["info"], financial_dict["balance_sheet_quarterly"], financial_dict["financials_annual"], info_dict["financials"])
     return info_dict, files_dict, financial_dict, variables_dict

--- a/src/ai_hedge/maya_reports.py
+++ b/src/ai_hedge/maya_reports.py
@@ -146,7 +146,7 @@ def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-def _record_unresolved_company_id(ticker: str) -> None:
+def _record_unresolved_company_id(ticker: str, company_info: Optional[Dict[str, Any]] = None) -> None:
     ticker_u = _normalize_ticker(ticker)
     if not ticker_u or not ticker_u.endswith(".TA"):
         return
@@ -162,7 +162,7 @@ def _record_unresolved_company_id(ticker: str) -> None:
         prev = existing.get(ticker_u, {}) if isinstance(existing.get(ticker_u, {}), dict) else {}
         now = _utc_now_iso()
         count = int(prev.get("count", 0) or 0) + 1
-        terms = _collect_ticker_terms(ticker_u)
+        terms = _collect_ticker_terms(ticker_u, company_info=company_info)
 
         existing[ticker_u] = {
             "count": count,
@@ -240,15 +240,19 @@ def _normalize_name_tokens(value: str) -> List[str]:
     return out
 
 
-def _collect_ticker_terms(ticker: str) -> List[str]:
+def _collect_ticker_terms(ticker: str, company_info: Optional[Dict[str, Any]] = None) -> List[str]:
     base = _normalize_ticker(ticker).replace(".TA", "")
     terms: List[str] = [base]
-    try:
-        info = yf.Ticker(_normalize_ticker(ticker)).info
-    except Exception:
-        info = {}
+
+    info = company_info if isinstance(company_info, dict) else {}
+    if not info:
+        try:
+            info = yf.Ticker(_normalize_ticker(ticker)).info
+        except Exception:
+            info = {}
+
     if isinstance(info, dict):
-        for key in ("longName", "shortName", "prevName"):
+        for key in ("longName", "shortName", "displayName", "prevName"):
             val = str(info.get(key, "") or "").strip()
             if val:
                 terms.append(val)
@@ -294,10 +298,14 @@ def _score_company_candidate(name: str, search_term: str, ticker_base: str) -> i
     return score
 
 
-def _resolve_company_id_dynamic(ticker: str, session: requests.Session) -> Optional[int]:
+def _resolve_company_id_dynamic(
+    ticker: str,
+    session: requests.Session,
+    company_info: Optional[Dict[str, Any]] = None,
+) -> Optional[int]:
     ticker_u = _normalize_ticker(ticker)
     ticker_base = ticker_u.replace(".TA", "")
-    terms = _collect_ticker_terms(ticker_u)
+    terms = _collect_ticker_terms(ticker_u, company_info=company_info)
     if not terms:
         return None
 
@@ -334,7 +342,10 @@ def _resolve_company_id_dynamic(ticker: str, session: requests.Session) -> Optio
             if company_id <= 0:
                 continue
             company_name = str(comp.get("name", "") or "")
-            score = term_weight + _score_company_candidate(company_name, term, ticker_base) + 1
+            match_score = _score_company_candidate(company_name, term, ticker_base)
+            if match_score <= 0:
+                continue
+            score = term_weight + match_score
             candidate_scores[company_id] = candidate_scores.get(company_id, 0) + score
             if company_name:
                 candidate_names[company_id] = company_name
@@ -350,15 +361,25 @@ def _resolve_company_id_dynamic(ticker: str, session: requests.Session) -> Optio
         return candidate_scores[cid], token_hits
 
     winner = max(candidate_scores.keys(), key=_tie_break)
-    return winner if winner > 0 else None
+    if winner <= 0:
+        return None
+
+    best_score = candidate_scores.get(winner, 0)
+    if best_score < 8:
+        return None
+    return winner
 
 
-def _resolve_company_id(ticker: str, session: requests.Session) -> Optional[int]:
+def _resolve_company_id(
+    ticker: str,
+    session: requests.Session,
+    company_info: Optional[Dict[str, Any]] = None,
+) -> Optional[int]:
     overrides = _load_company_overrides()
     ticker_u = _normalize_ticker(ticker)
     if ticker_u in overrides:
         return overrides[ticker_u]
-    return _resolve_company_id_dynamic(ticker_u, session)
+    return _resolve_company_id_dynamic(ticker_u, session, company_info=company_info)
 
 
 def _safe_dt(value: Any) -> datetime:
@@ -631,7 +652,14 @@ def _download_report_text(session: requests.Session, detail: Dict[str, Any]) -> 
     return "", ""
 
 
-def _build_entry(label: str, *, detail: Dict[str, Any], text: str, source_url: str) -> Dict[str, Any]:
+def _build_entry(
+    label: str,
+    *,
+    detail: Dict[str, Any],
+    text: str,
+    source_url: str,
+    company_id: int,
+) -> Dict[str, Any]:
     publish_date = str(detail.get("publishDate", "") or "")
     title = str(detail.get("title", "") or "")
     if title and title not in text[:2000]:
@@ -644,10 +672,14 @@ def _build_entry(label: str, *, detail: Dict[str, Any], text: str, source_url: s
         "title": title or None,
         "source": "MAYA",
         "label": label,
+        "resolved_company_id": int(company_id),
     }
 
 
-def fetch_latest_maya_reports(ticker: str) -> Dict[str, Dict[str, Any]]:
+def fetch_latest_maya_reports(
+    ticker: str,
+    company_info: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Dict[str, Any]]:
     """
     Fetch latest annual + quarterly MAYA reports for `.TA` tickers.
 
@@ -661,9 +693,9 @@ def fetch_latest_maya_reports(ticker: str) -> Dict[str, Dict[str, Any]]:
     session = requests.Session()
     out: Dict[str, Dict[str, Any]] = {}
 
-    company_id = _resolve_company_id(ticker_u, session)
+    company_id = _resolve_company_id(ticker_u, session, company_info=company_info)
     if not company_id:
-        _record_unresolved_company_id(ticker_u)
+        _record_unresolved_company_id(ticker_u, company_info=company_info)
         return {}
 
     annual_primary = _pick_latest_annual(session, company_id=company_id, lang="he")
@@ -761,6 +793,12 @@ def fetch_latest_maya_reports(ticker: str) -> Dict[str, Dict[str, Any]]:
 
         if not detail or not text:
             continue
-        out[label] = _build_entry(label, detail=detail, text=text, source_url=source_url)
+        out[label] = _build_entry(
+            label,
+            detail=detail,
+            text=text,
+            source_url=source_url,
+            company_id=company_id,
+        )
 
     return out

--- a/src/ai_hedge/service.py
+++ b/src/ai_hedge/service.py
@@ -54,7 +54,7 @@ You are a senior Buy-Side equity analyst at a top-tier investment fund.
 
 You specialize in:
 - Deep fundamental analysis
-- Financial statement interpretation (10-K, 10-Q, footnotes)
+- Financial statement interpretation (SEC forms, MAYA reports, footnotes)
 - Detecting earnings quality issues and accounting distortions
 - Competitive positioning and industry structure
 - Valuation under uncertainty
@@ -69,7 +69,7 @@ You are expected to:
 - Connect financial data, then business reality, then valuation implications
 
 Critical Data Constraint:
-- Use ONLY the provided inputs (info dict, financials, SEC filings).
+- Use ONLY the provided inputs (info dict, financials, official filing text).
 - Do NOT use prior knowledge.
 - If something is missing, write EXACTLY:
   "Not disclosed in the provided filings."
@@ -233,7 +233,7 @@ def _truncate_text(value: Any, max_chars: int) -> str:
 
 def _build_sec_text_payload(files_dict: Dict[str, object]) -> Tuple[str, List[str]]:
     """
-    Build SEC text-only context from files_dict (no tables).
+    Build official filing text-only context from files_dict (no tables).
 
     Returns:
         (combined_text, notes)
@@ -276,28 +276,37 @@ def _build_sec_text_payload(files_dict: Dict[str, object]) -> Tuple[str, List[st
     annual_budget = max(0, total_budget - quarterly_text_chars) if quarterly_entries else total_budget
     annual_budget_left = annual_budget
 
-    def _append_block(form_type: str, date: str, text: str) -> None:
-        header = f"## Filing: {form_type} | Date: {date}".strip()
+    def _append_block(form_type: str, raw: Dict[str, Any], date: str, text: str) -> None:
+        source = str(raw.get("source") or "").strip()
+        issuer = str(raw.get("resolved_company_id") or "").strip()
+        parts = [f"## Filing: {form_type}"]
+        if source:
+            parts.append(f"Source: {source}")
+        if issuer:
+            parts.append(f"MAYA company id: {issuer}")
+        if date:
+            parts.append(f"Date: {date}")
+        header = " | ".join(parts).strip()
         chunks.append(f"{header}\n{text}")
 
-    for form_type, _raw, text, date, _kind in quarterly_entries:
-        _append_block(form_type, date, text)
+    for form_type, raw, text, date, _kind in quarterly_entries:
+        _append_block(form_type, raw, date, text)
 
-    for form_type, _raw, text, date, _kind in annual_entries:
+    for form_type, raw, text, date, _kind in annual_entries:
         if annual_budget_left <= 0:
             clipped = ""
         else:
             clipped = _truncate_text(text, annual_budget_left)
             annual_budget_left -= len(clipped)
-        _append_block(form_type, date, clipped)
+        _append_block(form_type, raw, date, clipped)
 
     # Keep other filings only as best effort within the remaining annual budget.
-    for form_type, _raw, text, date, _kind in other_entries:
+    for form_type, raw, text, date, _kind in other_entries:
         if annual_budget_left <= 0:
             break
         clipped = _truncate_text(text, annual_budget_left)
         annual_budget_left -= len(clipped)
-        _append_block(form_type, date, clipped)
+        _append_block(form_type, raw, date, clipped)
 
     return "\n\n".join(chunks), notes
 def _sec_style_instruction(short_mode: bool) -> str:
@@ -501,7 +510,7 @@ def _build_sec_prompt(
         f"Ticker: {ticker}\n\n"
         f"Info dict (info_dict['info']):\n{info_text}\n\n"
         f"Financial reports (financial_dict['all_reports'/'All Reports']):\n{all_reports_text}\n\n"
-        f"SEC filings text (from files_dict, text only):\n{sec_text_bundle}\n"
+        f"Official filing text (from files_dict, text only):\n{sec_text_bundle}\n"
     )
 
 
@@ -522,7 +531,7 @@ def _generate_sec_analysis_text(
     sec_text_bundle, notes = _build_sec_text_payload(files_dict)
     errors.extend(notes)
     if not sec_text_bundle.strip():
-        errors.append("No SEC filing text available in files_dict.")
+        errors.append("No official filing text available in files_dict.")
         return "", errors
 
     info_text = _truncate_text(json.dumps(info_dict.get("info", {}), ensure_ascii=False), 120_000)
@@ -625,9 +634,9 @@ def _format_sec_qna_markdown(questions: List[str], answers_payload: Dict[str, An
         "## SEC Pre-Decision Q&A",
     ]
 
-    lines.extend(["", "### Answers from SEC filings"])
+    lines.extend(["", "### Answers from official filings"])
     if not rows:
-        lines.append("No SEC-based answers were generated.")
+        lines.append("No filing-based answers were generated.")
         return "\n".join(lines).strip()
 
     for idx, row in enumerate(rows, start=1):
@@ -662,7 +671,7 @@ def build_sec_question_answer_text(
 ) -> Dict[str, object]:
     """
     Build SEC-focused questions from initial analysis + all reports, then answer them
-    using SEC filing text. Returns markdown-ready Q&A text.
+    using official filing text. Returns markdown-ready Q&A text.
     """
     ticker_u = (ticker or "").strip().upper()
     errors: List[str] = []
@@ -685,7 +694,7 @@ def build_sec_question_answer_text(
         sec_text_bundle, notes = _build_sec_text_payload(files_dict or {})
         errors.extend(notes)
         if not sec_text_bundle.strip():
-            errors.append("No SEC filing text available in files_dict.")
+            errors.append("No official filing text available in files_dict.")
             return out
 
         analysis_slice = _truncate_text(analysis_text, 150_000)
@@ -695,7 +704,7 @@ def build_sec_question_answer_text(
         questions_prompt = (
             "You are preparing final investment decision diligence.\n"
             "Given the first-pass analysis text and financial reports, list the most critical\n"
-            "questions/information to verify directly in formal SEC filings BEFORE final decision.\n"
+            "questions/information to verify directly in formal company filings BEFORE final decision.\n"
             "Focus on falsifiable, valuation-critical checks (earnings quality, cash conversion,\n"
             "segment economics, contingent liabilities, dilution, covenant/legal risk, concentration risk).\n\n"
             f"Ticker: {ticker_u}\n\n"
@@ -727,8 +736,8 @@ def build_sec_question_answer_text(
 
         questions_block = "\n".join(f"{idx}. {q}" for idx, q in enumerate(questions, start=1))
         answers_prompt = (
-            "You are given SEC filing text and a diligence question list.\n"
-            "Answer each question strictly from the provided SEC text.\n"
+            "You are given official filing text and a diligence question list.\n"
+            "Answer each question strictly from the provided filing text.\n"
             'If unavailable, answer exactly: "Not disclosed in the provided filings."\n\n'
             "Return ONLY valid JSON in this exact shape:\n"
             "{\n"
@@ -744,7 +753,7 @@ def build_sec_question_answer_text(
             "}\n"
             "No markdown, no extra keys, no prose outside JSON.\n\n"
             f"Questions:\n{questions_block}\n\n"
-            f"SEC filings text:\n{sec_text_bundle}\n"
+            f"Official filing text:\n{sec_text_bundle}\n"
         )
 
         raw_answers = legacy.deepseek_simple_text(
@@ -871,7 +880,7 @@ def _run_sec_analysis(
 
         header = (
             f"# {ticker_u} - {'SEC Short' if short_mode else 'SEC Full'} Analysis\n\n"
-            "This report is based strictly on SEC filing text + info_dict['info'] + financial_dict['All Reports'].\n\n"
+            "This report is based strictly on official filing text + info_dict['info'] + financial_dict['All Reports'].\n\n"
             "\n\n"
         )
         analysis_target.write_text(header + generated_text + "\n", encoding="utf-8")

--- a/tests/test_maya_reports.py
+++ b/tests/test_maya_reports.py
@@ -133,6 +133,63 @@ def test_unresolved_ta_company_id_is_recorded():
             unresolved_path.unlink()
 
 
+def test_collect_ticker_terms_uses_supplied_yahoo_info_without_refetch():
+    with patch("ai_hedge.maya_reports.yf.Ticker") as p_ticker:
+        terms = maya_reports._collect_ticker_terms(
+            "AMRK.TA",
+            company_info={
+                "shortName": "AMIR MARKETING AND",
+                "longName": "Amir Marketing and Investments in Agriculture Ltd",
+            },
+        )
+
+    assert p_ticker.call_count == 0
+    assert terms[:3] == [
+        "AMRK",
+        "Amir Marketing and Investments in Agriculture Ltd",
+        "AMIR MARKETING AND",
+    ]
+
+
+def test_dynamic_company_resolution_rejects_zero_match_candidates():
+    rows = [
+        {
+            "companies": [
+                {"companyId": 1084, "name": "Tower Semiconductor Ltd."},
+            ]
+        }
+    ]
+
+    with patch("ai_hedge.maya_reports._safe_request_json", return_value=rows):
+        company_id = maya_reports._resolve_company_id_dynamic(
+            "AMRK.TA",
+            session=object(),
+            company_info={"shortName": "AMIR MARKETING AND"},
+        )
+
+    assert company_id is None
+
+
+def test_dynamic_company_resolution_uses_supplied_company_name():
+    rows = [
+        {
+            "companies": [
+                {"companyId": 1084, "name": "Tower Semiconductor Ltd."},
+                {"companyId": 2204, "name": "Amir Marketing and Investments in Agriculture Ltd."},
+            ]
+        }
+    ]
+
+    with patch("ai_hedge.maya_reports._safe_request_json", return_value=rows):
+        company_id = maya_reports._resolve_company_id_dynamic(
+            "AMRK.TA",
+            session=object(),
+            company_info={"shortName": "AMIR MARKETING AND"},
+        )
+
+    assert company_id == 2204
+
+
 def test_sec_payload_contract_accepts_maya_dict():
     files_dict = {
         "MAYA Annual Report": {


### PR DESCRIPTION
## Summary

- Preserve dotted Yahoo exchange suffixes for .IL tickers so valid symbols are not rewritten as share classes.
- Reuse already-fetched Yahoo company metadata when resolving MAYA company ids for .TA tickers.
- Reject zero-match MAYA company candidates, persist resolved MAYA company id metadata, and update filing prompts away from SEC-only wording.

## Preview

URL: pending preview workflow for frontend change

## Test plan

- [x] PYTHONPATH=src python -m pytest -q -> 24 passed
- [x] cd frontend; npm run build -> passed

## Notes for reviewer

If a .TA ticker cannot be matched confidently to a MAYA issuer, filings now become unavailable instead of accepting a best-effort unrelated issuer. This is intentional to avoid cross-company filing contamination like AMRK/Tower.