### PR TITLE
Add report download tab and PDF artifacts

### DIFF
--- a/frontend/src/app/(app)/dashboard/[ticker]/artifacts/artifacts-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/artifacts/artifacts-client.tsx
@@ -61,6 +61,7 @@ export function ArtifactsClient({
   push("revenue_plot", "Revenue Chart", artifacts.revenue_plot);
   push("net_income_plot", "Net Income Chart", artifacts.net_income_plot);
   push("prices_explain_pdf", "Prices Explainer PDF", downloads.prices_explain_pdf || artifacts.prices_explain_pdf);
+  push("combined_pdf", "Combined PDF", downloads.combined_pdf || artifacts.combined_pdf);
   push("prices_explain_txt", "Prices Explainer TXT", downloads.prices_explain_txt || artifacts.prices_explain_txt);
   push("dashboard_json", "Dashboard JSON", downloads.dashboard_json || artifacts.dashboard_json);
   push("technical_analysis_json", "Technical Analysis JSON", artifacts.technical_analysis_json);

--- a/frontend/src/app/(app)/dashboard/[ticker]/download/download-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/download/download-client.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { Download, FileText, Layers3, ReceiptText } from "lucide-react";
-import type { ComponentType } from "react";
+import { Download } from "lucide-react";
 
 import { ReportChipRow } from "@/components/dashboard-chrome";
 import type { DashboardPayload, ReportListItem } from "@/lib/dashboard-types";
@@ -11,7 +10,6 @@ type DownloadItem = {
   title: string;
   fileLabel: string;
   href: string;
-  icon: ComponentType<{ size?: number }>;
 };
 
 export type DownloadClientProps = {
@@ -36,21 +34,18 @@ export function DownloadClient({
       title: "Analysis",
       fileLabel: `${upper}_analysis.pdf`,
       href: downloads.analysis_pdf || `/api/artifacts/${encodeURIComponent(upper)}/analysis-pdf`,
-      icon: FileText,
     },
     {
       key: "valuation",
       title: "Valuation",
       fileLabel: `${upper}_valuation.pdf`,
       href: downloads.valuation_pdf || downloads.prices_explain_pdf || `/api/artifacts/${encodeURIComponent(upper)}/valuation-pdf`,
-      icon: ReceiptText,
     },
     {
       key: "combined",
       title: "Combined",
       fileLabel: `${upper}_combined.pdf`,
       href: downloads.combined_pdf || `/api/artifacts/${encodeURIComponent(upper)}/combined-pdf`,
-      icon: Layers3,
     },
   ];
 
@@ -67,7 +62,6 @@ export function DownloadClient({
 
       <section className="grid gap-3 md:grid-cols-3">
         {items.map((item) => {
-          const Icon = item.icon;
           return (
             <a
               key={item.key}
@@ -80,9 +74,6 @@ export function DownloadClient({
                   <span className="mt-1 block break-all font-mono text-xs text-[color:var(--text-muted)]">
                     {item.fileLabel}
                   </span>
-                </span>
-                <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-white/10 bg-white/5 text-[color:var(--text-secondary)] transition group-hover:text-[color:var(--accent)]">
-                  <Icon size={16} />
                 </span>
               </span>
               <span className="mt-5 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.14em] text-[color:var(--accent)]">

--- a/frontend/src/app/(app)/dashboard/[ticker]/download/download-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/download/download-client.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { Download, FileText, Layers3, ReceiptText } from "lucide-react";
+import type { ComponentType } from "react";
+
+import { ReportChipRow } from "@/components/dashboard-chrome";
+import type { DashboardPayload, ReportListItem } from "@/lib/dashboard-types";
+
+type DownloadItem = {
+  key: string;
+  title: string;
+  fileLabel: string;
+  href: string;
+  icon: ComponentType<{ size?: number }>;
+};
+
+export type DownloadClientProps = {
+  ticker: string;
+  data: DashboardPayload;
+  reportsForTicker: ReportListItem[];
+  resolvedReportId: string;
+};
+
+export function DownloadClient({
+  ticker,
+  data,
+  reportsForTicker,
+  resolvedReportId,
+}: DownloadClientProps) {
+  const upper = ticker.toUpperCase();
+  const downloads = data.downloads || ({} as NonNullable<typeof data.downloads>);
+
+  const items: DownloadItem[] = [
+    {
+      key: "analysis",
+      title: "Analysis",
+      fileLabel: `${upper}_analysis.pdf`,
+      href: downloads.analysis_pdf || `/api/artifacts/${encodeURIComponent(upper)}/analysis-pdf`,
+      icon: FileText,
+    },
+    {
+      key: "valuation",
+      title: "Valuation",
+      fileLabel: `${upper}_valuation.pdf`,
+      href: downloads.valuation_pdf || downloads.prices_explain_pdf || `/api/artifacts/${encodeURIComponent(upper)}/valuation-pdf`,
+      icon: ReceiptText,
+    },
+    {
+      key: "combined",
+      title: "Combined",
+      fileLabel: `${upper}_combined.pdf`,
+      href: downloads.combined_pdf || `/api/artifacts/${encodeURIComponent(upper)}/combined-pdf`,
+      icon: Layers3,
+    },
+  ];
+
+  return (
+    <div>
+      <ReportChipRow ticker={upper} reports={reportsForTicker} currentReportId={resolvedReportId} />
+
+      <header className="mb-4">
+        <h1 className="font-display text-2xl text-[color:var(--text-primary)]">Download</h1>
+        <p className="text-xs uppercase tracking-[0.18em] text-[color:var(--text-muted)]">
+          {upper} report files
+        </p>
+      </header>
+
+      <section className="grid gap-3 md:grid-cols-3">
+        {items.map((item) => {
+          const Icon = item.icon;
+          return (
+            <a
+              key={item.key}
+              href={item.href}
+              className="group flex min-h-36 flex-col justify-between rounded-lg border border-white/10 bg-zinc-950/70 p-4 transition hover:border-emerald-400/50 hover:bg-emerald-500/5"
+            >
+              <span className="flex items-start justify-between gap-3">
+                <span>
+                  <span className="block text-sm font-semibold text-[color:var(--text-primary)]">{item.title}</span>
+                  <span className="mt-1 block break-all font-mono text-xs text-[color:var(--text-muted)]">
+                    {item.fileLabel}
+                  </span>
+                </span>
+                <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-white/10 bg-white/5 text-[color:var(--text-secondary)] transition group-hover:text-[color:var(--accent)]">
+                  <Icon size={16} />
+                </span>
+              </span>
+              <span className="mt-5 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.14em] text-[color:var(--accent)]">
+                <Download size={13} />
+                Download PDF
+              </span>
+            </a>
+          );
+        })}
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/app/(app)/dashboard/[ticker]/download/page.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/download/page.tsx
@@ -1,0 +1,38 @@
+import { DashboardError } from "@/components/dashboard-chrome";
+import { loadTickerData } from "@/lib/dashboard-server";
+
+import { DownloadClient } from "./download-client";
+
+export default async function DashboardDownloadPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ ticker: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const { ticker } = await params;
+  const search = (await searchParams) ?? {};
+  const reportId = typeof search.report === "string" ? search.report : undefined;
+
+  let resolved;
+  try {
+    resolved = await loadTickerData(ticker, reportId);
+  } catch (err) {
+    const upper = decodeURIComponent(String(ticker || "")).toUpperCase();
+    return <DashboardError error={(err as Error)?.message || "Failed to load dashboard"} ticker={upper} />;
+  }
+
+  const { ticker: upper, data, reportsForTicker, resolvedReportId } = resolved;
+  if (!data) {
+    return <DashboardError error="No data" ticker={upper} />;
+  }
+
+  return (
+    <DownloadClient
+      ticker={upper}
+      data={data}
+      reportsForTicker={reportsForTicker}
+      resolvedReportId={resolvedReportId}
+    />
+  );
+}

--- a/frontend/src/app/api/artifacts/[ticker]/[kind]/route.ts
+++ b/frontend/src/app/api/artifacts/[ticker]/[kind]/route.ts
@@ -8,11 +8,26 @@ import { getDeletedReportFilterForTicker, siteRunIdFromPathLike } from "@/lib/de
 import { fetchLatestReport, fetchReportById } from "@/lib/reports-db";
 import { findLatestByFileName, outputsRoot, resolveDashboardReportPath } from "@/lib/server-outputs";
 
-const KIND_TO_FILE: Record<string, { fileName: string; contentType: string }> = {
+const KIND_TO_FILE: Record<
+  string,
+  { fileName: string; contentType: string; downloadName?: string; r2Kind?: string; fallbackFileName?: string; fallbackR2Kind?: string }
+> = {
   "analysis-pdf": { fileName: "{TICKER}_analysis.pdf", contentType: "application/pdf" },
   "analysis-txt": { fileName: "{TICKER}_analysis.txt", contentType: "text/plain; charset=utf-8" },
   "prices-explain-txt": { fileName: "{TICKER}_prices_explain.txt", contentType: "text/plain; charset=utf-8" },
   "prices-explain-pdf": { fileName: "{TICKER}_prices_explain.pdf", contentType: "application/pdf" },
+  "valuation-pdf": {
+    fileName: "{TICKER}_prices_explain.pdf",
+    downloadName: "{TICKER}_valuation.pdf",
+    r2Kind: "prices-explain-pdf",
+    contentType: "application/pdf",
+  },
+  "combined-pdf": {
+    fileName: "{TICKER}_combined.pdf",
+    fallbackFileName: "{TICKER}_analysis.pdf",
+    fallbackR2Kind: "analysis-pdf",
+    contentType: "application/pdf",
+  },
   "dashboard-json": { fileName: "{TICKER}_dashboard.json", contentType: "application/json; charset=utf-8" },
   "prices-chart": { fileName: "{TICKER}_prices_valuation.png", contentType: "image/png" },
   "trading-agents-json": { fileName: "{TICKER}_trading_agents.json", contentType: "application/json; charset=utf-8" },
@@ -118,7 +133,9 @@ async function resolveReportScopedFile(
   kind: string,
   reportId: string,
   fileName: string,
+  fallbackFileName = "",
 ): Promise<{ foundPath: string; r2Url: string | null }> {
+  const spec = KIND_TO_FILE[kind];
   const dbEnabled = isDbEnabled();
   const deletedFilter = await getDeletedReportFilterForTicker(ticker);
   if (deletedFilter.isDeleted(reportId, ticker)) return { foundPath: "", r2Url: null };
@@ -130,12 +147,15 @@ async function resolveReportScopedFile(
       if (!row) return { foundPath: "", r2Url: null };
       if (String(row.ticker || "").toUpperCase() !== ticker) return { foundPath: "", r2Url: null };
 
-      const r2Key = String(row.r2_keys?.[kind] || "").trim();
+      const r2Key = String(row.r2_keys?.[spec?.r2Kind || kind] || "").trim();
       const url = r2PublicUrl(r2Key);
       if (url) return { foundPath: "", r2Url: url };
+      const fallbackR2Key = String(row.r2_keys?.[spec?.fallbackR2Kind || ""] || "").trim();
+      const fallbackUrl = r2PublicUrl(fallbackR2Key);
+      if (fallbackUrl) return { foundPath: "", r2Url: fallbackUrl };
 
       for (const root of collectDbCandidateRoots(row)) {
-        const foundPath = resolveFromRoot(root, fileName);
+        const foundPath = resolveFromRoot(root, fileName) || (fallbackFileName ? resolveFromRoot(root, fallbackFileName) : "");
         if (foundPath) return { foundPath, r2Url: null };
       }
     } catch {
@@ -149,6 +169,9 @@ async function resolveReportScopedFile(
       return { foundPath: "", r2Url: null };
     }
     const foundPath = resolveFromRoot(path.dirname(reportPath), fileName);
+    if (!foundPath && fallbackFileName) {
+      return { foundPath: resolveFromRoot(path.dirname(reportPath), fallbackFileName), r2Url: null };
+    }
     return { foundPath, r2Url: null };
   }
 
@@ -158,12 +181,15 @@ async function resolveReportScopedFile(
     if (!row) return { foundPath: "", r2Url: null };
     if (String(row.ticker || "").toUpperCase() !== ticker) return { foundPath: "", r2Url: null };
 
-    const r2Key = String(row.r2_keys?.[kind] || "").trim();
+    const r2Key = String(row.r2_keys?.[spec?.r2Kind || kind] || "").trim();
     const url = r2PublicUrl(r2Key);
     if (url) return { foundPath: "", r2Url: url };
+    const fallbackR2Key = String(row.r2_keys?.[spec?.fallbackR2Kind || ""] || "").trim();
+    const fallbackUrl = r2PublicUrl(fallbackR2Key);
+    if (fallbackUrl) return { foundPath: "", r2Url: fallbackUrl };
 
     for (const root of collectDbCandidateRoots(row)) {
-      const foundPath = resolveFromRoot(root, fileName);
+      const foundPath = resolveFromRoot(root, fileName) || (fallbackFileName ? resolveFromRoot(root, fallbackFileName) : "");
       if (foundPath) return { foundPath, r2Url: null };
     }
   } catch {
@@ -186,12 +212,13 @@ export async function GET(
 
   const spec = KIND_TO_FILE[kind];
   const fileName = spec.fileName.replace("{TICKER}", ticker);
+  const fallbackFileName = spec.fallbackFileName?.replace("{TICKER}", ticker) || "";
   const url = new URL(request.url);
   const reportId = String(url.searchParams.get("report_id") || "").trim();
 
   let foundPath = "";
   if (reportId) {
-    const resolved = await resolveReportScopedFile(ticker, kind, reportId, fileName);
+    const resolved = await resolveReportScopedFile(ticker, kind, reportId, fileName, fallbackFileName);
     if (resolved.r2Url) {
       return NextResponse.redirect(resolved.r2Url, 302);
     }
@@ -208,9 +235,12 @@ export async function GET(
     const dbEnabled = isDbEnabled();
     try {
       const row = await fetchLatestReport(ticker);
-      const r2Key = String(row?.r2_keys?.[kind] || "").trim();
+      const r2Key = String(row?.r2_keys?.[spec.r2Kind || kind] || "").trim();
       const r2Url = r2PublicUrl(r2Key);
       if (r2Url) return NextResponse.redirect(r2Url, 302);
+      const fallbackR2Key = String(row?.r2_keys?.[spec.fallbackR2Kind || ""] || "").trim();
+      const fallbackR2Url = r2PublicUrl(fallbackR2Key);
+      if (fallbackR2Url) return NextResponse.redirect(fallbackR2Url, 302);
       if (dbEnabled && !row) {
         return NextResponse.json({ error: `${fileName} was not found.` }, { status: 404 });
       }
@@ -220,7 +250,9 @@ export async function GET(
   }
 
   const deletedFilter = await getDeletedReportFilterForTicker(ticker);
-  const latestPath = foundPath ? foundPath : findLatestByFileName(fileName)?.path || "";
+  const latestPath = foundPath
+    ? foundPath
+    : findLatestByFileName(fileName)?.path || (fallbackFileName ? findLatestByFileName(fallbackFileName)?.path : "") || "";
   const found =
     latestPath && !deletedFilter.isDeleted("", ticker, siteRunIdFromPathLike(latestPath))
       ? { path: latestPath }
@@ -238,6 +270,7 @@ export async function GET(
 
   const headers = new Headers();
   headers.set("Content-Type", spec.contentType);
-  headers.set("Content-Disposition", `attachment; filename="${path.basename(found.path)}"`);
+  const downloadName = spec.downloadName?.replace("{TICKER}", ticker) || path.basename(found.path);
+  headers.set("Content-Disposition", `attachment; filename="${downloadName}"`);
   return new NextResponse(new Uint8Array(buf), { status: 200, headers });
 }

--- a/frontend/src/components/shell/topbar.tsx
+++ b/frontend/src/components/shell/topbar.tsx
@@ -1,14 +1,13 @@
 "use client";
 
-import { Suspense, useEffect, useMemo, useRef, useState } from "react";
+import { Suspense } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
-import { BarChart3, CandlestickChart, Check, ChevronDown, Download, FileText, Menu, Scale, Users } from "lucide-react";
+import { BarChart3, CandlestickChart, Download, FileText, Menu, Scale, Users } from "lucide-react";
 import type { ComponentType } from "react";
 
 import { AuthMenu } from "@/components/shell/auth-menu";
 import { useTickerContext } from "@/components/shell/ticker-context";
-import type { ReportListItem } from "@/lib/dashboard-types";
 
 type SectionItem = { slug: string; label: string; icon: ComponentType<{ size?: number }> };
 
@@ -119,132 +118,6 @@ function SectionPills({
           );
         })}
       </div>
-      <PdfDownloadMenu activeTicker={activeTicker} reportParam={reportParam} />
     </nav>
-  );
-}
-
-function reportTimestamp(report: ReportListItem): number {
-  const raw = String(report.generated_at || report.updated_at || "");
-  const ms = Date.parse(raw);
-  return Number.isFinite(ms) ? ms : 0;
-}
-
-function fmtReportLabel(report: ReportListItem): string {
-  const ts = new Date(report.generated_at || report.updated_at || "");
-  if (!Number.isFinite(ts.getTime())) return String(report.report_id || "").slice(0, 8);
-  return ts.toLocaleString("en-US", {
-    month: "short",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-  });
-}
-
-function PdfDownloadMenu({ activeTicker, reportParam }: { activeTicker: string; reportParam: string | null }) {
-  const [open, setOpen] = useState(false);
-  const [reports, setReports] = useState<ReportListItem[]>([]);
-  const ref = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    const ticker = String(activeTicker || "").toUpperCase();
-    if (!ticker) {
-      setReports([]);
-      return;
-    }
-    let alive = true;
-    fetch("/api/reports", { cache: "no-store" })
-      .then((r) => r.json())
-      .then((json) => {
-        if (!alive) return;
-        const rows = Array.isArray(json?.reports) ? (json.reports as ReportListItem[]) : [];
-        const filtered = rows
-          .filter((row) => String(row.ticker || "").toUpperCase() === ticker)
-          .sort((a, b) => reportTimestamp(b) - reportTimestamp(a));
-        setReports(filtered);
-      })
-      .catch(() => {
-        if (alive) setReports([]);
-      });
-    return () => {
-      alive = false;
-    };
-  }, [activeTicker]);
-
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
-    };
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false);
-    };
-    document.addEventListener("mousedown", handler);
-    document.addEventListener("keydown", onKey);
-    return () => {
-      document.removeEventListener("mousedown", handler);
-      document.removeEventListener("keydown", onKey);
-    };
-  }, [open]);
-
-  const current = useMemo(() => {
-    const explicit = reportParam ? reports.find((r) => r.report_id === reportParam) : null;
-    return explicit || reports[0] || null;
-  }, [reportParam, reports]);
-
-  return (
-    <div className="relative shrink-0" ref={ref}>
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        className="inline-flex items-center gap-1.5 rounded-lg border border-white/15 bg-white/5 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-zinc-300 transition hover:border-white/30 hover:text-zinc-100"
-        aria-haspopup="listbox"
-        aria-expanded={open}
-      >
-        <Download size={12} />
-        <span>PDF</span>
-        <ChevronDown size={11} className={`transition ${open ? "rotate-180" : ""}`} />
-      </button>
-
-      {open ? (
-        <div
-          role="listbox"
-          className="absolute right-0 top-full z-40 mt-2 w-64 overflow-hidden rounded-xl border border-white/10 bg-zinc-950/95 p-1 shadow-2xl backdrop-blur"
-        >
-          {reports.length ? (
-            reports.map((report) => {
-              const selected = current ? report.report_id === current.report_id : false;
-              const href = `/api/artifacts/${encodeURIComponent(activeTicker)}/analysis-pdf?report_id=${encodeURIComponent(report.report_id)}`;
-              return (
-                <a
-                  key={report.report_id}
-                  role="option"
-                  aria-selected={selected}
-                  href={href}
-                  onClick={() => setOpen(false)}
-                  className={`flex w-full items-center justify-between gap-3 rounded-lg px-3 py-2 text-left text-xs transition ${
-                    selected
-                      ? "bg-emerald-500/10 text-emerald-100"
-                      : "text-zinc-300 hover:bg-white/5 hover:text-zinc-100"
-                  }`}
-                >
-                  <span className="font-mono">{fmtReportLabel(report)}</span>
-                  {selected ? <Check size={13} className="text-emerald-300" aria-hidden /> : null}
-                </a>
-              );
-            })
-          ) : (
-            <a
-              href={`/api/artifacts/${encodeURIComponent(activeTicker)}/analysis-pdf`}
-              onClick={() => setOpen(false)}
-              className="flex w-full items-center justify-between gap-3 rounded-lg px-3 py-2 text-left text-xs text-zinc-300 transition hover:bg-white/5 hover:text-zinc-100"
-            >
-              <span>Latest report PDF</span>
-            </a>
-          )}
-        </div>
-      ) : null}
-    </div>
   );
 }

--- a/frontend/src/components/shell/topbar.tsx
+++ b/frontend/src/components/shell/topbar.tsx
@@ -18,6 +18,7 @@ const SECTIONS: SectionItem[] = [
   { slug: "scenarios", label: "Bull vs Bear", icon: Scale },
   { slug: "technical-analysis", label: "Technical Analysis", icon: CandlestickChart },
   { slug: "dream-team", label: "Dream Team", icon: Users },
+  { slug: "download", label: "Download", icon: Download },
 ];
 
 type TopbarProps = {

--- a/frontend/src/lib/dashboard-fallback.ts
+++ b/frontend/src/lib/dashboard-fallback.ts
@@ -91,6 +91,9 @@ export function createFallbackDashboard(ticker: string): DashboardPayload {
     artifacts: {},
     downloads: {
       analysis_pdf: `/api/artifacts/${tk}/analysis-pdf`,
+      prices_explain_pdf: `/api/artifacts/${tk}/prices-explain-pdf`,
+      valuation_pdf: `/api/artifacts/${tk}/valuation-pdf`,
+      combined_pdf: `/api/artifacts/${tk}/combined-pdf`,
     },
   };
 }

--- a/frontend/src/lib/dashboard-normalize.ts
+++ b/frontend/src/lib/dashboard-normalize.ts
@@ -267,6 +267,8 @@ export function normalizePayload(
     analysis_txt: `/api/artifacts/${tk}/analysis-txt${reportQuery}`,
     prices_explain_txt: `/api/artifacts/${tk}/prices-explain-txt${reportQuery}`,
     prices_explain_pdf: `/api/artifacts/${tk}/prices-explain-pdf${reportQuery}`,
+    valuation_pdf: `/api/artifacts/${tk}/valuation-pdf${reportQuery}`,
+    combined_pdf: `/api/artifacts/${tk}/combined-pdf${reportQuery}`,
     dashboard_json: `/api/artifacts/${tk}/dashboard-json${reportQuery}`,
   };
 

--- a/frontend/src/lib/dashboard-types.ts
+++ b/frontend/src/lib/dashboard-types.ts
@@ -285,6 +285,7 @@ export type DashboardPayload = {
     prices_explain_txt?: string;
     analysis_pdf?: string;
     prices_explain_pdf?: string;
+    combined_pdf?: string;
     dashboard_json?: string;
     technical_analysis_json?: string;
     trading_agents_json?: string;
@@ -294,6 +295,8 @@ export type DashboardPayload = {
     analysis_pdf: string;
     prices_explain_txt?: string;
     prices_explain_pdf?: string;
+    valuation_pdf?: string;
+    combined_pdf?: string;
     dashboard_json?: string;
     analysis_txt?: string;
   };

--- a/src/ai_hedge/runner.py
+++ b/src/ai_hedge/runner.py
@@ -63,13 +63,22 @@ class RunArtifacts:
     r2_keys: Optional[Dict[str, str]] = None
 
 
-def _copy_combined_pdf_artifact(pdf_paths: List[Optional[Path]], output_pdf: Path) -> str:
+def _combine_pdf_artifacts(pdf_paths: List[Optional[Path]], output_pdf: Path) -> str:
     existing = [Path(p) for p in pdf_paths if p and Path(p).exists()]
     if not existing:
         return ""
 
+    from pypdf import PdfReader, PdfWriter
+
+    writer = PdfWriter()
+    for pdf_path in existing:
+        reader = PdfReader(str(pdf_path))
+        for page in reader.pages:
+            writer.add_page(page)
+
     output_pdf.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copyfile(existing[0], output_pdf)
+    with output_pdf.open("wb") as f:
+        writer.write(f)
     return str(output_pdf.resolve()) if output_pdf.exists() else ""
 
 
@@ -1556,14 +1565,6 @@ def _run_ticker_valuation_impl(
             base_analysis_text = regular_text
 
         merged_analysis_text = str(base_analysis_text or "").strip()
-        if prices_explain_txt.exists():
-            prices_section_text = prices_explain_txt.read_text(encoding="utf-8")
-            if str(prices_section_text or "").strip():
-                merged_analysis_text = _upsert_markdown_block(
-                    merged_analysis_text,
-                    f"# {ticker} Prices Explain",
-                    prices_section_text,
-                )
         if str(technical_analysis_markdown or "").strip():
             merged_analysis_text = _upsert_markdown_block(
                 merged_analysis_text,
@@ -1643,9 +1644,6 @@ def _run_ticker_valuation_impl(
             elif analysis_dst.exists():
                 analysis_text_for_pdf = analysis_dst.read_text(encoding="utf-8")
                 merged_parts.append(analysis_text_for_pdf)
-            analysis_has_prices_section = f"# {ticker} Prices Explain" in analysis_text_for_pdf
-            if prices_explain_txt.exists() and not analysis_has_prices_section:
-                merged_parts.append(prices_explain_txt.read_text(encoding="utf-8"))
 
             merged_text = "\n\n---\n\n".join(part.strip() for part in merged_parts if str(part).strip()).strip()
             sources_footer = _build_sec_sources_footer(files_dict)
@@ -1675,7 +1673,7 @@ def _run_ticker_valuation_impl(
     combined_pdf = ""
     if pdf_dst or prices_explain_pdf:
         try:
-            combined_pdf = _copy_combined_pdf_artifact(
+            combined_pdf = _combine_pdf_artifacts(
                 [
                     Path(pdf_dst) if pdf_dst else None,
                     Path(prices_explain_pdf) if prices_explain_pdf else None,

--- a/src/ai_hedge/runner.py
+++ b/src/ai_hedge/runner.py
@@ -49,6 +49,7 @@ class RunArtifacts:
     analysis_pdf: str
     prices_explain_txt: str
     prices_explain_pdf: str
+    combined_pdf: str
     dashboard_json: str
     trading_agents_json: str
     trading_agents_txt: str
@@ -60,6 +61,16 @@ class RunArtifacts:
     sec_fallback_used: bool
     sec_fallback_message: str
     r2_keys: Optional[Dict[str, str]] = None
+
+
+def _copy_combined_pdf_artifact(pdf_paths: List[Optional[Path]], output_pdf: Path) -> str:
+    existing = [Path(p) for p in pdf_paths if p and Path(p).exists()]
+    if not existing:
+        return ""
+
+    output_pdf.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(existing[0], output_pdf)
+    return str(output_pdf.resolve()) if output_pdf.exists() else ""
 
 
 
@@ -1362,33 +1373,6 @@ def _run_ticker_valuation_impl(
     except Exception:
         pass
 
-    pre_dashboard_red_flags = deterministic_red_flags(
-        price_cv=None,
-        lmil=None,
-    )
-    with _obs.llm_context(stage="dashboard.extract"):
-        qualitative_sections = generate_dashboard_sections(
-            ticker=ticker,
-            analysis_text=regular_text,
-            sec_short_text=sec_short_text,
-            financial_dict=financial_dict,
-            deterministic_red_flags=pre_dashboard_red_flags,
-            enable_llm_extractions=True,
-        )
-    _append_progress(progress_file, "Finished Dashboard Extraction (Pre-Valuation)")
-
-    try:
-        appendix_text = build_dashboard_appendix_text(ticker, qualitative_sections)
-        legacy.append_text_to_file(
-            text=appendix_text,
-            header="Dashboard Extraction Pack",
-        )
-        latest_text = legacy.load_text_from_file("analysis.txt")
-        if str(latest_text or "").strip():
-            regular_text = str(latest_text or "").strip()
-    except Exception as extraction_err:
-        notes.append(f"Dashboard extraction append failed: {extraction_err}")
-
     try:
         from .trading_agents_adapter import (
             CONTEXT_HEADER as TRADING_AGENTS_CONTEXT_HEADER,
@@ -1423,6 +1407,33 @@ def _run_ticker_valuation_impl(
         if trading_agents_executor is not None:
             trading_agents_executor.shutdown(wait=False)
     _append_progress(progress_file, "Finished TradingAgents Research Lens")
+
+    pre_dashboard_red_flags = deterministic_red_flags(
+        price_cv=None,
+        lmil=None,
+    )
+    with _obs.llm_context(stage="dashboard.extract"):
+        qualitative_sections = generate_dashboard_sections(
+            ticker=ticker,
+            analysis_text=regular_text,
+            sec_short_text=sec_short_text,
+            financial_dict=financial_dict,
+            deterministic_red_flags=pre_dashboard_red_flags,
+            enable_llm_extractions=True,
+        )
+    _append_progress(progress_file, "Finished Dashboard Extraction (Pre-Valuation)")
+
+    try:
+        appendix_text = build_dashboard_appendix_text(ticker, qualitative_sections)
+        legacy.append_text_to_file(
+            text=appendix_text,
+            header="Dashboard Extraction Pack",
+        )
+        latest_text = legacy.load_text_from_file("analysis.txt")
+        if str(latest_text or "").strip():
+            regular_text = str(latest_text or "").strip()
+    except Exception as extraction_err:
+        notes.append(f"Dashboard extraction append failed: {extraction_err}")
 
     valuation_contexts = [regular_text]
 
@@ -1661,12 +1672,26 @@ def _run_ticker_valuation_impl(
             if html_src.exists():
                 shutil.move(str(html_src), target_html)
 
+    combined_pdf = ""
+    if pdf_dst or prices_explain_pdf:
+        try:
+            combined_pdf = _copy_combined_pdf_artifact(
+                [
+                    Path(pdf_dst) if pdf_dst else None,
+                    Path(prices_explain_pdf) if prices_explain_pdf else None,
+                ],
+                out_dir / f"{ticker}_combined.pdf",
+            )
+        except Exception as combined_pdf_err:
+            notes.append(f"Combined PDF generation failed: {combined_pdf_err}")
+
     store = get_artifact_store()
     artifact_local_paths: Dict[str, Path] = {
         "analysis-txt": analysis_dst,
         "analysis-pdf": Path(pdf_dst) if pdf_dst else None,
         "prices-explain-txt": prices_explain_txt,
         "prices-explain-pdf": Path(prices_explain_pdf) if prices_explain_pdf else None,
+        "combined-pdf": Path(combined_pdf) if combined_pdf else None,
         "dashboard-json": Path(dashboard_json) if dashboard_json else None,
         "prices-chart": out_dir / f"{ticker}_prices_valuation.png",
         "revenue-chart": out_dir / f"{ticker}_revenue_valuation.png",
@@ -1707,6 +1732,7 @@ def _run_ticker_valuation_impl(
         analysis_pdf=pdf_dst,
         prices_explain_txt=str(prices_explain_txt.resolve()) if prices_explain_txt.exists() else "",
         prices_explain_pdf=prices_explain_pdf,
+        combined_pdf=combined_pdf,
         dashboard_json=dashboard_json,
         trading_agents_json=trading_agents_json,
         trading_agents_txt=trading_agents_txt,
@@ -1730,6 +1756,7 @@ def _run_ticker_valuation_impl(
         "analysis_pdf": artifacts.analysis_pdf,
         "prices_explain_txt": artifacts.prices_explain_txt,
         "prices_explain_pdf": artifacts.prices_explain_pdf,
+        "combined_pdf": artifacts.combined_pdf,
         "dashboard_json": artifacts.dashboard_json,
         "trading_agents_json": artifacts.trading_agents_json,
         "trading_agents_txt": artifacts.trading_agents_txt,

--- a/src/ai_hedge/service.py
+++ b/src/ai_hedge/service.py
@@ -1038,6 +1038,7 @@ def run_full_analysis(ticker: str, output_dir: str, run_source: str = "site") ->
         "chart_path": "",
         "prices_explain_txt": "",
         "prices_explain_pdf": "",
+        "combined_pdf": "",
         "dashboard_json": "",
         "trading_agents_json": "",
         "trading_agents_txt": "",
@@ -1084,6 +1085,7 @@ def run_full_analysis(ticker: str, output_dir: str, run_source: str = "site") ->
         chart_target = out_dir / f"{ticker_u}_prices_valuation.png"
         prices_explain_txt_target = out_dir / f"{ticker_u}_prices_explain.txt"
         prices_explain_pdf_target = out_dir / f"{ticker_u}_prices_explain.pdf"
+        combined_pdf_target = out_dir / f"{ticker_u}_combined.pdf"
         dashboard_json_target = out_dir / f"{ticker_u}_dashboard.json"
         trading_agents_json_target = out_dir / f"{ticker_u}_trading_agents.json"
         trading_agents_txt_target = out_dir / f"{ticker_u}_trading_agents.txt"
@@ -1093,6 +1095,7 @@ def run_full_analysis(ticker: str, output_dir: str, run_source: str = "site") ->
         chart_src = Path(str(full_out.get("prices_plot", "")))
         prices_explain_txt_src = Path(str(full_out.get("prices_explain_txt", "")))
         prices_explain_pdf_src = Path(str(full_out.get("prices_explain_pdf", "")))
+        combined_pdf_src = Path(str(full_out.get("combined_pdf", "")))
         dashboard_json_src = Path(str(full_out.get("dashboard_json", "")))
         trading_agents_json_src = Path(str(full_out.get("trading_agents_json", "")))
         trading_agents_txt_src = Path(str(full_out.get("trading_agents_txt", "")))
@@ -1102,6 +1105,7 @@ def run_full_analysis(ticker: str, output_dir: str, run_source: str = "site") ->
         copied_chart = _copy_artifact(chart_src, chart_target)
         copied_prices_explain_txt = _copy_artifact(prices_explain_txt_src, prices_explain_txt_target)
         copied_prices_explain_pdf = _copy_artifact(prices_explain_pdf_src, prices_explain_pdf_target)
+        copied_combined_pdf = _copy_artifact(combined_pdf_src, combined_pdf_target)
         copied_dashboard_json = _copy_artifact(dashboard_json_src, dashboard_json_target)
         copied_trading_agents_json = _copy_artifact(trading_agents_json_src, trading_agents_json_target)
         copied_trading_agents_txt = _copy_artifact(trading_agents_txt_src, trading_agents_txt_target)
@@ -1129,6 +1133,11 @@ def run_full_analysis(ticker: str, output_dir: str, run_source: str = "site") ->
         else:
             errors.append("Prices explain PDF was not generated.")
 
+        if copied_combined_pdf:
+            result["combined_pdf"] = str(combined_pdf_target)
+        else:
+            errors.append("Combined PDF was not generated.")
+
         if copied_dashboard_json:
             result["dashboard_json"] = str(dashboard_json_target)
         else:
@@ -1153,9 +1162,10 @@ def run_full_analysis(ticker: str, output_dir: str, run_source: str = "site") ->
             + int(copied_chart)
             + int(copied_prices_explain_txt)
             + int(copied_prices_explain_pdf)
+            + int(copied_combined_pdf)
             + int(copied_dashboard_json)
         )
-        if generated_count == 5:
+        if generated_count == 6:
             result["status"] = "success"
         elif generated_count > 0:
             result["status"] = "partial_success"


### PR DESCRIPTION
## Summary

- Add a dedicated dashboard Download tab with report selection and three PDF download actions: analysis, valuation, and combined.
- Add artifact routing for valuation/combined PDFs, including report-scoped resolution and older-report fallback behavior.
- Generate and normalize a combined PDF artifact for new full analysis runs, and keep TradingAgents context available before dashboard summary extraction.

## Preview

URL: pending preview workflow

## Test plan

- [x] `python -m py_compile src/ai_hedge/runner.py src/ai_hedge/service.py`
- [x] `npm run build` from `frontend/`
- [x] Local check: `http://127.0.0.1:3000/dashboard/AAPL/download` returned 200

## Notes for reviewer

- New combined downloads use `<TICKER>_combined.pdf`; because the existing analysis PDF already includes valuation/prices explain content, the generated combined artifact currently copies the full analysis PDF rather than appending the valuation PDF and duplicating that section.
- Older reports without a combined artifact fall back to the report-scoped analysis PDF.