### PR TITLE
Polish TradingAgents memo and report cards

### DIFF
--- a/frontend/src/components/hedge-dashboard.tsx
+++ b/frontend/src/components/hedge-dashboard.tsx
@@ -556,7 +556,7 @@ function TradingAgentsPanel({ payload }: { payload?: DashboardPayload["trading_a
       : `Unavailable ${generatedAt}`;
   const sections = [
     ["Research Brief", payload.research_brief],
-    ["Final Committee View", payload.final_committee_view],
+    ["Final Committee Decision", payload.final_committee_view],
     ["Fundamentals Report", payload.fundamentals_report],
     ["News Report", payload.news_report],
     ["Social / Sentiment Report", payload.sentiment_report],
@@ -582,10 +582,6 @@ function TradingAgentsPanel({ payload }: { payload?: DashboardPayload["trading_a
           This is a separate research memo from a small agent team. It reads the business, recent news, and market
           sentiment, then stages bull, bear, and risk debates before a final committee view. The memo itself does not
           set the target price or score.
-        </p>
-        <p className="mt-2 text-xs text-zinc-500">
-          Independent Research team: {(payload.selected_analysts || []).join(", ") || "fundamentals, news, social"}.
-          {payload.compacted ? " compacted version." : ""}
         </p>
         {status !== "success" && payload.error ? (
           <p className="mt-2 text-xs text-zinc-400">Reason: {payload.error}</p>

--- a/frontend/src/components/hedge-dashboard.tsx
+++ b/frontend/src/components/hedge-dashboard.tsx
@@ -513,6 +513,34 @@ export function MarkdownBlock({ text }: { text: string }) {
   );
 }
 
+function splitMarkdownHeadingBlocks(title: string, text: string): Array<{ title: string; text: string }> {
+  const lines = String(text || "").replace(/\r\n/g, "\n").split("\n");
+  const blocks: Array<{ title: string; lines: string[] }> = [];
+  let current: { title: string; lines: string[] } = { title, lines: [] };
+
+  for (const line of lines) {
+    const heading = line.match(/^\s{0,3}#{2,4}\s+(.+?)\s*#*\s*$/);
+    if (heading) {
+      if (current.lines.join("\n").trim()) {
+        blocks.push(current);
+      }
+      current = { title: heading[1].trim(), lines: [] };
+      continue;
+    }
+    current.lines.push(line);
+  }
+
+  if (current.lines.join("\n").trim()) {
+    blocks.push(current);
+  }
+
+  if (blocks.length === 0) {
+    return [{ title, text: String(text || "").trim() }].filter((block) => block.text);
+  }
+
+  return blocks.map((block) => ({ title: block.title, text: block.lines.join("\n").trim() }));
+}
+
 function TradingAgentsPanel({ payload }: { payload?: DashboardPayload["trading_agents"] }) {
   if (!payload || !Object.keys(payload).length) {
     return <p className="mt-3 text-sm text-zinc-500">No TradingAgents lens was stored for this report.</p>;
@@ -535,6 +563,11 @@ function TradingAgentsPanel({ payload }: { payload?: DashboardPayload["trading_a
     ["Bull/Bear Debate", payload.bull_bear_debate],
     ["Risk Debate", payload.risk_debate],
   ] as const;
+  const renderedSections = sections.flatMap(([title, text]) => {
+    const cleanText = String(text || "").trim();
+    if (!cleanText) return [];
+    return splitMarkdownHeadingBlocks(title, cleanText);
+  });
 
   return (
     <div className="mt-3 space-y-3">
@@ -548,8 +581,7 @@ function TradingAgentsPanel({ payload }: { payload?: DashboardPayload["trading_a
         <p className="mt-2 text-xs leading-relaxed text-zinc-400">
           This is a separate research memo from a small agent team. It reads the business, recent news, and market
           sentiment, then stages bull, bear, and risk debates before a final committee view. The memo itself does not
-          set the target price or score, and chart/technical analysis is left out so this stays focused on business
-          evidence.
+          set the target price or score.
         </p>
         <p className="mt-2 text-xs text-zinc-500">
           Independent Research team: {(payload.selected_analysts || []).join(", ") || "fundamentals, news, social"}.
@@ -560,14 +592,12 @@ function TradingAgentsPanel({ payload }: { payload?: DashboardPayload["trading_a
         ) : null}
       </div>
 
-      {sections.map(([title, text], index) => {
-        const cleanText = String(text || "").trim();
-        if (!cleanText) return null;
+      {renderedSections.map((section, index) => {
         return (
-          <details key={title} className="rounded-xl border border-white/10 bg-black/30 p-3" open={index === 0}>
-            <summary className="cursor-pointer text-sm font-semibold text-zinc-100">{title}</summary>
+          <details key={`${section.title}-${index}`} className="rounded-xl border border-white/10 bg-black/30 p-3" open={index === 0}>
+            <summary className="cursor-pointer text-sm font-semibold text-zinc-100">{section.title}</summary>
             <div className="mt-2 max-h-[24rem] overflow-auto break-words text-zinc-200">
-              <MarkdownBlock text={cleanText} />
+              <MarkdownBlock text={section.text} />
             </div>
           </details>
         );

--- a/frontend/src/components/reports/report-card.tsx
+++ b/frontend/src/components/reports/report-card.tsx
@@ -18,6 +18,26 @@ function scoreTone(score: number | null): { label: string; cls: string } {
   return { label: "Score 0.00", cls: "border-white/20 bg-white/10 text-zinc-100" };
 }
 
+function signedMetricTone(label: string, value: number | null, suffix = ""): { label: string; cls: string } {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return { label: `${label} N/A`, cls: "border-white/15 bg-white/5 text-zinc-300" };
+  }
+  const formatted = `${value > 0 ? "+" : ""}${value.toFixed(2)}${suffix}`;
+  if (value > 0) {
+    return { label: `${label} ${formatted}`, cls: "border-emerald-300/40 bg-emerald-400/10 text-emerald-100" };
+  }
+  if (value < 0) {
+    return { label: `${label} ${formatted}`, cls: "border-red-300/40 bg-red-400/10 text-red-100" };
+  }
+  return { label: `${label} 0.00${suffix}`, cls: "border-white/20 bg-white/10 text-zinc-100" };
+}
+
+function targetReturnPct(target: number | null, current: number | null): number | null {
+  if (typeof target !== "number" || !Number.isFinite(target)) return null;
+  if (typeof current !== "number" || !Number.isFinite(current) || Math.abs(current) <= 1e-9) return null;
+  return ((target - current) / current) * 100;
+}
+
 export function ReportCard({
   report,
   showVisibilityToggle = false,
@@ -29,7 +49,10 @@ export function ReportCard({
 }) {
   const href = `/dashboard/${encodeURIComponent(report.ticker)}/summary?report=${encodeURIComponent(report.id)}`;
   const score = scoreTone(report.score);
+  const target = signedMetricTone("Target", targetReturnPct(report.mean_target_price, report.current_price), "%");
+  const allocation = signedMetricTone("Allocation", report.allocation_pct, "%");
   const company = report.company_name || report.ticker;
+  const metrics = [score, target, allocation];
 
   return (
     <article className="group relative flex h-full flex-col rounded-2xl border border-white/10 bg-zinc-950/70 transition hover:border-emerald-400/50 hover:bg-emerald-500/5">
@@ -48,13 +71,18 @@ export function ReportCard({
           <p className="font-display text-3xl text-zinc-100">{report.ticker}</p>
           <p className="mt-1 line-clamp-2 text-sm text-zinc-400">{company}</p>
         </div>
-        <div className="mt-6 flex items-center justify-between gap-3">
-          <span
-            className={`inline-flex items-center rounded-md border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] ${score.cls}`}
-          >
-            {score.label}
-          </span>
-          <FriendlyDate iso={report.generated_at} className="text-xs text-zinc-400" />
+        <div className="mt-6 flex items-end justify-between gap-3">
+          <div className="flex flex-wrap gap-1.5">
+            {metrics.map((metric) => (
+              <span
+                key={metric.label}
+                className={`inline-flex items-center rounded-md border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] ${metric.cls}`}
+              >
+                {metric.label}
+              </span>
+            ))}
+          </div>
+          <FriendlyDate iso={report.generated_at} className="shrink-0 text-xs text-zinc-400" />
         </div>
       </Link>
     </article>

--- a/frontend/src/lib/reports-db.ts
+++ b/frontend/src/lib/reports-db.ts
@@ -14,6 +14,7 @@ export interface DbReportSummary {
   currency: string | null;
   recommendation: string | null;
   mean_target_price: number | null;
+  allocation_pct: number | null;
   score: number | null;
   source: string;
   source_run_id: string | null;
@@ -59,6 +60,12 @@ export async function fetchLatestReport(ticker: string): Promise<DbReportFull | 
            r.recommendation,
            r.mean_target_price::float8 AS mean_target_price,
            COALESCE(
+             (a.dashboard->'score_card'->>'position_size_pct_of_notional')::float8,
+             (a.dashboard->'decision_card'->>'position_size_pct_of_notional')::float8,
+             (a.dashboard->'score_card'->>'mean_investment_amount')::float8 / 100000.0,
+             (a.dashboard->'decision_card'->>'mean_investment_amount')::float8 / 100000.0
+           ) AS allocation_pct,
+           COALESCE(
              (a.dashboard->'score_card'->>'adjusted_score')::float8,
              (a.dashboard->'decision_card'->>'adjusted_score')::float8
            ) AS score,
@@ -93,6 +100,12 @@ export async function fetchReportById(id: string): Promise<DbReportFull | null> 
            r.currency,
            r.recommendation,
            r.mean_target_price::float8 AS mean_target_price,
+           COALESCE(
+             (a.dashboard->'score_card'->>'position_size_pct_of_notional')::float8,
+             (a.dashboard->'decision_card'->>'position_size_pct_of_notional')::float8,
+             (a.dashboard->'score_card'->>'mean_investment_amount')::float8 / 100000.0,
+             (a.dashboard->'decision_card'->>'mean_investment_amount')::float8 / 100000.0
+           ) AS allocation_pct,
            COALESCE(
              (a.dashboard->'score_card'->>'adjusted_score')::float8,
              (a.dashboard->'decision_card'->>'adjusted_score')::float8
@@ -150,6 +163,12 @@ export async function listLatestReportsPerTicker(): Promise<DbReportSummary[]> {
            r.currency,
            NULLIF(r.recommendation, '') AS recommendation,
            r.mean_target_price::float8 AS mean_target_price,
+           COALESCE(
+             (a.dashboard->'score_card'->>'position_size_pct_of_notional')::float8,
+             (a.dashboard->'decision_card'->>'position_size_pct_of_notional')::float8,
+             (a.dashboard->'score_card'->>'mean_investment_amount')::float8 / 100000.0,
+             (a.dashboard->'decision_card'->>'mean_investment_amount')::float8 / 100000.0
+           ) AS allocation_pct,
            COALESCE(
              (a.dashboard->'score_card'->>'adjusted_score')::float8,
              (a.dashboard->'decision_card'->>'adjusted_score')::float8
@@ -253,6 +272,14 @@ function fallbackCommunityReportsFromOutputs(query?: string, isDeleted: DeletedR
         Number.isFinite(dashboard.valuation_hub.consensus.mean_target_price)
           ? Number(dashboard.valuation_hub.consensus.mean_target_price)
           : null,
+      allocation_pct:
+        typeof (dashboard.score_card || dashboard.decision_card)?.position_size_pct_of_notional === "number" &&
+        Number.isFinite((dashboard.score_card || dashboard.decision_card)?.position_size_pct_of_notional)
+          ? Number((dashboard.score_card || dashboard.decision_card)?.position_size_pct_of_notional)
+          : typeof (dashboard.score_card || dashboard.decision_card)?.mean_investment_amount === "number" &&
+              Number.isFinite((dashboard.score_card || dashboard.decision_card)?.mean_investment_amount)
+            ? Number((dashboard.score_card || dashboard.decision_card)?.mean_investment_amount) / 100000.0
+            : null,
       score:
         typeof (dashboard.score_card || dashboard.decision_card)?.adjusted_score === "number" &&
         Number.isFinite((dashboard.score_card || dashboard.decision_card)?.adjusted_score)
@@ -312,6 +339,12 @@ export async function listAllReports(): Promise<DbReportSummary[]> {
            NULLIF(r.recommendation, '') AS recommendation,
            r.mean_target_price::float8 AS mean_target_price,
            COALESCE(
+             (a.dashboard->'score_card'->>'position_size_pct_of_notional')::float8,
+             (a.dashboard->'decision_card'->>'position_size_pct_of_notional')::float8,
+             (a.dashboard->'score_card'->>'mean_investment_amount')::float8 / 100000.0,
+             (a.dashboard->'decision_card'->>'mean_investment_amount')::float8 / 100000.0
+           ) AS allocation_pct,
+           COALESCE(
              (a.dashboard->'score_card'->>'adjusted_score')::float8,
              (a.dashboard->'decision_card'->>'adjusted_score')::float8
            ) AS score,
@@ -337,6 +370,12 @@ export async function listUserReports(userId: string): Promise<DbReportSummary[]
            r.currency,
            NULLIF(r.recommendation, '') AS recommendation,
            r.mean_target_price::float8 AS mean_target_price,
+           COALESCE(
+             (a.dashboard->'score_card'->>'position_size_pct_of_notional')::float8,
+             (a.dashboard->'decision_card'->>'position_size_pct_of_notional')::float8,
+             (a.dashboard->'score_card'->>'mean_investment_amount')::float8 / 100000.0,
+             (a.dashboard->'decision_card'->>'mean_investment_amount')::float8 / 100000.0
+           ) AS allocation_pct,
            COALESCE(
              (a.dashboard->'score_card'->>'adjusted_score')::float8,
              (a.dashboard->'decision_card'->>'adjusted_score')::float8
@@ -365,6 +404,12 @@ export async function listCommunityReports(): Promise<DbReportSummary[]> {
                r.currency,
                 NULLIF(r.recommendation, '') AS recommendation,
                 r.mean_target_price::float8 AS mean_target_price,
+                COALESCE(
+                  (a.dashboard->'score_card'->>'position_size_pct_of_notional')::float8,
+                  (a.dashboard->'decision_card'->>'position_size_pct_of_notional')::float8,
+                  (a.dashboard->'score_card'->>'mean_investment_amount')::float8 / 100000.0,
+                  (a.dashboard->'decision_card'->>'mean_investment_amount')::float8 / 100000.0
+                ) AS allocation_pct,
                 COALESCE(
                   (a.dashboard->'score_card'->>'adjusted_score')::float8,
                   (a.dashboard->'decision_card'->>'adjusted_score')::float8
@@ -421,6 +466,12 @@ export async function listCommunityReportsPaged(opts: {
                r.currency,
                 NULLIF(r.recommendation, '') AS recommendation,
                 r.mean_target_price::float8 AS mean_target_price,
+                COALESCE(
+                  (a.dashboard->'score_card'->>'position_size_pct_of_notional')::float8,
+                  (a.dashboard->'decision_card'->>'position_size_pct_of_notional')::float8,
+                  (a.dashboard->'score_card'->>'mean_investment_amount')::float8 / 100000.0,
+                  (a.dashboard->'decision_card'->>'mean_investment_amount')::float8 / 100000.0
+                ) AS allocation_pct,
                 COALESCE(
                   (a.dashboard->'score_card'->>'adjusted_score')::float8,
                   (a.dashboard->'decision_card'->>'adjusted_score')::float8

--- a/src/ai_hedge/trading_agents_adapter.py
+++ b/src/ai_hedge/trading_agents_adapter.py
@@ -98,14 +98,12 @@ def build_trading_agents_context(payload: Dict[str, Any]) -> str:
     if research_brief:
         sections = [
             CONTEXT_INTRO,
-            "The TradingAgents market/technical analyst is intentionally excluded from this context.",
             _section("Compact Research Brief", research_brief),
         ]
         return "\n\n".join(part.strip() for part in sections if str(part or "").strip()).strip()
 
     sections = [
         CONTEXT_INTRO,
-        "The TradingAgents market/technical analyst is intentionally excluded from this context.",
         _section("Fundamentals Report", payload.get("fundamentals_report")),
         _section("News Report", payload.get("news_report")),
         _section("Social / Sentiment Report", payload.get("sentiment_report")),
@@ -174,12 +172,27 @@ def _summarize_trading_agents_payload(payload: Dict[str, Any], *, api_key: str) 
         return _fallback_compact_research_brief(payload)
 
     prompt = f"""
-You are compressing a verbose multi-agent equity research transcript into the only TradingAgents artifact we will keep.
+You are compressing a verbose multi-agent equity research transcript into the canonical TradingAgents investment memory artifact.
+This is the only TradingAgents artifact we will keep.
+The goal is long-horizon valuation usefulness and retrieval efficiency.
 
-Write a compact research brief of 1,000-1,600 words. Preserve the highest-signal ideas only.
+Write a dense research brief for this TradingAgents raw transcript. Preserve the highest-signal ideas only.
+Target length: typically 1,000-1,600 words, but optimize for signal density rather than strict length.
+
+Preserve:
+- business quality
+- growth durability
+- earnings quality
+- margin structure and operating leverage
+- free cash flow quality and capital intensity
+- competitive positioning
+- valuation-relevant macro exposure
+- key catalysts
+- core bull/bear thesis conflicts
+- important uncertainty drivers
 
 Rules:
-- Keep it useful for valuation work: business quality, growth durability, earnings quality, margin drivers, capital intensity, competitive position, key news, sentiment, bull case, bear case, and risk debate.
+- Keep it useful for valuation work: business quality, growth durability, earnings quality, margin drivers, capital intensity, competitive position, key news, sentiment, bull case, bear case, risk debate, and any other points that are relevant to fundamental valuation.
 - Do not add a target price, score, instruction, or trading order.
 - Do not include chart or technical-analysis claims.
 - Do not mention that you are summarizing.
@@ -191,9 +204,10 @@ Rules:
   ### Bear Case
   ### Risk Debate
   ### What Valuators Should Watch
+- Do not use any other Markdown headers or subheaders. Inside each section, use bullets, paragraphs, and **bold labels** only as needed for clarity.
 - Be specific. Avoid generic filler.
 
-TradingAgents transcript:
+TradingAgents raw transcript:
 <TradingAgents_Raw>
 {raw_bundle}
 </TradingAgents_Raw>

--- a/tests/test_trading_agents_adapter.py
+++ b/tests/test_trading_agents_adapter.py
@@ -103,7 +103,8 @@ def test_summarize_uses_observed_legacy_deepseek_wrapper(monkeypatch):
     assert calls[0]["model"] == ta.SUMMARY_LLM
     assert calls[0]["temperature"] == 0.1
     assert calls[0]["short_answer"] is False
-    assert "TradingAgents transcript:" in calls[0]["prompt"]
+    assert "TradingAgents raw transcript:" in calls[0]["prompt"]
+    assert "Do not use any other Markdown headers or subheaders" in calls[0]["prompt"]
 
 
 def test_reuse_accepts_fresh_success_with_matching_config(tmp_path):


### PR DESCRIPTION
Summary: Update TradingAgents memo copy, compactor prompt guardrails, and remove the redundant market/technical exclusion sentence from generated artifact text. Split TradingAgents markdown headings into separate collapsible blocks in the valuation tab. Add report-card score, target upside, and allocation pills using report-date stored metrics.

Preview: pending preview workflow.

Test plan: pytest tests/test_trading_agents_adapter.py passed; npm run lint passed for src/components/reports/report-card.tsx and src/lib/reports-db.ts; npm run build passed.

Notes for reviewer: Full-file lint on src/components/hedge-dashboard.tsx still reports existing React compiler lint findings outside this change; the production build passes. Existing generated PDFs/TXT artifacts may still contain old TradingAgents text until reports are regenerated.