### PR TITLE
Improve MAYA extraction, currency handling, and report deletion

### DIFF
--- a/frontend/src/app/(app)/reports/page.tsx
+++ b/frontend/src/app/(app)/reports/page.tsx
@@ -117,7 +117,7 @@ async function MineTabContent({
     <ul className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
       {filtered.map((r) => (
         <li key={r.id} className="h-full">
-          <ReportCard report={r} showVisibilityToggle />
+          <ReportCard report={r} showVisibilityToggle showDeleteAction />
         </li>
       ))}
     </ul>

--- a/frontend/src/app/api/artifacts/[ticker]/[kind]/route.ts
+++ b/frontend/src/app/api/artifacts/[ticker]/[kind]/route.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 
 import { NextResponse } from "next/server";
 
+import { getDeletedReportFilterForTicker, siteRunIdFromPathLike } from "@/lib/deleted-reports";
 import { fetchLatestReport, fetchReportById } from "@/lib/reports-db";
 import { findLatestByFileName, outputsRoot, resolveDashboardReportPath } from "@/lib/server-outputs";
 
@@ -109,8 +110,14 @@ async function resolveReportScopedFile(
   reportId: string,
   fileName: string,
 ): Promise<{ foundPath: string; r2Url: string | null }> {
+  const deletedFilter = await getDeletedReportFilterForTicker(ticker);
+  if (deletedFilter.isDeleted(reportId, ticker)) return { foundPath: "", r2Url: null };
+
   const reportPath = resolveDashboardReportPath(reportId);
   if (reportPath) {
+    if (deletedFilter.isDeleted(reportId, ticker, siteRunIdFromPathLike(reportPath))) {
+      return { foundPath: "", r2Url: null };
+    }
     const foundPath = resolveFromRoot(path.dirname(reportPath), fileName);
     return { foundPath, r2Url: null };
   }
@@ -178,7 +185,12 @@ export async function GET(
     }
   }
 
-  const found = foundPath ? { path: foundPath } : findLatestByFileName(fileName);
+  const deletedFilter = await getDeletedReportFilterForTicker(ticker);
+  const latestPath = foundPath ? foundPath : findLatestByFileName(fileName)?.path || "";
+  const found =
+    latestPath && !deletedFilter.isDeleted("", ticker, siteRunIdFromPathLike(latestPath))
+      ? { path: latestPath }
+      : null;
   if (!found) {
     return NextResponse.json({ error: `${fileName} was not found.` }, { status: 404 });
   }

--- a/frontend/src/app/api/dashboard/[ticker]/dream-team/chat/route.ts
+++ b/frontend/src/app/api/dashboard/[ticker]/dream-team/chat/route.ts
@@ -7,6 +7,7 @@ import { NextResponse } from "next/server";
 import { fetchReportById } from "@/lib/reports-db";
 import { normalizePayload } from "@/lib/dashboard-normalize";
 import type { DashboardPayload } from "@/lib/dashboard-types";
+import { getDeletedReportFilterForTicker, siteRunIdFromPathLike } from "@/lib/deleted-reports";
 import { parseJsonObjectFromMixedOutput } from "@/lib/python-json";
 import { repoRoot, TICKER_RE } from "@/lib/site-runner";
 import { readJson, resolveDashboardReportPath } from "@/lib/server-outputs";
@@ -291,6 +292,10 @@ export async function POST(
   let reportRow: Awaited<ReturnType<typeof fetchReportById>> | null = null;
   let localDashboardPath = "";
   let localDashboard: DashboardPayload | null = null;
+  const deletedFilter = await getDeletedReportFilterForTicker(ticker);
+  if (deletedFilter.isDeleted(reportId, ticker)) {
+    return NextResponse.json({ error: "Report not found." }, { status: 404 });
+  }
   try {
     reportRow = await fetchReportById(reportId);
   } catch {
@@ -299,6 +304,9 @@ export async function POST(
   if (!reportRow) {
     localDashboardPath = String(resolveDashboardReportPath(reportId) || "");
     if (!localDashboardPath) {
+      return NextResponse.json({ error: "Report not found." }, { status: 404 });
+    }
+    if (deletedFilter.isDeleted(reportId, ticker, siteRunIdFromPathLike(localDashboardPath))) {
       return NextResponse.json({ error: "Report not found." }, { status: 404 });
     }
     localDashboard = readJson<DashboardPayload>(localDashboardPath);

--- a/frontend/src/app/api/dashboard/[ticker]/summary/route.ts
+++ b/frontend/src/app/api/dashboard/[ticker]/summary/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 
 import type { DashboardPayload } from "@/lib/dashboard-types";
 import { getLiveCurrentPricesBatch } from "@/lib/dashboard-server";
+import { getDeletedReportFilterForTicker, siteRunIdFromPathLike } from "@/lib/deleted-reports";
 import {
   computeTickerSummaryAggregation,
   type SummarySourceReport,
@@ -21,16 +22,9 @@ function parseWindow(value: string | null): SummaryWindow {
   return WINDOW_VALUES.has(raw as SummaryWindow) ? (raw as SummaryWindow) : "all";
 }
 
-function siteRunIdFromPathLike(value: string): string | null {
-  const raw = String(value || "").trim();
-  if (!raw) return null;
-  const normalized = raw.replace(/\\/g, "/");
-  const match = normalized.match(/\/_site_runs\/([^/]+)/i);
-  return match?.[1] ? String(match[1]).trim() : null;
-}
-
 async function loadTickerDashboards(ticker: string): Promise<SummarySourceReport[]> {
   const merged = new Map<string, SummarySourceReport>();
+  const deletedFilter = await getDeletedReportFilterForTicker(ticker);
 
   try {
     const dbRows = await listDashboardsForTicker(ticker);
@@ -60,6 +54,7 @@ async function loadTickerDashboards(ticker: string): Promise<SummarySourceReport
     const row: SummarySourceReport = { ticker, generatedAt, payload };
     const runId = siteRunIdFromPathLike(entry.path);
     const key = runId ? `run:${ticker}:${runId}` : `file:${entry.path}`;
+    if (deletedFilter.isDeleted(entry.report_id, ticker, runId)) continue;
     if (merged.has(key)) continue;
     merged.set(key, row);
   }

--- a/frontend/src/app/api/discovery/route.ts
+++ b/frontend/src/app/api/discovery/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from "next/server";
 
 import { DashboardPayload, DiscoveryRow } from "@/lib/dashboard-types";
 import { getLiveCurrentPricesBatch } from "@/lib/dashboard-server";
+import { getDeletedReportFilter, siteRunIdFromPathLike } from "@/lib/deleted-reports";
 import { listAllDashboardsForHitRate } from "@/lib/reports-db";
 import { listDashboardReports, readJson } from "@/lib/server-outputs";
 import {
@@ -94,14 +95,6 @@ function cleanLensKey(value: string | null | undefined): string | null {
   return key ? key : null;
 }
 
-function siteRunIdFromPathLike(value: string): string | null {
-  const raw = String(value || "").trim();
-  if (!raw) return null;
-  const normalized = raw.replace(/\\/g, "/");
-  const match = normalized.match(/\/_site_runs\/([^/]+)/i);
-  return match?.[1] ? String(match[1]).trim() : null;
-}
-
 function resolveLensSelection(
   lensType: DiscoveryLensType,
   lensKey: string | null,
@@ -158,6 +151,7 @@ async function loadDashboards(): Promise<
   Array<{ ticker: string; payload: DashboardPayload; updatedAt: string; sourceLabel: string }>
 > {
   const merged = new Map<string, { ticker: string; payload: DashboardPayload; updatedAt: string; sourceLabel: string }>();
+  const deletedFilter = await getDeletedReportFilter();
 
   try {
     const dbRows = await listAllDashboardsForHitRate();
@@ -193,6 +187,7 @@ async function loadDashboards(): Promise<
     };
     const runId = siteRunIdFromPathLike(entry.path);
     const key = runId ? `run:${ticker}:${runId}` : `file:${entry.path}`;
+    if (deletedFilter.isDeleted(entry.report_id, ticker, runId)) continue;
     if (merged.has(key)) continue;
     merged.set(key, row);
   }

--- a/frontend/src/app/api/hit-rate/route.ts
+++ b/frontend/src/app/api/hit-rate/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 
 import type { DashboardPayload } from "@/lib/dashboard-types";
 import { getLiveCurrentPricesBatch } from "@/lib/dashboard-server";
+import { getDeletedReportFilter, siteRunIdFromPathLike } from "@/lib/deleted-reports";
 import { computeHitRateAggregation, type HitRateMode } from "@/lib/hit-rate-aggregate";
 import { listAllDashboardsForHitRate } from "@/lib/reports-db";
 import { listDashboardReports, readJson } from "@/lib/server-outputs";
@@ -16,16 +17,9 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
-function siteRunIdFromPathLike(value: string): string | null {
-  const raw = String(value || "").trim();
-  if (!raw) return null;
-  const normalized = raw.replace(/\\/g, "/");
-  const match = normalized.match(/\/_site_runs\/([^/]+)/i);
-  return match?.[1] ? String(match[1]).trim() : null;
-}
-
 async function loadHistoricalDashboards(): Promise<LoadedDashboard[]> {
   const merged = new Map<string, LoadedDashboard>();
+  const deletedFilter = await getDeletedReportFilter();
 
   try {
     const dbRows = await listAllDashboardsForHitRate();
@@ -56,6 +50,7 @@ async function loadHistoricalDashboards(): Promise<LoadedDashboard[]> {
     const row = { ticker, generatedAt, payload };
     const runId = siteRunIdFromPathLike(entry.path);
     const key = runId ? `run:${ticker}:${runId}` : `file:${entry.path}`;
+    if (deletedFilter.isDeleted(entry.report_id, ticker, runId)) continue;
     if (merged.has(key)) continue;
     merged.set(key, row);
   }

--- a/frontend/src/app/api/reports/[id]/route.ts
+++ b/frontend/src/app/api/reports/[id]/route.ts
@@ -1,0 +1,30 @@
+import { revalidateTag } from "next/cache";
+import { NextResponse } from "next/server";
+
+import { auth } from "@/auth";
+import { deleteUserReport } from "@/lib/reports-db";
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const reportId = String(id || "").trim();
+  if (!reportId) {
+    return NextResponse.json({ error: "missing_report_id" }, { status: 400 });
+  }
+
+  const session = await auth();
+  const userId = session?.user?.id;
+  if (!userId) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const deleted = await deleteUserReport({ reportId, userId });
+  if (!deleted) {
+    return NextResponse.json({ error: "forbidden_or_missing" }, { status: 403 });
+  }
+
+  revalidateTag("reports", "max");
+  return NextResponse.json({ ok: true });
+}

--- a/frontend/src/components/reports/delete-report-button.tsx
+++ b/frontend/src/components/reports/delete-report-button.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { Trash2 } from "lucide-react";
+
+export function DeleteReportButton({ reportId }: { reportId: string }) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+
+  async function deleteReport(event: React.MouseEvent<HTMLButtonElement>) {
+    event.preventDefault();
+    event.stopPropagation();
+    if (busy) return;
+    const confirmed = window.confirm("Delete this report?");
+    if (!confirmed) return;
+
+    setBusy(true);
+    try {
+      const res = await fetch(`/api/reports/${encodeURIComponent(reportId)}`, {
+        method: "DELETE",
+        cache: "no-store",
+      });
+      if (res.ok) {
+        router.refresh();
+      } else {
+        window.alert("Could not delete this report.");
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={(event) => void deleteReport(event)}
+      disabled={busy}
+      title="Delete report"
+      aria-label="Delete report"
+      className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-red-300/40 bg-red-400/10 text-red-100 transition hover:bg-red-400/20 disabled:opacity-50"
+    >
+      <Trash2 size={13} />
+    </button>
+  );
+}

--- a/frontend/src/components/reports/report-card.tsx
+++ b/frontend/src/components/reports/report-card.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 
 import type { DbReportSummary } from "@/lib/reports-db";
+import { DeleteReportButton } from "./delete-report-button";
 import { FriendlyDate } from "./friendly-date";
 import { VisibilityToggle } from "./visibility-toggle";
 
@@ -25,9 +26,11 @@ function recommendationTone(rec: string | null): { label: string; cls: string } 
 export function ReportCard({
   report,
   showVisibilityToggle = false,
+  showDeleteAction = false,
 }: {
   report: DbReportSummary;
   showVisibilityToggle?: boolean;
+  showDeleteAction?: boolean;
 }) {
   const href = `/dashboard/${encodeURIComponent(report.ticker)}/summary?report=${encodeURIComponent(report.id)}`;
   const rec = recommendationTone(report.recommendation);
@@ -38,6 +41,11 @@ export function ReportCard({
       {showVisibilityToggle ? (
         <div className="absolute right-3 top-3 z-10">
           <VisibilityToggle reportId={report.id} variant="icon" />
+        </div>
+      ) : null}
+      {showDeleteAction ? (
+        <div className="absolute right-12 top-3 z-10">
+          <DeleteReportButton reportId={report.id} />
         </div>
       ) : null}
       <Link href={href} className="flex h-full flex-col justify-between p-5">

--- a/frontend/src/lib/dashboard-server.ts
+++ b/frontend/src/lib/dashboard-server.ts
@@ -12,6 +12,11 @@ import {
   normalizePayload,
 } from "@/lib/dashboard-normalize";
 import {
+  getDeletedReportFilter,
+  getDeletedReportFilterForTicker,
+  siteRunIdFromPathLike,
+} from "@/lib/deleted-reports";
+import {
   fetchLatestReport,
   fetchReportById,
   listAllReports,
@@ -39,16 +44,9 @@ export type LivePerformance = {
   };
 };
 
-function siteRunIdFromPathLike(value: string): string | null {
-  const raw = String(value || "").trim();
-  if (!raw) return null;
-  const normalized = raw.replace(/\\/g, "/");
-  const match = normalized.match(/\/_site_runs\/([^/]+)/i);
-  return match?.[1] ? String(match[1]).trim() : null;
-}
-
 async function loadReportsList(): Promise<ReportListItem[]> {
   const merged = new Map<string, ReportListItem>();
+  const deletedFilter = await getDeletedReportFilter();
 
   try {
     const dbRows = await listAllReports();
@@ -81,6 +79,7 @@ async function loadReportsList(): Promise<ReportListItem[]> {
     };
     const runId = siteRunIdFromPathLike(report.path);
     const key = runId ? `run:${report.ticker}:${runId}` : `file:${report.path}`;
+    if (deletedFilter.isDeleted(report.report_id, report.ticker, runId)) continue;
     if (merged.has(key)) continue;
     merged.set(key, row);
   }
@@ -105,6 +104,12 @@ async function loadDashboardPayload(
   reportId: string,
 ): Promise<DashboardPayload> {
   const tk = ticker.toUpperCase();
+  const deletedFilter = await getDeletedReportFilterForTicker(tk);
+  if (reportId && deletedFilter.isDeleted(reportId, tk)) {
+    return normalizePayload(tk, { ticker: tk } as DashboardPayload, {
+      reportId,
+    });
+  }
 
   try {
     const dbRow = reportId
@@ -128,6 +133,12 @@ async function loadDashboardPayload(
   if (reportId) {
     const resolved = resolveDashboardReportPath(reportId);
     if (resolved) {
+      const runId = siteRunIdFromPathLike(resolved);
+      if (deletedFilter.isDeleted(reportId, tk, runId)) {
+        return normalizePayload(tk, { ticker: tk } as DashboardPayload, {
+          reportId,
+        });
+      }
       const base = resolved.split(/[\\/]/).pop() || "";
       if (base.toUpperCase().startsWith(`${tk}_DASHBOARD.JSON`)) {
         dashboardPath = resolved;
@@ -143,7 +154,7 @@ async function loadDashboardPayload(
   if (!dashboardPath) {
     const dashboardName = `${tk}_dashboard.json`;
     const latest = findLatestByFileName(dashboardName);
-    if (latest) {
+    if (latest && !deletedFilter.isDeleted("", tk, siteRunIdFromPathLike(latest.path))) {
       dashboardPath = latest.path;
       dashboardMtime = latest.mtimeMs;
     }

--- a/frontend/src/lib/deleted-reports.ts
+++ b/frontend/src/lib/deleted-reports.ts
@@ -1,0 +1,55 @@
+import "server-only";
+
+import { listDeletedReportRefs, listDeletedReportRefsForTicker } from "@/lib/reports-db";
+
+export function siteRunIdFromPathLike(value: string): string | null {
+  const raw = String(value || "").trim();
+  if (!raw) return null;
+  const normalized = raw.replace(/\\/g, "/");
+  const match = normalized.match(/\/_site_runs\/([^/]+)/i);
+  return match?.[1] ? String(match[1]).trim() : null;
+}
+
+export type DeletedReportFilter = {
+  isDeleted: (reportId: string, ticker?: string, runId?: string | null) => boolean;
+};
+
+function buildDeletedReportFilter(
+  refs: Array<{ id: string; ticker: string; source_run_id: string | null }>,
+): DeletedReportFilter {
+  const ids = new Set<string>();
+  const runKeys = new Set<string>();
+
+  for (const ref of refs) {
+    const id = String(ref.id || "").trim();
+    const ticker = String(ref.ticker || "").trim().toUpperCase();
+    const runId = String(ref.source_run_id || "").trim();
+    if (id) ids.add(id);
+    if (ticker && runId) runKeys.add(`${ticker}:${runId}`);
+  }
+
+  return {
+    isDeleted(reportId: string, ticker?: string, runId?: string | null) {
+      const id = String(reportId || "").trim();
+      const tk = String(ticker || "").trim().toUpperCase();
+      const run = String(runId || "").trim();
+      return Boolean((id && ids.has(id)) || (tk && run && runKeys.has(`${tk}:${run}`)));
+    },
+  };
+}
+
+export async function getDeletedReportFilter(): Promise<DeletedReportFilter> {
+  try {
+    return buildDeletedReportFilter(await listDeletedReportRefs());
+  } catch {
+    return buildDeletedReportFilter([]);
+  }
+}
+
+export async function getDeletedReportFilterForTicker(ticker: string): Promise<DeletedReportFilter> {
+  try {
+    return buildDeletedReportFilter(await listDeletedReportRefsForTicker(ticker));
+  } catch {
+    return buildDeletedReportFilter([]);
+  }
+}

--- a/frontend/src/lib/filings-stored.ts
+++ b/frontend/src/lib/filings-stored.ts
@@ -1,4 +1,5 @@
 import type { DashboardPayload } from "@/lib/dashboard-types";
+import { getDeletedReportFilterForTicker, siteRunIdFromPathLike } from "@/lib/deleted-reports";
 import { fetchLatestReport } from "@/lib/reports-db";
 import { listDashboardReports, readJson } from "@/lib/server-outputs";
 
@@ -58,8 +59,10 @@ async function readLatestDashboardPayload(ticker: string): Promise<DashboardPayl
     // Fall through to outputs scan.
   }
 
+  const deletedFilter = await getDeletedReportFilterForTicker(tk);
   for (const entry of listDashboardReports()) {
     if (String(entry.ticker || "").toUpperCase() !== tk) continue;
+    if (deletedFilter.isDeleted(entry.report_id, tk, siteRunIdFromPathLike(entry.path))) continue;
     const payload = readJson<DashboardPayload>(entry.path);
     if (payload) return payload;
   }

--- a/frontend/src/lib/reports-db.ts
+++ b/frontend/src/lib/reports-db.ts
@@ -37,6 +37,12 @@ export interface DbTickerRow {
   last_analyzed_at: string | null;
 }
 
+export interface DeletedReportRef {
+  id: string;
+  ticker: string;
+  source_run_id: string | null;
+}
+
 export async function fetchLatestReport(ticker: string): Promise<DbReportFull | null> {
   const sql = getSql();
   if (!sql) return null;
@@ -164,7 +170,37 @@ export async function attributeReportToUser(opts: {
   return rows.length > 0;
 }
 
-function fallbackCommunityReportsFromOutputs(query?: string): DbReportSummary[] {
+type DeletedReportPredicate = (reportId: string, ticker: string, runId: string | null) => boolean;
+
+function siteRunIdFromPathLike(value: string): string | null {
+  const raw = String(value || "").trim();
+  if (!raw) return null;
+  const normalized = raw.replace(/\\/g, "/");
+  const match = normalized.match(/\/_site_runs\/([^/]+)/i);
+  return match?.[1] ? String(match[1]).trim() : null;
+}
+
+async function deletedReportPredicate(): Promise<DeletedReportPredicate> {
+  try {
+    const refs = await listDeletedReportRefs();
+    const ids = new Set<string>();
+    const runKeys = new Set<string>();
+    for (const ref of refs) {
+      const id = String(ref.id || "").trim();
+      const ticker = String(ref.ticker || "").trim().toUpperCase();
+      const runId = String(ref.source_run_id || "").trim();
+      if (id) ids.add(id);
+      if (ticker && runId) runKeys.add(`${ticker}:${runId}`);
+    }
+    return (reportId, ticker, runId) =>
+      ids.has(String(reportId || "").trim()) ||
+      runKeys.has(`${String(ticker || "").trim().toUpperCase()}:${String(runId || "").trim()}`);
+  } catch {
+    return () => false;
+  }
+}
+
+function fallbackCommunityReportsFromOutputs(query?: string, isDeleted: DeletedReportPredicate = () => false): DbReportSummary[] {
   const q = String(query || "").trim().toLowerCase();
   const rows: DbReportSummary[] = [];
   for (const entry of listDashboardReports()) {
@@ -172,6 +208,7 @@ function fallbackCommunityReportsFromOutputs(query?: string): DbReportSummary[] 
     if (!dashboard) continue;
     const ticker = String(dashboard.ticker || entry.ticker || "").toUpperCase();
     if (!ticker) continue;
+    if (isDeleted(entry.report_id, ticker, siteRunIdFromPathLike(entry.path))) continue;
     const companyName = String(dashboard.header?.company_name || "").trim() || null;
     if (q) {
       const inTicker = ticker.toLowerCase().includes(q);
@@ -315,7 +352,7 @@ export async function listCommunityReports(): Promise<DbReportSummary[]> {
       `) as unknown as DbReportSummary[]);
     return rows;
   } catch {
-    return fallbackCommunityReportsFromOutputs();
+    return fallbackCommunityReportsFromOutputs(undefined, await deletedReportPredicate());
   }
 }
 
@@ -372,7 +409,7 @@ export async function listCommunityReportsPaged(opts: {
     const hasMore = rows.length > limit;
     return { rows: hasMore ? rows.slice(0, limit) : rows, hasMore };
   } catch {
-    const all = fallbackCommunityReportsFromOutputs(opts.query);
+    const all = fallbackCommunityReportsFromOutputs(opts.query, await deletedReportPredicate());
     const pageRows = all.slice(offset, offset + limit + 1);
     const hasMore = pageRows.length > limit;
     return { rows: hasMore ? pageRows.slice(0, limit) : pageRows, hasMore };
@@ -396,6 +433,51 @@ export async function setReportVisibility(opts: {
      RETURNING id;
   `) as Array<{ id: string }>;
   return rows.length > 0;
+}
+
+/** Owner-scoped soft delete. Deleted reports are excluded from lists and aggregate calculations. */
+export async function deleteUserReport(opts: {
+  reportId: string;
+  userId: string;
+}): Promise<boolean> {
+  const sql = getSql();
+  if (!sql) return false;
+  const rows = (await sql`
+    UPDATE reports
+       SET deleted_at = now()
+     WHERE id = ${opts.reportId}::uuid
+       AND user_id = ${opts.userId}::uuid
+       AND deleted_at IS NULL
+     RETURNING id;
+  `) as Array<{ id: string }>;
+  return rows.length > 0;
+}
+
+export async function listDeletedReportRefs(): Promise<DeletedReportRef[]> {
+  const sql = getSql();
+  if (!sql) return [];
+  const rows = (await sql`
+    SELECT id::text AS id,
+           ticker,
+           source_run_id
+      FROM reports
+     WHERE deleted_at IS NOT NULL;
+  `) as unknown as DeletedReportRef[];
+  return rows;
+}
+
+export async function listDeletedReportRefsForTicker(ticker: string): Promise<DeletedReportRef[]> {
+  const sql = getSql();
+  if (!sql) return [];
+  const rows = (await sql`
+    SELECT id::text AS id,
+           ticker,
+           source_run_id
+      FROM reports
+     WHERE deleted_at IS NOT NULL
+       AND ticker = ${String(ticker || "").toUpperCase()};
+  `) as unknown as DeletedReportRef[];
+  return rows;
 }
 
 /**

--- a/src/ai_hedge/legacy_port.py
+++ b/src/ai_hedge/legacy_port.py
@@ -140,12 +140,26 @@ def df_to_llm_csv(df: pd.DataFrame, scale_abs_gt: float = 1.0) -> str:
 
 
 from copy import deepcopy
-from typing import Any, Dict, Iterable, Optional, Set, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 import yfinance as yf
 
 
 def _is_number(x: Any) -> bool:
     return isinstance(x, (int, float)) and not isinstance(x, bool)
+
+
+def _select_shares_outstanding(info: Dict[str, Any], *, default: Optional[float] = 1) -> Optional[float]:
+    for key in ("impliedSharesOutstanding", "sharesOutstanding"):
+        value = info.get(key)
+        if _is_number(value) and value > 0:
+            return float(value)
+
+    market_cap = info.get("marketCap")
+    price = info.get("currentPrice")
+    if _is_number(market_cap) and market_cap > 0 and _is_number(price) and price > 0:
+        return float(market_cap) / float(price)
+
+    return default
 
 
 def _convert_range_str(value: str, factor: float) -> str:
@@ -305,7 +319,11 @@ def convert_financial_keys_to_usd(
 
     return out
 
-def find_currency(curr):
+def _currency_symbol_candidates(curr: Any) -> List[str]:
+    raw = str(curr or "").strip()
+    if not raw:
+        return []
+    curr_u = raw.upper()
     currency_tickers = {
     # --- Israel ---
     'ILA': "ILS=X",   # Israeli Agorot (Minor unit of ILS)
@@ -342,11 +360,22 @@ def find_currency(curr):
     'TRY': "TRY=X",   # Turkish Lira
 }
 
-    currency_symbol = currency_tickers.get(curr)
-    if not currency_symbol:
-      currency_rate = 1
-    else:
-      currency_rate = 1
+    candidates: List[str] = []
+    for key in (raw, curr_u):
+        symbol = currency_tickers.get(key)
+        if symbol and symbol not in candidates:
+            candidates.append(symbol)
+
+    if re.fullmatch(r"[A-Z]{3}", curr_u):
+        for symbol in (f"{curr_u}=X", f"USD{curr_u}=X"):
+            if symbol not in candidates:
+                candidates.append(symbol)
+    return candidates
+
+
+def find_currency(curr):
+    currency_rate = 1
+    for currency_symbol in _currency_symbol_candidates(curr):
       for _ in range(3):
         try:
           ticker_obj = yf.Ticker(currency_symbol)
@@ -356,8 +385,11 @@ def find_currency(curr):
             break
         except:
           pass
+      if currency_rate != 1:
+        break
 
-    if curr in ['ILA', 'GBp', 'ZAC']:
+    curr_raw = str(curr or "").strip()
+    if curr_raw in ['GBp'] or curr_raw.upper() in ['ILA', 'GBX', 'ZAC']:
         currency_rate = currency_rate * 100
 
     return currency_rate
@@ -369,7 +401,7 @@ def recalculate_derived_metrics(info: Dict[str, Any]) -> Dict[str, Any]:
     """
     # 1. Ensure basic values exist
     price = info.get("currentPrice")
-    shares = info.get("impliedSharesOutstanding") or info.get("sharesOutstanding")
+    shares = _select_shares_outstanding(info, default=None)
 
     if not price or not shares:
         return info
@@ -1092,9 +1124,16 @@ warnings.filterwarnings('ignore')
 
 def get_variables(ticker: str, info_dict: dict, financial_dict_quarter_bs, financial_dict_annual_finance, info_financials: dict) -> dict:
     variables_dict = {}
-    variables_dict["shares_outstanding"] = info_dict.get("impliedSharesOutstanding", 1)
-    variables_dict["price"] = info_dict.get("currentPrice", 0)
-    variables_dict["market_cap"] = info_dict.get("marketCap", 0)
+    variables_dict["shares_outstanding"] = _select_shares_outstanding(info_dict, default=1)
+    price = info_dict.get("currentPrice", 0)
+    variables_dict["price"] = price if _is_number(price) else 0
+    market_cap = info_dict.get("marketCap", 0)
+    if _is_number(market_cap) and market_cap > 0:
+        variables_dict["market_cap"] = market_cap
+    elif _is_number(variables_dict["price"]) and variables_dict["price"] > 0 and _is_number(variables_dict["shares_outstanding"]):
+        variables_dict["market_cap"] = variables_dict["price"] * variables_dict["shares_outstanding"]
+    else:
+        variables_dict["market_cap"] = 0
     variables_dict["price_currency"] = info_dict.get("price_currency_to_USD", 1)
     variables_dict["financial_currency"] = info_dict.get("financial_currency_to_USD", 1)
     total_debt = info_dict.get("totalDebt")

--- a/src/ai_hedge/maya_reports.py
+++ b/src/ai_hedge/maya_reports.py
@@ -80,6 +80,7 @@ _NOISY_NAME_TOKENS = {
     "FINANCIAL",
     "FINANCE",
     "THE",
+    "AND",
 }
 
 
@@ -256,6 +257,9 @@ def _collect_ticker_terms(ticker: str, company_info: Optional[Dict[str, Any]] = 
             val = str(info.get(key, "") or "").strip()
             if val:
                 terms.append(val)
+                cleaned = " ".join(_normalize_name_tokens(val))
+                if cleaned:
+                    terms.append(cleaned)
     uniq: List[str] = []
     seen = set()
     for term in terms:
@@ -277,6 +281,20 @@ def _iter_companies_from_search_rows(rows: Iterable[Dict[str, Any]]) -> Iterable
         for comp in companies:
             if isinstance(comp, dict):
                 yield comp
+
+
+def _iter_reporter_company_ids_from_search_rows(rows: Iterable[Dict[str, Any]]) -> Iterable[int]:
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        for key in ("reporterId", "reporterSecurityId"):
+            try:
+                company_id = int(row.get(key))
+            except Exception:
+                continue
+            if company_id > 0:
+                yield company_id
+                break
 
 
 def _score_company_candidate(name: str, search_term: str, ticker_base: str) -> int:
@@ -321,34 +339,41 @@ def _resolve_company_id_dynamic(
 
     candidate_scores: Dict[int, int] = {}
     candidate_names: Dict[int, str] = {}
-    headers = _base_headers(lang="en", referer=f"{MAYA_BASE_URL}/en/reports/search")
-
     for term, term_weight in weighted_terms:
-        payload = {"pageSize": 50, "pageNumber": 1, "freeText": term}
-        rows = _safe_request_json(
-            session,
-            method="POST",
-            url=MAYA_REPORT_SEARCH_ENDPOINT,
-            headers=headers,
-            payload=payload,
-        )
-        if not isinstance(rows, list):
-            continue
-        for comp in _iter_companies_from_search_rows(rows):
-            try:
-                company_id = int(comp.get("companyId"))
-            except Exception:
+        for lang in ("en", "he"):
+            payload = {"pageSize": 50, "pageNumber": 1, "freeText": term}
+            headers = _base_headers(lang=lang, referer=f"{MAYA_BASE_URL}/{lang}/reports/search")
+            rows = _safe_request_json(
+                session,
+                method="POST",
+                url=MAYA_REPORT_SEARCH_ENDPOINT,
+                headers=headers,
+                payload=payload,
+            )
+            if not isinstance(rows, list):
                 continue
-            if company_id <= 0:
-                continue
-            company_name = str(comp.get("name", "") or "")
-            match_score = _score_company_candidate(company_name, term, ticker_base)
-            if match_score <= 0:
-                continue
-            score = term_weight + match_score
-            candidate_scores[company_id] = candidate_scores.get(company_id, 0) + score
-            if company_name:
-                candidate_names[company_id] = company_name
+            for comp in _iter_companies_from_search_rows(rows):
+                try:
+                    company_id = int(comp.get("companyId"))
+                except Exception:
+                    continue
+                if company_id <= 0:
+                    continue
+                company_name = str(comp.get("name", "") or "")
+                match_score = _score_company_candidate(company_name, term, ticker_base)
+                if match_score <= 0:
+                    continue
+                score = term_weight + match_score
+                candidate_scores[company_id] = candidate_scores.get(company_id, 0) + score
+                if company_name:
+                    candidate_names[company_id] = company_name
+            for company_id in _iter_reporter_company_ids_from_search_rows(rows):
+                if str(term or "").strip().upper() == ticker_base:
+                    score = term_weight + 2
+                else:
+                    score = term_weight + 5
+                candidate_scores[company_id] = candidate_scores.get(company_id, 0) + score
+                candidate_names.setdefault(company_id, f"reporterId:{company_id}")
 
     if not candidate_scores:
         return None

--- a/tests/test_legacy_port_currency.py
+++ b/tests/test_legacy_port_currency.py
@@ -1,0 +1,31 @@
+from unittest.mock import patch
+
+from ai_hedge import legacy_port
+
+
+class _FakeTicker:
+    def __init__(self, price):
+        self.info = {"regularMarketPrice": price}
+
+
+def test_currency_symbol_candidates_use_dynamic_iso_fallback():
+    assert legacy_port._currency_symbol_candidates("KZT")[:2] == ["KZT=X", "USDKZT=X"]
+
+
+def test_find_currency_uses_dynamic_iso_pair_when_not_in_static_map():
+    seen = []
+
+    def fake_ticker(symbol):
+        seen.append(symbol)
+        return _FakeTicker(470.25 if symbol == "KZT=X" else None)
+
+    with patch("ai_hedge.legacy_port.yf.Ticker", side_effect=fake_ticker):
+        rate = legacy_port.find_currency("KZT")
+
+    assert rate == 470.25
+    assert seen == ["KZT=X"]
+
+
+def test_find_currency_keeps_minor_unit_multiplier():
+    with patch("ai_hedge.legacy_port.yf.Ticker", return_value=_FakeTicker(3.7)):
+        assert legacy_port.find_currency("ILA") == 370

--- a/tests/test_legacy_port_shares.py
+++ b/tests/test_legacy_port_shares.py
@@ -1,0 +1,54 @@
+from ai_hedge import legacy_port
+
+
+def _variables_for(info):
+    return legacy_port.get_variables(
+        "TEST",
+        info,
+        {"index": ["Total Assets"], "values": [[1000]]},
+        {},
+        {"totalRevenue": 100, "netIncomeToCommon": 10},
+    )
+
+
+def test_get_variables_prefers_implied_shares_outstanding():
+    variables = _variables_for(
+        {
+            "impliedSharesOutstanding": 123,
+            "sharesOutstanding": 456,
+            "currentPrice": 10,
+            "marketCap": 4560,
+            "bookValue": 2,
+        }
+    )
+
+    assert variables["shares_outstanding"] == 123
+
+
+def test_get_variables_falls_back_to_shares_outstanding_when_implied_missing():
+    variables = _variables_for(
+        {
+            "impliedSharesOutstanding": None,
+            "sharesOutstanding": 272083008,
+            "currentPrice": 31.15,
+            "marketCap": None,
+            "bookValue": 2,
+        }
+    )
+
+    assert variables["shares_outstanding"] == 272083008
+    assert variables["market_cap"] == 31.15 * 272083008
+
+
+def test_get_variables_derives_shares_from_market_cap_and_price():
+    variables = _variables_for(
+        {
+            "impliedSharesOutstanding": None,
+            "sharesOutstanding": None,
+            "currentPrice": 25,
+            "marketCap": 2500,
+            "bookValue": 2,
+        }
+    )
+
+    assert variables["shares_outstanding"] == 100

--- a/tests/test_maya_reports.py
+++ b/tests/test_maya_reports.py
@@ -144,10 +144,12 @@ def test_collect_ticker_terms_uses_supplied_yahoo_info_without_refetch():
         )
 
     assert p_ticker.call_count == 0
-    assert terms[:3] == [
+    assert terms[:5] == [
         "AMRK",
         "Amir Marketing and Investments in Agriculture Ltd",
+        "AMIR MARKETING INVESTMENTS AGRICULTURE",
         "AMIR MARKETING AND",
+        "AMIR MARKETING",
     ]
 
 
@@ -188,6 +190,67 @@ def test_dynamic_company_resolution_uses_supplied_company_name():
         )
 
     assert company_id == 2204
+
+
+def test_dynamic_company_resolution_uses_reporter_id_from_direct_report_rows():
+    rows = [
+        {
+            "id": 1738575,
+            "title": "Form 20-F For the fiscal year ended December 31, 2025",
+            "publishDate": "2026-04-30T23:00:03.293",
+            "reporterId": 2028,
+            "reporterSecurityId": 1082379,
+        }
+    ]
+
+    with patch("ai_hedge.maya_reports._safe_request_json", return_value=rows):
+        company_id = maya_reports._resolve_company_id_dynamic(
+            "AMRK.TA",
+            session=object(),
+            company_info={"shortName": "AMIR MARKETING AND"},
+        )
+
+    assert company_id == 2028
+
+
+def test_dynamic_company_resolution_prefers_repeated_hebrew_reporter_hits():
+    tower_rows = [
+        {
+            "id": 1738575,
+            "title": "Form 20-F For the fiscal year ended December 31, 2025",
+            "reporterId": 2028,
+            "reporterSecurityId": 1082379,
+            "companies": [{"companyId": 2028, "name": "TOWER"}],
+        }
+    ]
+    amrk_rows = [
+        {
+            "id": 1740428 + idx,
+            "title": "מרשם בעלי מניות",
+            "reporterId": 1232,
+            "reporterSecurityId": 1092204,
+            "companies": [{"companyId": 1232, "name": "עמיר שיווק"}],
+        }
+        for idx in range(4)
+    ]
+
+    def _fake_search(_session, *, method: str, url: str, headers: dict, payload: dict | None = None):
+        term = str((payload or {}).get("freeText", ""))
+        language = str((headers or {}).get("Accept-Language", ""))
+        if term == "AMIR MARKETING" and language.startswith("he-IL"):
+            return amrk_rows
+        if term in {"AMIR MARKETING", "AMIR MARKETING AND"}:
+            return tower_rows
+        return []
+
+    with patch("ai_hedge.maya_reports._safe_request_json", side_effect=_fake_search):
+        company_id = maya_reports._resolve_company_id_dynamic(
+            "AMRK.TA",
+            session=object(),
+            company_info={"shortName": "AMIR MARKETING AND"},
+        )
+
+    assert company_id == 1232
 
 
 def test_sec_payload_contract_accepts_maya_dict():


### PR DESCRIPTION
## Summary

- Improve MAYA `.TA` filing resolution by using cleaned company terms, Hebrew/English MAYA search, and reporter identifiers so AMRK.TA resolves to the correct issuer/files.
- Make share count and currency normalization more robust: fallback from implied shares to shares outstanding / derived shares, derive missing market cap, and dynamically resolve missing ISO FX pairs like KZT.
- Add owner-scoped report deletion from Mine and ensure deleted reports are excluded from report lists, dashboard fallbacks, filings, artifacts, Dream Team chat, Summary, Discovery, and Hit Rate calculations.

## Preview

URL: pending preview workflow

## Test plan

- [x] `PYTHONPATH=src python -m pytest -q tests/test_legacy_port_currency.py tests/test_legacy_port_shares.py tests/test_maya_reports.py`
- [x] `cd frontend && npm run build`
- [x] Live AMRK.TA MAYA fetch resolved company_id 1232 and extracted annual + quarterly MAYA PDFs.
- [x] Live KZT FX fallback resolved `KZT=X` successfully.

## Notes for reviewer

- Report deletion is currently a soft delete (`reports.deleted_at`) with active app paths guarded so deleted reports are not used; physical R2/local artifacts are not removed.
- `npm run lint` remains blocked by existing unrelated React Compiler/lint issues in files outside this change.