### PR TITLE
Add competitor market review agent

### DIFF
--- a/frontend/src/app/(app)/dashboard/[ticker]/artifacts/artifacts-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/artifacts/artifacts-client.tsx
@@ -67,6 +67,7 @@ export function ArtifactsClient({
   push("technical_analysis_json", "Technical Analysis JSON", artifacts.technical_analysis_json);
   push("trading_agents_json", "TradingAgents JSON", artifacts.trading_agents_json);
   push("trading_agents_txt", "TradingAgents TXT", artifacts.trading_agents_txt);
+  push("market_review_json", "Market Review JSON", downloads.market_review_json || artifacts.market_review_json);
 
   const images = items.filter((it) => it.kind === "png");
   const docs = items.filter((it) => it.kind !== "png");

--- a/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { Store } from "lucide-react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+import { ReportChipRow } from "@/components/dashboard-chrome";
+import { SmallCopyButton } from "@/components/hedge-dashboard";
+import type { DashboardPayload, MarketReviewPayload, ReportListItem } from "@/lib/dashboard-types";
+
+type MarketClientProps = {
+  ticker: string;
+  data: DashboardPayload;
+  reportsForTicker: ReportListItem[];
+  resolvedReportId: string;
+};
+
+function markdownText(value: unknown): string {
+  return String(value || "").trim();
+}
+
+function MarkdownPanel({ title, text, emptyText }: { title: string; text: string; emptyText: string }) {
+  const body = markdownText(text);
+  return (
+    <section className="rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+        <h2 className="text-xs font-semibold uppercase tracking-[0.16em] text-zinc-300">{title}</h2>
+        <SmallCopyButton text={body} label={`Copy ${title}`} />
+      </div>
+      {body ? (
+        <div className="hib-markdown text-sm leading-relaxed text-zinc-200">
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{body}</ReactMarkdown>
+        </div>
+      ) : (
+        <p className="text-sm text-zinc-500">{emptyText}</p>
+      )}
+    </section>
+  );
+}
+
+function competitorRows(payload: MarketReviewPayload | undefined) {
+  return Array.isArray(payload?.competitors) ? payload.competitors.slice(0, 5) : [];
+}
+
+export function MarketClient({ ticker, data, reportsForTicker, resolvedReportId }: MarketClientProps) {
+  const market = data.market_review || {};
+  const rows = competitorRows(market);
+  const reviewMarkdown = markdownText(market.review_markdown);
+  const marketAgentMarkdown = markdownText(market.market_agent_markdown);
+  const status = String(market.status || "unavailable");
+  const hasReview = Boolean(reviewMarkdown || marketAgentMarkdown || rows.length);
+  const marketName = markdownText(market.name_of_market) || "Market context";
+  const error = markdownText(market.error);
+
+  return (
+    <div>
+      <ReportChipRow ticker={ticker} reports={reportsForTicker} currentReportId={resolvedReportId} />
+
+      <header className="mb-4 flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <p className="text-xs uppercase tracking-[0.2em] text-zinc-500">{ticker}</p>
+          <h1 className="font-display text-2xl text-zinc-100">Market</h1>
+          <p className="mt-1 text-sm text-zinc-400">{marketName}</p>
+        </div>
+        <div className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-zinc-950/70 px-3 py-2 text-xs text-zinc-300">
+          <Store size={14} />
+          <span className="font-semibold uppercase tracking-[0.14em]">{status}</span>
+        </div>
+      </header>
+
+      {!hasReview ? (
+        <section className="mb-4 rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
+          <h2 className="text-xs font-semibold uppercase tracking-[0.16em] text-zinc-300">Market Review</h2>
+          <p className="mt-3 text-sm text-zinc-500">
+            This report was generated before the competitor market review agent was added. Run a fresh report to build this tab.
+          </p>
+          {error ? <p className="mt-2 text-xs text-zinc-500">{error}</p> : null}
+        </section>
+      ) : null}
+
+      {rows.length ? (
+        <section className="mb-4 rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
+          <h2 className="text-xs font-semibold uppercase tracking-[0.16em] text-zinc-300">Closest Public Companies</h2>
+          <div className="mt-3 grid gap-2 md:grid-cols-2 xl:grid-cols-3">
+            {rows.map((row, idx) => (
+              <article key={`${row.ticker || "competitor"}-${idx}`} className="rounded-xl border border-white/10 bg-black/25 p-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="font-mono text-sm font-semibold text-zinc-100">{row.ticker || "N/A"}</p>
+                    <p className="text-sm text-zinc-300">{row.company_name || "Unnamed company"}</p>
+                  </div>
+                  <span className="rounded-full border border-white/10 px-2 py-0.5 text-[10px] uppercase tracking-[0.14em] text-zinc-400">
+                    #{row.rank || idx + 1}
+                  </span>
+                </div>
+                {row.similarity_rationale ? (
+                  <p className="mt-2 text-xs leading-relaxed text-zinc-400">{row.similarity_rationale}</p>
+                ) : null}
+              </article>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      <div className="grid gap-4">
+        <MarkdownPanel
+          title="Competitor Market Review"
+          text={reviewMarkdown}
+          emptyText="No competitor market review was stored for this report."
+        />
+        <MarkdownPanel
+          title="Current Market Agent"
+          text={marketAgentMarkdown}
+          emptyText="No current market-agent text was found for this report."
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(app)/dashboard/[ticker]/market/page.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/market/page.tsx
@@ -1,0 +1,38 @@
+import { DashboardError } from "@/components/dashboard-chrome";
+import { loadTickerData } from "@/lib/dashboard-server";
+
+import { MarketClient } from "./market-client";
+
+export default async function DashboardMarketPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ ticker: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const { ticker } = await params;
+  const search = (await searchParams) ?? {};
+  const reportId = typeof search.report === "string" ? search.report : undefined;
+
+  let resolved;
+  try {
+    resolved = await loadTickerData(ticker, reportId);
+  } catch (err) {
+    const upper = decodeURIComponent(String(ticker || "")).toUpperCase();
+    return <DashboardError error={(err as Error)?.message || "Failed to load dashboard"} ticker={upper} />;
+  }
+
+  const { ticker: upper, data, reportsForTicker, resolvedReportId } = resolved;
+  if (!data) {
+    return <DashboardError error="No data" ticker={upper} />;
+  }
+
+  return (
+    <MarketClient
+      ticker={upper}
+      data={data}
+      reportsForTicker={reportsForTicker}
+      resolvedReportId={resolvedReportId}
+    />
+  );
+}

--- a/frontend/src/app/api/artifacts/[ticker]/[kind]/route.ts
+++ b/frontend/src/app/api/artifacts/[ticker]/[kind]/route.ts
@@ -32,6 +32,7 @@ const KIND_TO_FILE: Record<
   "prices-chart": { fileName: "{TICKER}_prices_valuation.png", contentType: "image/png" },
   "trading-agents-json": { fileName: "{TICKER}_trading_agents.json", contentType: "application/json; charset=utf-8" },
   "trading-agents-txt": { fileName: "{TICKER}_trading_agents.txt", contentType: "text/plain; charset=utf-8" },
+  "market-review-json": { fileName: "{TICKER}_market_review.json", contentType: "application/json; charset=utf-8" },
 };
 
 function findInTree(rootDir: string, fileName: string): string | null {

--- a/frontend/src/components/shell/topbar.tsx
+++ b/frontend/src/components/shell/topbar.tsx
@@ -3,7 +3,7 @@
 import { Suspense } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
-import { BarChart3, CandlestickChart, Download, FileText, Menu, Scale, Users } from "lucide-react";
+import { BarChart3, CandlestickChart, Download, FileText, Menu, Scale, Store, Users } from "lucide-react";
 import type { ComponentType } from "react";
 
 import { AuthMenu } from "@/components/shell/auth-menu";
@@ -14,6 +14,7 @@ type SectionItem = { slug: string; label: string; icon: ComponentType<{ size?: n
 const SECTIONS: SectionItem[] = [
   { slug: "overview", label: "Overview", icon: FileText },
   { slug: "valuation", label: "Valuation", icon: BarChart3 },
+  { slug: "market", label: "Market", icon: Store },
   { slug: "scenarios", label: "Bull vs Bear", icon: Scale },
   { slug: "technical-analysis", label: "Technical Analysis", icon: CandlestickChart },
   { slug: "dream-team", label: "Dream Team", icon: Users },

--- a/frontend/src/lib/dashboard-fallback.ts
+++ b/frontend/src/lib/dashboard-fallback.ts
@@ -88,6 +88,14 @@ export function createFallbackDashboard(ticker: string): DashboardPayload {
       analysis: {},
       error: "Technical analysis is not available for this report yet.",
     },
+    market_review: {
+      status: "unavailable",
+      name_of_market: "",
+      competitors: [],
+      review_markdown: "",
+      market_agent_markdown: "",
+      error: "Market review is not available for this report yet.",
+    },
     artifacts: {},
     downloads: {
       analysis_pdf: `/api/artifacts/${tk}/analysis-pdf`,

--- a/frontend/src/lib/dashboard-normalize.ts
+++ b/frontend/src/lib/dashboard-normalize.ts
@@ -251,6 +251,11 @@ export function normalizePayload(
       ...base.artifacts,
       ...(payload.artifacts || {}),
     },
+    market_review: {
+      ...(base.market_review || {}),
+      ...(payload.market_review || {}),
+      competitors: Array.isArray(payload.market_review?.competitors) ? payload.market_review.competitors : base.market_review?.competitors || [],
+    },
     red_flag_shield: payload.red_flag_shield || [],
     dream_team: payload.dream_team || [],
     report_id: reportMeta?.reportId || payload.report_id,
@@ -270,6 +275,7 @@ export function normalizePayload(
     valuation_pdf: `/api/artifacts/${tk}/valuation-pdf${reportQuery}`,
     combined_pdf: `/api/artifacts/${tk}/combined-pdf${reportQuery}`,
     dashboard_json: `/api/artifacts/${tk}/dashboard-json${reportQuery}`,
+    market_review_json: `/api/artifacts/${tk}/market-review-json${reportQuery}`,
   };
 
   const scale = inferLegacyModelTargetScale(merged);

--- a/frontend/src/lib/dashboard-types.ts
+++ b/frontend/src/lib/dashboard-types.ts
@@ -63,6 +63,25 @@ export type TradingAgentsPayload = {
   artifact_txt?: string;
 };
 
+export type MarketReviewPayload = {
+  status?: "success" | "unavailable" | "error" | string;
+  generated_at?: string | null;
+  name_of_market?: string;
+  competitors?: Array<{
+    rank?: number;
+    ticker?: string;
+    company_name?: string;
+    similarity_rationale?: string;
+    overlap_notes?: string;
+    confidence?: string | number | null;
+    status?: string;
+    error?: string;
+  }>;
+  review_markdown?: string;
+  market_agent_markdown?: string;
+  error?: string;
+};
+
 export type DashboardPayload = {
   dashboard_version?: string;
   generated_at?: string;
@@ -261,6 +280,7 @@ export type DashboardPayload = {
     };
   };
   trading_agents?: TradingAgentsPayload;
+  market_review?: MarketReviewPayload;
   filings?: {
     annual?: {
       available?: boolean;
@@ -290,6 +310,7 @@ export type DashboardPayload = {
     technical_analysis_json?: string;
     trading_agents_json?: string;
     trading_agents_txt?: string;
+    market_review_json?: string;
   };
   downloads?: {
     analysis_pdf: string;
@@ -299,6 +320,7 @@ export type DashboardPayload = {
     combined_pdf?: string;
     dashboard_json?: string;
     analysis_txt?: string;
+    market_review_json?: string;
   };
 };
 

--- a/src/ai_hedge/competitor_market_review.py
+++ b/src/ai_hedge/competitor_market_review.py
@@ -1,0 +1,472 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import yfinance as yf
+
+
+CONTEXT_HEADER = "Competitor Market Review"
+SIDECAR_FILENAME = "market_review_payload.json"
+MAX_COMPETITORS_FOR_CONTEXT = 5
+YFINANCE_COMPETITOR_RETRIES = 3
+
+COUNTRY_SUFFIX_GUIDANCE: Dict[str, Dict[str, str]] = {
+    "israel": {
+        "suffix": ".TA",
+        "exchange": "Tel Aviv Stock Exchange",
+        "example": "TEVA.TA",
+    },
+}
+
+
+InfoFetcher = Callable[[str], Dict[str, Any]]
+AnnualTableFetcher = Callable[[str, Dict[str, Any]], str]
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _ticker_key(value: Any) -> str:
+    return re.sub(r"\s+", "", str(value or "").strip().upper())
+
+
+def parse_json_object(text: str) -> Dict[str, Any]:
+    src = str(text or "").strip()
+    if not src:
+        return {}
+    src = re.sub(r"```(?:json)?", "", src, flags=re.IGNORECASE).replace("```", "").strip()
+    if src.startswith("{") and src.endswith("}"):
+        try:
+            parsed = json.loads(src)
+            return parsed if isinstance(parsed, dict) else {}
+        except Exception:
+            pass
+
+    stack: List[str] = []
+    start_idx: Optional[int] = None
+    for idx, ch in enumerate(src):
+        if ch == "{":
+            if not stack:
+                start_idx = idx
+            stack.append(ch)
+        elif ch == "}":
+            if not stack:
+                continue
+            stack.pop()
+            if not stack and start_idx is not None:
+                candidate = src[start_idx : idx + 1]
+                try:
+                    parsed = json.loads(candidate)
+                    return parsed if isinstance(parsed, dict) else {}
+                except Exception:
+                    start_idx = None
+    return {}
+
+
+def _country_key(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def _country_suffix(country: Any) -> str:
+    guidance = COUNTRY_SUFFIX_GUIDANCE.get(_country_key(country))
+    return str(guidance.get("suffix") or "") if guidance else ""
+
+
+def _with_country_suffix(ticker: str, *, country: Any) -> str:
+    tk = _ticker_key(ticker)
+    suffix = _country_suffix(country)
+    if suffix and tk and "." not in tk:
+        return f"{tk}{suffix.upper()}"
+    return tk
+
+
+def normalize_competitors(
+    payload: Dict[str, Any],
+    *,
+    original_ticker: str,
+) -> List[Dict[str, Any]]:
+    raw_items = payload.get("competitors")
+    if not isinstance(raw_items, list):
+        raw_items = payload.get("companies")
+    if not isinstance(raw_items, list):
+        return []
+
+    original = _ticker_key(original_ticker)
+    seen: set[str] = set()
+    normalized: List[Dict[str, Any]] = []
+    for item in raw_items:
+        if not isinstance(item, dict):
+            continue
+        country = str(item.get("country") or item.get("listing_country") or "").strip()
+        ticker = _with_country_suffix(item.get("ticker") or item.get("symbol"), country=country)
+        if not ticker or ticker == original or ticker in seen:
+            continue
+        seen.add(ticker)
+        normalized.append(
+            {
+                "rank": len(normalized) + 1,
+                "ticker": ticker,
+                "company_name": str(item.get("company_name") or item.get("name") or "").strip(),
+                "similarity_rationale": str(item.get("similarity_rationale") or item.get("rationale") or "").strip(),
+                "overlap_notes": str(item.get("overlap_notes") or item.get("product_overlap") or "").strip(),
+                "country": country,
+                "exchange": str(item.get("exchange") or item.get("listing_exchange") or "").strip(),
+                "confidence": item.get("confidence"),
+            }
+        )
+    return normalized
+
+
+def _compact_info_for_llm(info: Dict[str, Any]) -> Dict[str, Any]:
+    keys = [
+        "shortName",
+        "longName",
+        "symbol",
+        "quoteType",
+        "industry",
+        "sector",
+        "country",
+        "currency",
+        "financialCurrency",
+        "original_price_currency",
+        "original_financial_currency",
+        "marketCap",
+        "enterpriseValue",
+        "totalRevenue",
+        "revenueGrowth",
+        "grossMargins",
+        "operatingMargins",
+        "profitMargins",
+        "ebitdaMargins",
+        "netIncomeToCommon",
+        "trailingPE",
+        "forwardPE",
+        "priceToSalesTrailing12Months",
+        "enterpriseToRevenue",
+        "enterpriseToEbitda",
+        "returnOnAssets",
+        "returnOnEquity",
+        "totalDebt",
+        "totalCash",
+        "fullTimeEmployees",
+        "website",
+        "longBusinessSummary",
+    ]
+    return {key: info.get(key) for key in keys if key in info}
+
+
+def _default_info_fetcher(ticker: str) -> Dict[str, Any]:
+    from . import legacy_port as legacy
+
+    return legacy.get_info_data(ticker)
+
+
+def _default_annual_table_fetcher(ticker: str, info_data: Dict[str, Any]) -> str:
+    from . import legacy_port as legacy
+
+    info = info_data.get("info") if isinstance(info_data, dict) else {}
+    if not isinstance(info, dict):
+        return "### Annual Income Statement\nNot available\n\n"
+    rate = info.get("financial_currency_to_USD", info.get("financial_currency_to_usd", 1))
+    try:
+        rate = float(rate) if rate else 1.0
+    except Exception:
+        rate = 1.0
+    try:
+        csv_table = legacy.df_to_llm_csv(yf.Ticker(ticker).financials, rate)
+    except Exception:
+        csv_table = ""
+    if not str(csv_table or "").strip():
+        return "### Annual Income Statement\nNot available\n\n"
+    return f"### Annual Income Statement\n```csv\n{csv_table}```\n\n"
+
+
+def _valid_info_data(info_data: Dict[str, Any]) -> bool:
+    if not isinstance(info_data, dict):
+        return False
+    info = info_data.get("info")
+    if not isinstance(info, dict):
+        return False
+    name = str(info.get("shortName") or info.get("longName") or "").strip()
+    symbol = str(info.get("symbol") or "").strip()
+    quote_type = str(info.get("quoteType") or "").strip()
+    return bool(name or symbol or quote_type)
+
+
+def _fetch_info_with_retries(ticker: str, fetch_info: InfoFetcher, *, attempts: int) -> Dict[str, Any]:
+    last_error: Optional[Exception] = None
+    for _ in range(max(1, int(attempts))):
+        try:
+            info_data = fetch_info(ticker)
+            if _valid_info_data(info_data):
+                return info_data
+            last_error = RuntimeError("yfinance returned no valid company info")
+        except Exception as exc:
+            last_error = exc
+    raise RuntimeError(f"Invalid or unavailable competitor ticker {ticker}: {last_error}")
+
+
+def _fetch_annual_with_retries(
+    ticker: str,
+    info_data: Dict[str, Any],
+    fetch_annual: AnnualTableFetcher,
+    *,
+    attempts: int,
+) -> str:
+    last_error: Optional[Exception] = None
+    for _ in range(max(1, int(attempts))):
+        try:
+            return fetch_annual(ticker, info_data)
+        except Exception as exc:
+            last_error = exc
+    raise RuntimeError(f"Annual financial table unavailable for {ticker}: {last_error}")
+
+
+def build_discovery_prompt(ticker: str, info: Dict[str, Any]) -> str:
+    original_country = str(info.get("country") or "").strip()
+    suffix_guidance = COUNTRY_SUFFIX_GUIDANCE.get(_country_key(original_country))
+    local_guidance = ""
+    if original_country and _country_key(original_country) not in {"united states", "usa", "us"}:
+        if suffix_guidance:
+            local_guidance = (
+                f"The original company is from {original_country}. Try to include public companies from "
+                f"{original_country} and public companies from the United States. For {original_country}, use Yahoo "
+                f"Finance tickers with the {suffix_guidance['suffix']} suffix for {suffix_guidance['exchange']} "
+                f"listings, for example {suffix_guidance['example']}."
+            )
+        else:
+            local_guidance = (
+                f"The original company is from {original_country}. Try to include public companies from "
+                f"{original_country} and public companies from the United States. Use Yahoo Finance-compatible "
+                "exchange suffixes for non-US listings."
+            )
+    return f"""
+You are a senior public-equity industry analyst.
+
+Your task is to identify public companies most similar to the original company.
+Use the company's business description, sector, industry, products, customers, geography, and revenue model.
+
+Original ticker: {ticker}
+Original country: {original_country or "Unknown"}
+Original company info_dict["info"]:
+{json.dumps(info, ensure_ascii=False, default=str)}
+
+Return ONLY valid JSON with this exact shape:
+{{
+  "name_of_market": "specific market name shared by the original company and the ranked companies",
+  "competitors": [
+    {{
+      "rank": 1,
+      "ticker": "PUBLIC_TICKER",
+      "company_name": "Company name",
+      "country": "listing country",
+      "exchange": "listing exchange",
+      "similarity_rationale": "why this public company is similar",
+      "overlap_notes": "products, customers, or business model overlap",
+      "confidence": "high|medium|low"
+    }}
+  ]
+}}
+
+Rules:
+- Do not include the original company.
+- Prefer publicly traded companies with usable exchange tickers.
+- Rank from most similar to least similar.
+- Return a ranked list of all strong public-company matches you can identify. It is okay to return more than 5.
+- The next stage will use only the top 5 ranked companies for financial enrichment, so put the best matches first.
+- For non-US companies, use Yahoo Finance-compatible exchange suffixes.
+- {local_guidance or "For US companies, use the normal US ticker without an exchange suffix."}
+- Keep the market name specific, not a broad sector label.
+""".strip()
+
+
+def discover_competitors(
+    *,
+    ticker: str,
+    info_dict: Dict[str, Any],
+    api_key: str,
+) -> Dict[str, Any]:
+    from . import legacy_port as legacy
+
+    info = info_dict.get("info") if isinstance(info_dict, dict) else {}
+    if not isinstance(info, dict):
+        info = {}
+    raw = legacy.deepseek_simple_text(
+        api_key=api_key,
+        prompt=build_discovery_prompt(ticker, info),
+        model="deepseek-reasoner",
+        temperature=0.1,
+        short_answer=False,
+    )
+    parsed = parse_json_object(raw)
+    competitors = normalize_competitors(parsed, original_ticker=ticker)
+    return {
+        "name_of_market": str(parsed.get("name_of_market") or "").strip(),
+        "competitors": competitors,
+        "raw_response": raw,
+    }
+
+
+def collect_competitor_context(
+    *,
+    discovery: Dict[str, Any],
+    original_ticker: str,
+    info_fetcher: Optional[InfoFetcher] = None,
+    annual_table_fetcher: Optional[AnnualTableFetcher] = None,
+    limit: int = MAX_COMPETITORS_FOR_CONTEXT,
+    retries: int = YFINANCE_COMPETITOR_RETRIES,
+) -> List[Dict[str, Any]]:
+    fetch_info = info_fetcher or _default_info_fetcher
+    fetch_annual = annual_table_fetcher or _default_annual_table_fetcher
+    competitors = normalize_competitors(discovery, original_ticker=original_ticker)
+    out: List[Dict[str, Any]] = []
+
+    for competitor in competitors[: max(0, int(limit))]:
+        ticker = str(competitor.get("ticker") or "").strip().upper()
+        try:
+            info_data = _fetch_info_with_retries(ticker, fetch_info, attempts=retries)
+            info = info_data.get("info") if isinstance(info_data, dict) else {}
+            entry: Dict[str, Any] = {
+                **competitor,
+                "status": "success",
+                "info": {},
+                "annual_financials": "### Annual Income Statement\nNot available\n\n",
+                "error": "",
+            }
+            if isinstance(info, dict):
+                entry["info"] = _compact_info_for_llm(info)
+                entry["company_name"] = entry.get("company_name") or str(
+                    info.get("shortName") or info.get("longName") or ""
+                ).strip()
+            entry["annual_financials"] = _fetch_annual_with_retries(
+                ticker,
+                info_data if isinstance(info_data, dict) else {},
+                fetch_annual,
+                attempts=retries,
+            )
+            out.append(entry)
+        except Exception as exc:
+            print(f"[market_review] Skipping competitor {ticker}: {type(exc).__name__}: {str(exc)[:300]}")
+    return out
+
+
+def build_review_prompt(payload: Dict[str, Any]) -> str:
+    return f"""
+You are a senior buy-side market analyst writing a dashboard-ready market review.
+
+You receive:
+- the original ticker
+- the market name
+- ranked public competitors
+- normalized competitor info produced by the same info engine used for the original company
+- annual income-statement tables produced by the same financial table engine used for the original company
+
+Payload:
+{json.dumps(payload, ensure_ascii=False, default=str)}
+
+Write a comprehensive market review in Markdown for a tab called "Market".
+
+Required sections:
+## Market Definition
+## Ranked Competitor Map
+## Financial Comparison
+## Product And Customer Overlap
+## Competitive Positioning
+## Market Structure And Risks
+## Valuation Implications
+
+Rules:
+- Focus on what matters to investors and valuation.
+- Use the competitor financials when available; explicitly say when data is unavailable.
+- Compare business model, scale, profitability, growth, pricing power, cyclicality, and competitive intensity.
+- Do not make buy/sell/hold recommendations.
+- Do not include raw JSON.
+""".strip()
+
+
+def generate_market_review(
+    *,
+    payload: Dict[str, Any],
+    api_key: str,
+) -> str:
+    from . import legacy_port as legacy
+
+    return legacy.deepseek_simple_text(
+        api_key=api_key,
+        prompt=build_review_prompt(payload),
+        model="deepseek-reasoner",
+        temperature=0.15,
+        short_answer=False,
+    ).strip()
+
+
+def build_market_review_markdown(payload: Dict[str, Any]) -> str:
+    review = str(payload.get("review_markdown") or "").strip()
+    if review:
+        return review
+    status = str(payload.get("status") or "unavailable")
+    err = str(payload.get("error") or "").strip()
+    if err:
+        return f"Competitor market review is {status}: {err}"
+    return "Competitor market review is unavailable for this report."
+
+
+def write_sidecar(payload: Dict[str, Any], path: str | Path = SIDECAR_FILENAME) -> str:
+    target = Path(path)
+    target.write_text(json.dumps(payload, ensure_ascii=False, indent=2, default=str), encoding="utf-8")
+    return str(target.resolve())
+
+
+def run_competitor_market_review(
+    *,
+    ticker: str,
+    info_dict: Dict[str, Any],
+    api_key: Optional[str] = None,
+) -> Dict[str, Any]:
+    key = str(api_key if api_key is not None else os.getenv("DEEPSEEK_API_KEY", "")).strip()
+    if not key:
+        raise RuntimeError("Missing DEEPSEEK_API_KEY for competitor market review.")
+
+    discovery = discover_competitors(ticker=ticker, info_dict=info_dict, api_key=key)
+    competitors = collect_competitor_context(discovery=discovery, original_ticker=ticker)
+    review_payload = {
+        "ticker": ticker.upper().strip(),
+        "name_of_market": discovery.get("name_of_market") or "",
+        "competitors": competitors,
+    }
+    review_markdown = generate_market_review(payload=review_payload, api_key=key)
+    return {
+        "status": "success",
+        "ticker": ticker.upper().strip(),
+        "generated_at": _utc_now(),
+        "name_of_market": discovery.get("name_of_market") or "",
+        "competitors": competitors,
+        "review_markdown": review_markdown,
+        "error": "",
+    }
+
+
+def competitor_market_review_result(ticker: str, info_dict: Dict[str, Any]) -> Tuple[str, str]:
+    try:
+        payload = run_competitor_market_review(ticker=ticker, info_dict=info_dict)
+    except Exception as exc:
+        payload = {
+            "status": "unavailable",
+            "ticker": ticker.upper().strip(),
+            "generated_at": _utc_now(),
+            "name_of_market": "",
+            "competitors": [],
+            "review_markdown": "",
+            "error": f"{type(exc).__name__}: {str(exc)[:300]}",
+        }
+    try:
+        write_sidecar(payload)
+    except Exception:
+        pass
+    return CONTEXT_HEADER, build_market_review_markdown(payload)

--- a/src/ai_hedge/dashboard.py
+++ b/src/ai_hedge/dashboard.py
@@ -283,6 +283,55 @@ def _is_reason_key(key: str) -> bool:
     return key_l == "step_by_step_analysis" or "rationale" in key_l or "reason" in key_l
 
 
+def _extract_analysis_section(text: str, header: str) -> str:
+    src = str(text or "").replace("\r\n", "\n")
+    if not src.strip():
+        return ""
+    target = str(header or "").strip().rstrip(":").lower()
+    lines = src.split("\n")
+    start: Optional[int] = None
+    for idx, line in enumerate(lines):
+        match = re.match(r"^\s*#\s+(.+?)\s*:?\s*$", line)
+        if match and match.group(1).strip().rstrip(":").lower() == target:
+            start = idx + 1
+            break
+    if start is None:
+        return ""
+    end = len(lines)
+    for idx in range(start, len(lines)):
+        if re.match(r"^\s*#\s+.+?\s*:?\s*$", lines[idx]):
+            end = idx
+            break
+    return "\n".join(lines[start:end]).strip()
+
+
+def _normalize_market_review_payload(
+    payload: Optional[Dict[str, Any]],
+    *,
+    analysis_text: str,
+) -> Dict[str, Any]:
+    raw = payload if isinstance(payload, dict) else {}
+    competitor_text = str(raw.get("review_markdown") or "").strip()
+    if not competitor_text:
+        competitor_text = _extract_analysis_section(analysis_text, "Competitor Market Review")
+    market_agent_text = str(raw.get("market_agent_markdown") or "").strip()
+    if not market_agent_text:
+        market_agent_text = _extract_analysis_section(analysis_text, "Market Analysis")
+    competitors = raw.get("competitors")
+    if not isinstance(competitors, list):
+        competitors = []
+    status = str(raw.get("status") or ("success" if competitor_text else "unavailable")).strip() or "unavailable"
+    return {
+        "status": status,
+        "generated_at": raw.get("generated_at"),
+        "name_of_market": str(raw.get("name_of_market") or "").strip(),
+        "competitors": competitors,
+        "review_markdown": competitor_text,
+        "market_agent_markdown": market_agent_text,
+        "error": str(raw.get("error") or "").strip(),
+    }
+
+
 def _as_readable_text(value: Any) -> str:
     if value is None:
         return ""
@@ -1406,6 +1455,7 @@ def build_dashboard_payload(
     artifacts: Dict[str, str],
     technical_analysis: Optional[Dict[str, Any]] = None,
     trading_agents: Optional[Dict[str, Any]] = None,
+    market_review: Optional[Dict[str, Any]] = None,
     analysis_duration_minutes: Optional[float] = None,
     qualitative_sections: Optional[Dict[str, Any]] = None,
     filings: Optional[Dict[str, Any]] = None,
@@ -1650,6 +1700,7 @@ def build_dashboard_payload(
         },
         "technical_analysis": technical_analysis if isinstance(technical_analysis, dict) else {},
         "trading_agents": trading_agents if isinstance(trading_agents, dict) else {},
+        "market_review": _normalize_market_review_payload(market_review, analysis_text=analysis_text),
         "filings": filings if isinstance(filings, dict) else {},
         "artifacts": artifacts,
     }

--- a/src/ai_hedge/legacy_port.py
+++ b/src/ai_hedge/legacy_port.py
@@ -2896,10 +2896,13 @@ def make_analysis_file(
         print("No valid ticker")
         return info_dict, files_dict, financial_dict, variables_dict
 
+    from .competitor_market_review import competitor_market_review_result
+
     parallel_tasks: List[Tuple[Callable[..., Any], tuple, dict]] = [
         (what_it_does_insights_result, (info_dict,), {}),
         (info_insights_result, (info_dict,), {}),
         (news_insights_result, (info_dict,), {}),
+        (competitor_market_review_result, (ticker, info_dict), {}),
         (financials_annual_insights_result, (financial_dict, info_dict), {}),
         (financials_quarterly_insights_result, (financial_dict, info_dict), {}),
         (financials_all_insights_result, (financial_dict, info_dict), {}),

--- a/src/ai_hedge/runner.py
+++ b/src/ai_hedge/runner.py
@@ -53,6 +53,7 @@ class RunArtifacts:
     dashboard_json: str
     trading_agents_json: str
     trading_agents_txt: str
+    market_review_json: str
     notes: List[str]
     current_revenue: Optional[float]
     target_revenue: Optional[float]
@@ -1314,6 +1315,12 @@ def _run_ticker_valuation_impl(
     run_started = time.perf_counter()
 
     legacy.ticker = ticker
+    try:
+        from .competitor_market_review import SIDECAR_FILENAME as MARKET_REVIEW_SIDECAR
+
+        Path(MARKET_REVIEW_SIDECAR).unlink(missing_ok=True)
+    except Exception:
+        pass
 
     with _obs.llm_context(stage="analyst"):
         info_dict, files_dict, financial_dict, variables_dict = legacy.make_analysis_file(
@@ -1327,6 +1334,29 @@ def _run_ticker_valuation_impl(
     text = legacy.load_text_from_file("analysis.txt")
     regular_text = str(text or "").strip()
     notes: List[str] = []
+    market_review_payload: Dict[str, Any] = {}
+    market_review_json = ""
+    try:
+        from .competitor_market_review import SIDECAR_FILENAME as MARKET_REVIEW_SIDECAR
+
+        market_review_sidecar = Path(MARKET_REVIEW_SIDECAR)
+        if market_review_sidecar.exists():
+            market_review_payload = json.loads(market_review_sidecar.read_text(encoding="utf-8"))
+            if isinstance(market_review_payload, dict):
+                market_review_target = out_dir / f"{ticker}_market_review.json"
+                market_review_target.write_text(
+                    json.dumps(market_review_payload, ensure_ascii=False, indent=2),
+                    encoding="utf-8",
+                )
+                market_review_json = str(market_review_target.resolve())
+            else:
+                market_review_payload = {}
+    except Exception as market_review_err:
+        market_review_payload = {
+            "status": "unavailable",
+            "error": str(market_review_err),
+        }
+        notes.append(f"Competitor market review payload load failed: {market_review_err}")
     trading_agents_payload: Dict[str, Any] = {}
     trading_agents_context = ""
     trading_agents_json = ""
@@ -1665,6 +1695,7 @@ def _run_ticker_valuation_impl(
             qualitative_sections=qualitative_sections,
             technical_analysis=technical_analysis_payload,
             trading_agents=trading_agents_payload,
+            market_review=market_review_payload,
             filings=filing_sources,
             enable_llm_extractions=True,
             analysis_duration_minutes=analysis_duration_minutes,
@@ -1677,6 +1708,7 @@ def _run_ticker_valuation_impl(
                 "technical_analysis_json": technical_analysis_json,
                 "trading_agents_json": trading_agents_json,
                 "trading_agents_txt": trading_agents_txt,
+                "market_review_json": market_review_json,
             },
         )
         dashboard_json = write_dashboard_payload(out_dir / f"{ticker}_dashboard.json", dashboard_payload)
@@ -1780,6 +1812,7 @@ def _run_ticker_valuation_impl(
         "net-income-chart": out_dir / f"{ticker}_net_income_valuation.png",
         "trading-agents-json": Path(trading_agents_json) if trading_agents_json else None,
         "trading-agents-txt": Path(trading_agents_txt) if trading_agents_txt else None,
+        "market-review-json": Path(market_review_json) if market_review_json else None,
     }
     generated_at_iso = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     collected_keys: Dict[str, str] = {}
@@ -1818,6 +1851,7 @@ def _run_ticker_valuation_impl(
         dashboard_json=dashboard_json,
         trading_agents_json=trading_agents_json,
         trading_agents_txt=trading_agents_txt,
+        market_review_json=market_review_json,
         notes=notes,
         current_revenue=current_revenue,
         target_revenue=target_revenue,
@@ -1842,6 +1876,7 @@ def _run_ticker_valuation_impl(
         "dashboard_json": artifacts.dashboard_json,
         "trading_agents_json": artifacts.trading_agents_json,
         "trading_agents_txt": artifacts.trading_agents_txt,
+        "market_review_json": artifacts.market_review_json,
         "notes": artifacts.notes,
         "current_revenue": artifacts.current_revenue,
         "target_revenue": artifacts.target_revenue,

--- a/src/ai_hedge/service.py
+++ b/src/ai_hedge/service.py
@@ -1042,6 +1042,7 @@ def run_full_analysis(ticker: str, output_dir: str, run_source: str = "site") ->
         "dashboard_json": "",
         "trading_agents_json": "",
         "trading_agents_txt": "",
+        "market_review_json": "",
         "errors": errors,
         "r2_keys": None,
     }
@@ -1089,6 +1090,7 @@ def run_full_analysis(ticker: str, output_dir: str, run_source: str = "site") ->
         dashboard_json_target = out_dir / f"{ticker_u}_dashboard.json"
         trading_agents_json_target = out_dir / f"{ticker_u}_trading_agents.json"
         trading_agents_txt_target = out_dir / f"{ticker_u}_trading_agents.txt"
+        market_review_json_target = out_dir / f"{ticker_u}_market_review.json"
 
         analysis_src = Path(str(full_out.get("analysis_txt", "")))
         pdf_src = Path(str(full_out.get("analysis_pdf", "")))
@@ -1099,6 +1101,7 @@ def run_full_analysis(ticker: str, output_dir: str, run_source: str = "site") ->
         dashboard_json_src = Path(str(full_out.get("dashboard_json", "")))
         trading_agents_json_src = Path(str(full_out.get("trading_agents_json", "")))
         trading_agents_txt_src = Path(str(full_out.get("trading_agents_txt", "")))
+        market_review_json_src = Path(str(full_out.get("market_review_json", "")))
 
         copied_analysis = _copy_artifact(analysis_src, analysis_target)
         copied_pdf = _copy_artifact(pdf_src, pdf_target)
@@ -1109,6 +1112,7 @@ def run_full_analysis(ticker: str, output_dir: str, run_source: str = "site") ->
         copied_dashboard_json = _copy_artifact(dashboard_json_src, dashboard_json_target)
         copied_trading_agents_json = _copy_artifact(trading_agents_json_src, trading_agents_json_target)
         copied_trading_agents_txt = _copy_artifact(trading_agents_txt_src, trading_agents_txt_target)
+        copied_market_review_json = _copy_artifact(market_review_json_src, market_review_json_target)
 
         if copied_analysis:
             result["analysis_txt"] = str(analysis_target)
@@ -1148,6 +1152,9 @@ def run_full_analysis(ticker: str, output_dir: str, run_source: str = "site") ->
 
         if copied_trading_agents_txt:
             result["trading_agents_txt"] = str(trading_agents_txt_target)
+
+        if copied_market_review_json:
+            result["market_review_json"] = str(market_review_json_target)
 
         result["current_revenue"] = full_out.get("current_revenue")
         result["target_revenue"] = full_out.get("target_revenue")

--- a/tests/test_competitor_market_review.py
+++ b/tests/test_competitor_market_review.py
@@ -1,0 +1,168 @@
+import json
+
+import pandas as pd
+
+from ai_hedge import competitor_market_review as cmr
+
+
+def test_parse_json_object_handles_fenced_response():
+    parsed = cmr.parse_json_object(
+        'Here you go:\n```json\n{"name_of_market":"AI chips","competitors":[{"ticker":"AMD"}]}\n```'
+    )
+    assert parsed["name_of_market"] == "AI chips"
+    assert parsed["competitors"][0]["ticker"] == "AMD"
+
+
+def test_normalize_competitors_excludes_original_and_duplicates():
+    payload = {
+        "competitors": [
+            {"ticker": "AAPL", "company_name": "Apple"},
+            {"ticker": "MSFT", "company_name": "Microsoft"},
+            {"ticker": "msft", "company_name": "Microsoft duplicate"},
+            {"symbol": "GOOG", "name": "Alphabet"},
+        ]
+    }
+    out = cmr.normalize_competitors(payload, original_ticker="AAPL")
+    assert [row["ticker"] for row in out] == ["MSFT", "GOOG"]
+    assert out[0]["rank"] == 1
+
+
+def test_normalize_competitors_keeps_more_than_five_and_adds_israeli_suffix():
+    payload = {
+        "competitors": [
+            {"ticker": "ONE", "country": "Israel", "company_name": "One"},
+            {"ticker": "TWO.TA", "country": "Israel", "company_name": "Two"},
+            {"ticker": "US1", "country": "United States", "company_name": "US 1"},
+            {"ticker": "US2", "country": "United States", "company_name": "US 2"},
+            {"ticker": "US3", "country": "United States", "company_name": "US 3"},
+            {"ticker": "US4", "country": "United States", "company_name": "US 4"},
+        ]
+    }
+    out = cmr.normalize_competitors(payload, original_ticker="MAIN")
+    assert [row["ticker"] for row in out] == ["ONE.TA", "TWO.TA", "US1", "US2", "US3", "US4"]
+
+
+def test_discovery_prompt_allows_more_than_five_and_israeli_suffix():
+    prompt = cmr.build_discovery_prompt("TEST.TA", {"country": "Israel", "longBusinessSummary": "software"})
+    assert "okay to return more than 5" in prompt
+    assert "top 5 ranked companies" in prompt
+    assert ".TA" in prompt
+    assert "United States" in prompt
+
+
+def test_collect_competitor_context_caps_to_five_and_uses_info_engine():
+    discovery = {
+        "competitors": [
+            {"ticker": f"T{i}", "company_name": f"Company {i}"}
+            for i in range(1, 8)
+        ]
+    }
+    info_calls = []
+    annual_calls = []
+
+    def fake_info(ticker):
+        info_calls.append(ticker)
+        return {
+            "info": {
+                "shortName": f"{ticker} Inc",
+                "marketCap": 123,
+                "financial_currency_to_USD": 2,
+                "longBusinessSummary": "summary",
+            }
+        }
+
+    def fake_annual(ticker, info_data):
+        annual_calls.append((ticker, info_data["info"]["financial_currency_to_USD"]))
+        return "### Annual Income Statement\n```csv\nRevenue\n```\n\n"
+
+    out = cmr.collect_competitor_context(
+        discovery=discovery,
+        original_ticker="MAIN",
+        info_fetcher=fake_info,
+        annual_table_fetcher=fake_annual,
+    )
+
+    assert [row["ticker"] for row in out] == ["T1", "T2", "T3", "T4", "T5"]
+    assert info_calls == ["T1", "T2", "T3", "T4", "T5"]
+    assert annual_calls == [("T1", 2), ("T2", 2), ("T3", 2), ("T4", 2), ("T5", 2)]
+    assert out[0]["info"]["marketCap"] == 123
+
+
+def test_collect_competitor_context_retries_invalid_ticker_then_skips():
+    discovery = {
+        "competitors": [
+            {"ticker": "BAD", "company_name": "Bad"},
+            {"ticker": "GOOD", "company_name": "Good"},
+        ]
+    }
+    calls = []
+
+    def fake_info(ticker):
+        calls.append(ticker)
+        if ticker == "BAD":
+            return {"info": "Not available"}
+        return {"info": {"shortName": "Good Inc", "symbol": "GOOD", "financial_currency_to_USD": 1}}
+
+    def fake_annual(ticker, _info_data):
+        return f"### Annual Income Statement\n```csv\n{ticker}\n```\n\n"
+
+    out = cmr.collect_competitor_context(
+        discovery=discovery,
+        original_ticker="MAIN",
+        info_fetcher=fake_info,
+        annual_table_fetcher=fake_annual,
+        retries=3,
+    )
+
+    assert [row["ticker"] for row in out] == ["GOOD"]
+    assert calls == ["BAD", "BAD", "BAD", "GOOD"]
+
+
+def test_default_annual_table_fetcher_uses_financials_and_csv_engine(monkeypatch):
+    calls = {}
+
+    class FakeTicker:
+        def __init__(self, ticker):
+            calls["ticker"] = ticker
+
+        @property
+        def financials(self):
+            calls["financials"] = True
+            return pd.DataFrame({"2025": [100]}, index=["Revenue"])
+
+        @property
+        def balance_sheet(self):
+            raise AssertionError("balance sheet should not be fetched")
+
+        @property
+        def cashflow(self):
+            raise AssertionError("cashflow should not be fetched")
+
+    def fake_csv(df, scale):
+        calls["scale"] = scale
+        return "Reporting_Period,Revenue\n2025,50"
+
+    monkeypatch.setattr(cmr.yf, "Ticker", FakeTicker)
+    monkeypatch.setattr("ai_hedge.legacy_port.df_to_llm_csv", fake_csv)
+
+    table = cmr._default_annual_table_fetcher("TEST", {"info": {"financial_currency_to_USD": 2}})
+
+    assert calls == {"ticker": "TEST", "financials": True, "scale": 2.0}
+    assert "Annual Income Statement" in table
+    assert "Reporting_Period,Revenue" in table
+
+
+def test_result_degrades_to_unavailable_and_writes_sidecar(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    def fail_run(**_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(cmr, "run_competitor_market_review", fail_run)
+    header, body = cmr.competitor_market_review_result("TEST", {"info": {}})
+
+    assert header == cmr.CONTEXT_HEADER
+    assert "unavailable" in body
+    payload = json.loads((tmp_path / cmr.SIDECAR_FILENAME).read_text(encoding="utf-8"))
+    assert payload["status"] == "unavailable"
+    assert "boom" in payload["error"]


### PR DESCRIPTION
## Summary

- Adds a competitor market review agent that discovers ranked public peers, enriches the top 5 through the existing info/currency/table engine, and writes the review before the existing market analyst.
- Adds a top-level Market dashboard route with copyable competitor review and current market-agent text.
- Stores and exposes market review JSON artifacts while keeping old reports safe with an unavailable/empty state.

## Preview

URL: pending — frontend change; preview workflow should deploy and post the PR preview URL.

## Test plan

- [x] `PYTHONPATH=src python -m pytest tests/test_competitor_market_review.py -q --basetemp=.codex-pytest-market-review-pr`
- [x] `python -m py_compile src/ai_hedge/competitor_market_review.py src/ai_hedge/legacy_port.py src/ai_hedge/runner.py src/ai_hedge/dashboard.py src/ai_hedge/service.py`
- [x] `cd frontend && npm run build`

## Notes for reviewer

- The first LLM can return more than 5 competitors; only the enrichment stage takes the top 5.
- Invalid competitor tickers retry up to 3 times and are skipped instead of failing the report.
- Non-US discovery guidance is suffix-aware, including `.TA` for Israeli companies.
- Full live LLM report generation was not run locally.