### PR TITLE
Prevent deleted reports from resurfacing via artifacts

### DIFF
--- a/frontend/src/app/api/artifacts/[ticker]/[kind]/route.ts
+++ b/frontend/src/app/api/artifacts/[ticker]/[kind]/route.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 
 import { NextResponse } from "next/server";
 
+import { isDbEnabled } from "@/lib/db";
 import { getDeletedReportFilterForTicker, siteRunIdFromPathLike } from "@/lib/deleted-reports";
 import { fetchLatestReport, fetchReportById } from "@/lib/reports-db";
 import { findLatestByFileName, outputsRoot, resolveDashboardReportPath } from "@/lib/server-outputs";
@@ -54,6 +55,12 @@ function isExistingFile(filePath: string): boolean {
   } catch {
     return false;
   }
+}
+
+function isUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    String(value || "").trim(),
+  );
 }
 
 function r2PublicUrl(r2Key: string): string | null {
@@ -112,8 +119,29 @@ async function resolveReportScopedFile(
   reportId: string,
   fileName: string,
 ): Promise<{ foundPath: string; r2Url: string | null }> {
+  const dbEnabled = isDbEnabled();
   const deletedFilter = await getDeletedReportFilterForTicker(ticker);
   if (deletedFilter.isDeleted(reportId, ticker)) return { foundPath: "", r2Url: null };
+
+  if (dbEnabled) {
+    if (!isUuid(reportId)) return { foundPath: "", r2Url: null };
+    try {
+      const row = await fetchReportById(reportId);
+      if (!row) return { foundPath: "", r2Url: null };
+      if (String(row.ticker || "").toUpperCase() !== ticker) return { foundPath: "", r2Url: null };
+
+      const r2Key = String(row.r2_keys?.[kind] || "").trim();
+      const url = r2PublicUrl(r2Key);
+      if (url) return { foundPath: "", r2Url: url };
+
+      for (const root of collectDbCandidateRoots(row)) {
+        const foundPath = resolveFromRoot(root, fileName);
+        if (foundPath) return { foundPath, r2Url: null };
+      }
+    } catch {
+      // DB unreachable or invalid UUID parse; fall through to filesystem compatibility.
+    }
+  }
 
   const reportPath = resolveDashboardReportPath(reportId);
   if (reportPath) {
@@ -177,11 +205,15 @@ export async function GET(
     }
   } else {
     // No explicit report scope: prefer latest DB report's R2 object when available.
+    const dbEnabled = isDbEnabled();
     try {
       const row = await fetchLatestReport(ticker);
       const r2Key = String(row?.r2_keys?.[kind] || "").trim();
       const r2Url = r2PublicUrl(r2Key);
       if (r2Url) return NextResponse.redirect(r2Url, 302);
+      if (dbEnabled && !row) {
+        return NextResponse.json({ error: `${fileName} was not found.` }, { status: 404 });
+      }
     } catch {
       // DB unreachable / missing row: fall through to FS path below.
     }

--- a/frontend/src/app/api/dashboard/[ticker]/dream-team/chat/route.ts
+++ b/frontend/src/app/api/dashboard/[ticker]/dream-team/chat/route.ts
@@ -4,6 +4,7 @@ import { spawn } from "node:child_process";
 
 import { NextResponse } from "next/server";
 
+import { isDbEnabled } from "@/lib/db";
 import { fetchReportById } from "@/lib/reports-db";
 import { normalizePayload } from "@/lib/dashboard-normalize";
 import type { DashboardPayload } from "@/lib/dashboard-types";
@@ -69,6 +70,12 @@ function trimText(value: unknown, maxChars: number): string {
 
 function cacheKey(ticker: string, reportId: string): string {
   return `${String(ticker || "").toUpperCase()}::${String(reportId || "").trim()}`;
+}
+
+function isUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    String(value || "").trim(),
+  );
 }
 
 function getCache(key: string): ContextCacheEntry | null {
@@ -285,6 +292,7 @@ export async function POST(
   const persona = String(body.persona || "").trim();
   const includeAnnual = Boolean(body.include_annual);
   const includeQuarterly = Boolean(body.include_quarterly);
+  const dbEnabled = isDbEnabled();
 
   if (!reportId) return NextResponse.json({ error: "report_id is required." }, { status: 400 });
   if (!persona) return NextResponse.json({ error: "persona is required." }, { status: 400 });
@@ -294,6 +302,9 @@ export async function POST(
   let localDashboard: DashboardPayload | null = null;
   const deletedFilter = await getDeletedReportFilterForTicker(ticker);
   if (deletedFilter.isDeleted(reportId, ticker)) {
+    return NextResponse.json({ error: "Report not found." }, { status: 404 });
+  }
+  if (dbEnabled && !isUuid(reportId)) {
     return NextResponse.json({ error: "Report not found." }, { status: 404 });
   }
   try {

--- a/frontend/src/app/api/dashboard/[ticker]/summary/route.ts
+++ b/frontend/src/app/api/dashboard/[ticker]/summary/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 
 import type { DashboardPayload } from "@/lib/dashboard-types";
 import { getLiveCurrentPricesBatch } from "@/lib/dashboard-server";
+import { isDbEnabled } from "@/lib/db";
 import { getDeletedReportFilterForTicker, siteRunIdFromPathLike } from "@/lib/deleted-reports";
 import {
   computeTickerSummaryAggregation,
@@ -25,6 +26,7 @@ function parseWindow(value: string | null): SummaryWindow {
 async function loadTickerDashboards(ticker: string): Promise<SummarySourceReport[]> {
   const merged = new Map<string, SummarySourceReport>();
   const deletedFilter = await getDeletedReportFilterForTicker(ticker);
+  const dbEnabled = isDbEnabled();
 
   try {
     const dbRows = await listDashboardsForTicker(ticker);
@@ -38,6 +40,11 @@ async function loadTickerDashboards(ticker: string): Promise<SummarySourceReport
       const runId = String((r as { source_run_id?: unknown }).source_run_id || "").trim();
       const key = runId ? `run:${row.ticker}:${runId}` : `db:${row.ticker}:${row.generatedAt}`;
       merged.set(key, row);
+    }
+    if (dbEnabled) {
+      return Array.from(merged.values()).sort(
+        (a, b) => Date.parse(String(b.generatedAt || "")) - Date.parse(String(a.generatedAt || "")),
+      );
     }
   } catch (err) {
     console.warn("[ticker-summary] DB read failed:", err);

--- a/frontend/src/app/api/discovery/route.ts
+++ b/frontend/src/app/api/discovery/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from "next/server";
 
 import { DashboardPayload, DiscoveryRow } from "@/lib/dashboard-types";
 import { getLiveCurrentPricesBatch } from "@/lib/dashboard-server";
+import { isDbEnabled } from "@/lib/db";
 import { getDeletedReportFilter, siteRunIdFromPathLike } from "@/lib/deleted-reports";
 import { listAllDashboardsForHitRate } from "@/lib/reports-db";
 import { listDashboardReports, readJson } from "@/lib/server-outputs";
@@ -141,6 +142,7 @@ async function loadDashboards(): Promise<
 > {
   const merged = new Map<string, { ticker: string; payload: DashboardPayload; updatedAt: string; sourceLabel: string }>();
   const deletedFilter = await getDeletedReportFilter();
+  const dbEnabled = isDbEnabled();
 
   try {
     const dbRows = await listAllDashboardsForHitRate();
@@ -154,6 +156,11 @@ async function loadDashboards(): Promise<
       const runId = String(r.source_run_id || "").trim();
       const key = runId ? `run:${row.ticker}:${runId}` : `db:${row.ticker}:${row.updatedAt}`;
       merged.set(key, row);
+    }
+    if (dbEnabled) {
+      return Array.from(merged.values()).sort(
+        (a, b) => Date.parse(String(b.updatedAt || "")) - Date.parse(String(a.updatedAt || "")),
+      );
     }
   } catch (err) {
     console.warn("[discovery] DB read failed:", err);

--- a/frontend/src/app/api/hit-rate/route.ts
+++ b/frontend/src/app/api/hit-rate/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 
 import type { DashboardPayload } from "@/lib/dashboard-types";
 import { getLiveCurrentPricesBatch } from "@/lib/dashboard-server";
+import { isDbEnabled } from "@/lib/db";
 import { getDeletedReportFilter, siteRunIdFromPathLike } from "@/lib/deleted-reports";
 import { computeHitRateAggregation, type HitRateMode } from "@/lib/hit-rate-aggregate";
 import { listAllDashboardsForHitRate } from "@/lib/reports-db";
@@ -20,6 +21,7 @@ export const revalidate = 0;
 async function loadHistoricalDashboards(): Promise<LoadedDashboard[]> {
   const merged = new Map<string, LoadedDashboard>();
   const deletedFilter = await getDeletedReportFilter();
+  const dbEnabled = isDbEnabled();
 
   try {
     const dbRows = await listAllDashboardsForHitRate();
@@ -33,6 +35,11 @@ async function loadHistoricalDashboards(): Promise<LoadedDashboard[]> {
       const runId = String(r.source_run_id || "").trim();
       const key = runId ? `run:${row.ticker}:${runId}` : `db:${row.ticker}:${row.generatedAt}`;
       merged.set(key, row);
+    }
+    if (dbEnabled) {
+      return Array.from(merged.values()).sort(
+        (a, b) => Date.parse(String(b.generatedAt || "")) - Date.parse(String(a.generatedAt || "")),
+      );
     }
   } catch (err) {
     console.warn("[hit-rate] DB read failed:", err);

--- a/frontend/src/components/hedge-dashboard.tsx
+++ b/frontend/src/components/hedge-dashboard.tsx
@@ -527,6 +527,7 @@ function TradingAgentsPanel({ payload }: { payload?: DashboardPayload["trading_a
       ? `Generated fresh ${generatedAt}`
       : `Unavailable ${generatedAt}`;
   const sections = [
+    ["Research Brief", payload.research_brief],
     ["Final Committee View", payload.final_committee_view],
     ["Fundamentals Report", payload.fundamentals_report],
     ["News Report", payload.news_report],
@@ -554,6 +555,7 @@ function TradingAgentsPanel({ payload }: { payload?: DashboardPayload["trading_a
           Research team: {(payload.selected_analysts || []).join(", ") || "fundamentals, news, social"}
           {". "}
           Not included here: {(payload.excluded_analysts || []).join(", ") || "market"}.
+          {payload.compacted ? " Stored as a compact brief." : ""}
         </p>
         {status !== "success" && payload.error ? (
           <p className="mt-2 text-xs text-zinc-400">Reason: {payload.error}</p>

--- a/frontend/src/components/hedge-dashboard.tsx
+++ b/frontend/src/components/hedge-dashboard.tsx
@@ -545,12 +545,15 @@ function TradingAgentsPanel({ payload }: { payload?: DashboardPayload["trading_a
           </span>
         </div>
         <p className="mt-2 text-xs leading-relaxed text-zinc-400">
-          This is another independent view of the company. It is not a target price, score, or instruction, and the market/technical analyst is excluded.
+          This is a separate research memo from a small agent team. It reads the business, recent news, and market
+          sentiment, then stages bull, bear, and risk debates before a final committee view. The memo itself does not
+          set the target price or score, and chart/technical analysis is left out so this stays focused on business
+          evidence.
         </p>
         <p className="mt-2 text-xs text-zinc-500">
-          Analysts: {(payload.selected_analysts || []).join(", ") || "fundamentals, news, social"}
-          {" · "}
-          Excluded: {(payload.excluded_analysts || []).join(", ") || "market"}
+          Research team: {(payload.selected_analysts || []).join(", ") || "fundamentals, news, social"}
+          {". "}
+          Not included here: {(payload.excluded_analysts || []).join(", ") || "market"}.
         </p>
         {status !== "success" && payload.error ? (
           <p className="mt-2 text-xs text-zinc-400">Reason: {payload.error}</p>
@@ -561,7 +564,7 @@ function TradingAgentsPanel({ payload }: { payload?: DashboardPayload["trading_a
         const cleanText = String(text || "").trim();
         if (!cleanText) return null;
         return (
-          <details key={title} className="rounded-xl border border-white/10 bg-black/30 p-3" open={index < 2}>
+          <details key={title} className="rounded-xl border border-white/10 bg-black/30 p-3" open={index === 0}>
             <summary className="cursor-pointer text-sm font-semibold text-zinc-100">{title}</summary>
             <div className="mt-2 max-h-[24rem] overflow-auto break-words text-zinc-200">
               <MarkdownBlock text={cleanText} />

--- a/frontend/src/components/hedge-dashboard.tsx
+++ b/frontend/src/components/hedge-dashboard.tsx
@@ -552,10 +552,8 @@ function TradingAgentsPanel({ payload }: { payload?: DashboardPayload["trading_a
           evidence.
         </p>
         <p className="mt-2 text-xs text-zinc-500">
-          Research team: {(payload.selected_analysts || []).join(", ") || "fundamentals, news, social"}
-          {". "}
-          Not included here: {(payload.excluded_analysts || []).join(", ") || "market"}.
-          {payload.compacted ? " Stored as a compact brief." : ""}
+          Independent Research team: {(payload.selected_analysts || []).join(", ") || "fundamentals, news, social"}.
+          {payload.compacted ? " compacted version." : ""}
         </p>
         {status !== "success" && payload.error ? (
           <p className="mt-2 text-xs text-zinc-400">Reason: {payload.error}</p>

--- a/frontend/src/lib/dashboard-server.ts
+++ b/frontend/src/lib/dashboard-server.ts
@@ -7,6 +7,7 @@ import { spawn } from "node:child_process";
 import { unstable_cache } from "next/cache";
 
 import type { DashboardPayload, ReportListItem } from "@/lib/dashboard-types";
+import { isDbEnabled } from "@/lib/db";
 import {
   buildFallbackFromArtifacts,
   normalizePayload,
@@ -47,6 +48,7 @@ export type LivePerformance = {
 async function loadReportsList(): Promise<ReportListItem[]> {
   const merged = new Map<string, ReportListItem>();
   const deletedFilter = await getDeletedReportFilter();
+  const dbEnabled = isDbEnabled();
 
   try {
     const dbRows = await listAllReports();
@@ -61,6 +63,15 @@ async function loadReportsList(): Promise<ReportListItem[]> {
       const runId = String(r.source_run_id || "").trim();
       const key = runId ? `run:${String(r.ticker || "").toUpperCase()}:${runId}` : `db:${r.id}`;
       merged.set(key, row);
+    }
+    if (dbEnabled) {
+      return Array.from(merged.values()).sort((a, b) => {
+        const aMs = Date.parse(String(a.generated_at || a.updated_at || ""));
+        const bMs = Date.parse(String(b.generated_at || b.updated_at || ""));
+        const safeA = Number.isFinite(aMs) ? aMs : 0;
+        const safeB = Number.isFinite(bMs) ? bMs : 0;
+        return safeB - safeA;
+      });
     }
   } catch (err) {
     console.warn("[reports] DB read failed:", err);
@@ -104,9 +115,15 @@ async function loadDashboardPayload(
   reportId: string,
 ): Promise<DashboardPayload> {
   const tk = ticker.toUpperCase();
+  const dbEnabled = isDbEnabled();
   const deletedFilter = await getDeletedReportFilterForTicker(tk);
   if (reportId && deletedFilter.isDeleted(reportId, tk)) {
     return normalizePayload(tk, { ticker: tk } as DashboardPayload, {
+      reportId,
+    });
+  }
+  if (dbEnabled && reportId && !isUuid(reportId)) {
+    return normalizePayload(tk, buildFallbackFromArtifacts(tk), {
       reportId,
     });
   }
@@ -121,6 +138,11 @@ async function loadDashboardPayload(
         reportId: dbRow.id,
         reportFile: undefined,
         reportMtime: generated,
+      });
+    }
+    if (dbEnabled) {
+      return normalizePayload(tk, buildFallbackFromArtifacts(tk), {
+        reportId: reportId || undefined,
       });
     }
   } catch (err) {
@@ -330,6 +352,12 @@ export type ResolvedTickerData = {
   resolvedReportId: string;
   data: DashboardPayload;
 };
+
+function isUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    String(value || "").trim(),
+  );
+}
 
 function reportTimestamp(report: ReportListItem): number {
   const ms = Date.parse(String(report.generated_at || report.updated_at || ""));

--- a/frontend/src/lib/dashboard-types.ts
+++ b/frontend/src/lib/dashboard-types.ts
@@ -50,6 +50,9 @@ export type TradingAgentsPayload = {
   selected_analysts?: string[];
   excluded_analysts?: string[];
   error?: string;
+  research_brief?: string;
+  compacted?: boolean;
+  summary_model?: string;
   fundamentals_report?: string;
   news_report?: string;
   sentiment_report?: string;

--- a/frontend/src/lib/filings-stored.ts
+++ b/frontend/src/lib/filings-stored.ts
@@ -1,4 +1,5 @@
 import type { DashboardPayload } from "@/lib/dashboard-types";
+import { isDbEnabled } from "@/lib/db";
 import { getDeletedReportFilterForTicker, siteRunIdFromPathLike } from "@/lib/deleted-reports";
 import { fetchLatestReport } from "@/lib/reports-db";
 import { listDashboardReports, readJson } from "@/lib/server-outputs";
@@ -48,6 +49,7 @@ function extractFromDashboard(payload: DashboardPayload | null | undefined): Sto
 async function readLatestDashboardPayload(ticker: string): Promise<DashboardPayload | null> {
   const tk = String(ticker || "").trim().toUpperCase();
   if (!tk) return null;
+  const dbEnabled = isDbEnabled();
 
   try {
     const dbRow = await fetchLatestReport(tk);
@@ -55,6 +57,7 @@ async function readLatestDashboardPayload(ticker: string): Promise<DashboardPayl
     if (dashboard && typeof dashboard === "object") {
       return dashboard;
     }
+    if (dbEnabled) return null;
   } catch {
     // Fall through to outputs scan.
   }

--- a/src/ai_hedge/runner.py
+++ b/src/ai_hedge/runner.py
@@ -5,6 +5,7 @@ import shutil
 import sys
 import json
 import time
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -1220,6 +1221,36 @@ def _run_ticker_valuation_impl(
     text = legacy.load_text_from_file("analysis.txt")
     regular_text = str(text or "").strip()
     notes: List[str] = []
+    trading_agents_payload: Dict[str, Any] = {}
+    trading_agents_context = ""
+    trading_agents_json = ""
+    trading_agents_txt = ""
+    trading_agents_executor: Optional[ThreadPoolExecutor] = None
+    trading_agents_future = None
+
+    try:
+        from .trading_agents_adapter import (
+            run_trading_agents_lens,
+        )
+
+        trading_agents_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="trading-agents")
+
+        def _run_trading_agents() -> Dict[str, Any]:
+            with _obs.llm_context(stage="trading_agents"):
+                return run_trading_agents_lens(
+                    ticker=ticker,
+                    output_dir=out_dir,
+                    api_key=str(os.getenv("DEEPSEEK_API_KEY", "") or "").strip(),
+                )
+
+        trading_agents_future = _obs.obs_submit(trading_agents_executor, _run_trading_agents)
+        _append_progress(progress_file, "Started TradingAgents Research Lens")
+    except Exception as trading_agents_start_err:
+        trading_agents_payload = {
+            "status": "unavailable",
+            "error": str(trading_agents_start_err),
+        }
+        notes.append(f"TradingAgents research lens failed to start: {trading_agents_start_err}")
 
     # SEC/MAYA pre-score Q&A: run only when filing text exists.
     if _has_filing_text(files_dict):
@@ -1358,23 +1389,14 @@ def _run_ticker_valuation_impl(
     except Exception as extraction_err:
         notes.append(f"Dashboard extraction append failed: {extraction_err}")
 
-    trading_agents_payload: Dict[str, Any] = {}
-    trading_agents_context = ""
-    trading_agents_json = ""
-    trading_agents_txt = ""
     try:
         from .trading_agents_adapter import (
             CONTEXT_HEADER as TRADING_AGENTS_CONTEXT_HEADER,
             build_trading_agents_context,
-            run_trading_agents_lens,
         )
 
-        with _obs.llm_context(stage="trading_agents"):
-            trading_agents_payload = run_trading_agents_lens(
-                ticker=ticker,
-                output_dir=out_dir,
-                api_key=str(os.getenv("DEEPSEEK_API_KEY", "") or "").strip(),
-            )
+        if trading_agents_future is not None:
+            trading_agents_payload = trading_agents_future.result()
         trading_agents_json = str(trading_agents_payload.get("artifact_json") or "")
         trading_agents_txt = str(trading_agents_payload.get("artifact_txt") or "")
         trading_agents_context = build_trading_agents_context(trading_agents_payload)
@@ -1397,6 +1419,9 @@ def _run_ticker_valuation_impl(
             "error": str(trading_agents_err),
         }
         notes.append(f"TradingAgents research lens failed: {trading_agents_err}")
+    finally:
+        if trading_agents_executor is not None:
+            trading_agents_executor.shutdown(wait=False)
     _append_progress(progress_file, "Finished TradingAgents Research Lens")
 
     valuation_contexts = [regular_text]

--- a/src/ai_hedge/trading_agents_adapter.py
+++ b/src/ai_hedge/trading_agents_adapter.py
@@ -5,12 +5,13 @@ import math
 import os
 import shutil
 import inspect
+import requests
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 
-ADAPTER_VERSION = "2026-05-27.v1"
+ADAPTER_VERSION = "2026-05-27.v2"
 CONFIG_VERSION = "deepseek-v0.2.4-fundamentals-news-social"
 REUSE_WINDOW_DAYS = 7
 SELECTED_ANALYSTS = ["fundamentals", "news", "social"]
@@ -18,7 +19,9 @@ EXCLUDED_ANALYSTS = ["market"]
 LLM_PROVIDER = "deepseek"
 QUICK_THINK_LLM = "deepseek-chat"
 DEEP_THINK_LLM = "deepseek-reasoner"
+SUMMARY_LLM = "deepseek-v4-flash"
 DEEPSEEK_BACKEND_URL = "https://api.deepseek.com/v1"
+COMPACT_BRIEF_MAX_CHARS = 9000
 
 CONTEXT_HEADER = "Independent Multi-Agent Research Lens"
 CONTEXT_INTRO = (
@@ -75,6 +78,13 @@ def _text(value: Any) -> str:
     return str(value).strip()
 
 
+def _trim_chars(value: str, limit: int) -> str:
+    text = str(value or "").strip()
+    if len(text) <= limit:
+        return text
+    return text[: max(0, int(limit))].rstrip() + "\n\n[Truncated]"
+
+
 def _section(title: str, body: Any) -> str:
     text = _text(body)
     if not text:
@@ -85,6 +95,14 @@ def _section(title: str, body: Any) -> str:
 def build_trading_agents_context(payload: Dict[str, Any]) -> str:
     if not isinstance(payload, dict) or payload.get("status") != "success":
         return ""
+    research_brief = _text(payload.get("research_brief"))
+    if research_brief:
+        sections = [
+            CONTEXT_INTRO,
+            "The TradingAgents market/technical analyst is intentionally excluded from this context.",
+            _section("Compact Research Brief", research_brief),
+        ]
+        return "\n\n".join(part.strip() for part in sections if str(part or "").strip()).strip()
 
     sections = [
         CONTEXT_INTRO,
@@ -116,6 +134,117 @@ def build_trading_agents_artifact_text(payload: Dict[str, Any]) -> str:
     if error:
         lines.append(f"Reason: {error}")
     return "\n".join(lines).strip() + "\n"
+
+
+def _raw_trading_agents_bundle(payload: Dict[str, Any]) -> str:
+    sections = [
+        _section("Final Committee View", payload.get("final_committee_view")),
+        _section("Fundamentals Report", payload.get("fundamentals_report")),
+        _section("News Report", payload.get("news_report")),
+        _section("Social / Sentiment Report", payload.get("sentiment_report")),
+        _section("Bull/Bear Debate", payload.get("bull_bear_debate")),
+        _section("Risk Debate", payload.get("risk_debate")),
+    ]
+    return "\n\n".join(part.strip() for part in sections if str(part or "").strip()).strip()
+
+
+def _fallback_compact_research_brief(payload: Dict[str, Any]) -> str:
+    pieces = []
+    final_view = _text(payload.get("final_committee_view"))
+    if final_view:
+        pieces.append(f"### Final Committee View\n{_trim_chars(final_view, 1200)}")
+    for title, key in [
+        ("Fundamental Signals", "fundamentals_report"),
+        ("News And Sentiment Signals", "news_report"),
+        ("Social Sentiment Signals", "sentiment_report"),
+        ("Bull/Bear Debate", "bull_bear_debate"),
+        ("Risk Debate", "risk_debate"),
+    ]:
+        text = _text(payload.get(key))
+        if text:
+            pieces.append(f"### {title}\n{_trim_chars(text, 1400)}")
+    return _trim_chars("\n\n".join(pieces).strip(), COMPACT_BRIEF_MAX_CHARS)
+
+
+def _summarize_trading_agents_payload(payload: Dict[str, Any], *, api_key: str) -> str:
+    raw_bundle = _raw_trading_agents_bundle(payload)
+    if not raw_bundle:
+        return ""
+    key = str(api_key or "").strip()
+    if not key:
+        return _fallback_compact_research_brief(payload)
+
+    prompt = f"""
+You are compressing a verbose multi-agent equity research transcript into the only TradingAgents artifact we will keep.
+
+Write a compact research brief of 1,000-1,400 words. Preserve the highest-signal ideas only.
+
+Rules:
+- Keep it useful for valuation work: business quality, growth durability, earnings quality, margin drivers, capital intensity, competitive position, key news, sentiment, bull case, bear case, and risk debate.
+- Do not add a target price, score, instruction, or trading order.
+- Do not include chart or technical-analysis claims.
+- Do not mention that you are summarizing.
+- Use Markdown with these headings exactly:
+  ### Final Committee View
+  ### Business And Fundamentals
+  ### News And Sentiment
+  ### Bull Case
+  ### Bear Case
+  ### Risk Debate
+  ### What Valuators Should Watch
+- Be specific. Avoid generic filler.
+
+TradingAgents transcript:
+<TradingAgents_Raw>
+{raw_bundle}
+</TradingAgents_Raw>
+""".strip()
+
+    try:
+        response = requests.post(
+            "https://api.deepseek.com/chat/completions",
+            headers={
+                "Authorization": f"Bearer {key}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "model": SUMMARY_LLM,
+                "temperature": 0.1,
+                "messages": [
+                    {"role": "system", "content": "Write concise, high-signal investment research."},
+                    {"role": "user", "content": prompt},
+                ],
+            },
+            timeout=(10.0, 180.0),
+        )
+        response.raise_for_status()
+        data = response.json()
+        content = ((data.get("choices") or [{}])[0].get("message") or {}).get("content", "")
+        summary = _text(content)
+        if summary:
+            return _trim_chars(summary, COMPACT_BRIEF_MAX_CHARS)
+    except Exception:
+        pass
+    return _fallback_compact_research_brief(payload)
+
+
+def compact_trading_agents_payload(payload: Dict[str, Any], *, api_key: str = "") -> Dict[str, Any]:
+    if not isinstance(payload, dict) or payload.get("status") != "success":
+        return payload
+    brief = _summarize_trading_agents_payload(payload, api_key=api_key)
+    compact = _base_payload(str(payload.get("ticker") or ""), now=_parse_dt(payload.get("generated_at")) or _now_utc())
+    compact.update(
+        {
+            "status": "success",
+            "trade_date": payload.get("trade_date"),
+            "research_brief": brief,
+            "final_committee_view": _text(payload.get("final_committee_view")),
+            "market_report_excluded": bool(payload.get("market_report_excluded")),
+            "compacted": True,
+            "summary_model": SUMMARY_LLM if str(api_key or "").strip() else "fallback",
+        }
+    )
+    return compact
 
 
 def _artifact_paths(output_dir: Path, ticker: str) -> Tuple[Path, Path]:
@@ -362,6 +491,7 @@ def run_trading_agents_lens(
         state, decision = _propagate_trading_agents_graph(graph, ticker_u, run_date)
         payload = normalize_trading_agents_state(ticker_u, state if isinstance(state, dict) else {}, decision, now=now)
         payload["trade_date"] = run_date
+        payload = compact_trading_agents_payload(payload, api_key=key)
     except Exception as exc:
         payload["status"] = "unavailable"
         payload["error"] = str(exc)

--- a/src/ai_hedge/trading_agents_adapter.py
+++ b/src/ai_hedge/trading_agents_adapter.py
@@ -4,6 +4,7 @@ import json
 import math
 import os
 import shutil
+import inspect
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
@@ -295,6 +296,17 @@ def _reuse_artifact(output_dir: Path, ticker: str, source_path: Path, source_pay
     return copied
 
 
+def _propagate_trading_agents_graph(graph: Any, ticker: str, trade_date: str) -> Tuple[Any, Any]:
+    propagate = graph.propagate
+    try:
+        params = inspect.signature(propagate).parameters
+    except (TypeError, ValueError):
+        params = {}
+    if "asset_type" in params:
+        return propagate(ticker, trade_date, asset_type="stock")
+    return propagate(ticker, trade_date)
+
+
 def run_trading_agents_lens(
     ticker: str,
     output_dir: str | Path,
@@ -347,7 +359,7 @@ def run_trading_agents_lens(
             }
         )
         graph = TradingAgentsGraph(selected_analysts=list(SELECTED_ANALYSTS), debug=False, config=config)
-        state, decision = graph.propagate(ticker_u, run_date, asset_type="stock")
+        state, decision = _propagate_trading_agents_graph(graph, ticker_u, run_date)
         payload = normalize_trading_agents_state(ticker_u, state if isinstance(state, dict) else {}, decision, now=now)
         payload["trade_date"] = run_date
     except Exception as exc:

--- a/tests/test_trading_agents_adapter.py
+++ b/tests/test_trading_agents_adapter.py
@@ -52,6 +52,31 @@ def test_context_framing_includes_research_lens_and_excludes_market_payload():
     assert "market_report" not in payload
 
 
+def test_compact_payload_keeps_brief_and_drops_verbose_sections(monkeypatch):
+    payload = ta.normalize_trading_agents_state(
+        "TEST",
+        {
+            "fundamentals_report": "fundamental point " * 100,
+            "news_report": "news point " * 100,
+            "sentiment_report": "social point " * 100,
+            "investment_debate_state": {"bull_history": "bull", "bear_history": "bear"},
+            "risk_debate_state": {"neutral_history": "risk"},
+        },
+        decision="committee output",
+    )
+    monkeypatch.setattr(ta, "_summarize_trading_agents_payload", lambda _payload, api_key="": "compact brief")
+
+    compact = ta.compact_trading_agents_payload(payload, api_key="key")
+    context = ta.build_trading_agents_context(compact)
+
+    assert compact["status"] == "success"
+    assert compact["compacted"] is True
+    assert compact["research_brief"] == "compact brief"
+    assert "fundamentals_report" not in compact
+    assert "compact brief" in context
+    assert "fundamental point" not in context
+
+
 def test_reuse_accepts_fresh_success_with_matching_config(tmp_path):
     now = datetime(2026, 5, 27, tzinfo=timezone.utc)
     old_dir = tmp_path / "outputs" / "_site_runs" / "old" / "TEST"

--- a/tests/test_trading_agents_adapter.py
+++ b/tests/test_trading_agents_adapter.py
@@ -102,3 +102,37 @@ def test_reuse_rejects_stale_failure_and_config_mismatch(tmp_path):
     found = ta.find_reusable_trading_agents_artifact(output_dir=new_dir, ticker="TEST", now=now)
 
     assert found is None
+
+
+def test_propagate_helper_supports_v024_signature_without_asset_type():
+    class Graph:
+        def __init__(self):
+            self.calls = []
+
+        def propagate(self, ticker, trade_date):
+            self.calls.append((ticker, trade_date))
+            return {"fundamentals_report": "ok"}, "decision"
+
+    graph = Graph()
+
+    state, decision = ta._propagate_trading_agents_graph(graph, "AAPL", "2026-05-27")
+
+    assert graph.calls == [("AAPL", "2026-05-27")]
+    assert state["fundamentals_report"] == "ok"
+    assert decision == "decision"
+
+
+def test_propagate_helper_keeps_asset_type_when_supported():
+    class Graph:
+        def __init__(self):
+            self.calls = []
+
+        def propagate(self, ticker, trade_date, *, asset_type):
+            self.calls.append((ticker, trade_date, asset_type))
+            return {"fundamentals_report": "ok"}, "decision"
+
+    graph = Graph()
+
+    ta._propagate_trading_agents_graph(graph, "AAPL", "2026-05-27")
+
+    assert graph.calls == [("AAPL", "2026-05-27", "stock")]


### PR DESCRIPTION
﻿## Summary

- Make DB-backed report reads authoritative so hard-deleted reports cannot resurface from stale filesystem artifacts.
- Keep filesystem report artifacts as fallback only when DB is disabled or unreachable.
- Block legacy filesystem report IDs on DB-backed dashboard, artifact, and Dream Team chat paths.

## Preview

URL: pending - site preview workflow should post pr-<N>-hedge-in-a-box-site.fly.dev

## Test plan

- [x] Verified `HSBK.IL` has no rows in the configured reports DB.
- [x] Ran `npm run build` in `frontend/`.

## Notes for reviewer

This preserves user soft delete (`reports.deleted_at = now()`) and only changes read behavior so deleted or hard-deleted reports are not revived by `/data/outputs` files when DB access is configured.
