### PR TITLE
Enhance market tab review payload and rendering

### DIFF
--- a/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
@@ -30,6 +30,17 @@ function markdownText(value: unknown): string {
   return String(value || "").trim();
 }
 
+function normalizeTableMissingValues(text: string): string {
+  return String(text || "")
+    .split("\n")
+    .map((line) => (
+      line.includes("|")
+        ? line.replace(/(\|\s*)(?:n\/a|N\/A)(\s*(?=\|))/g, "$1-$2")
+        : line
+    ))
+    .join("\n");
+}
+
 function numeric(value: unknown): number | null {
   const n = Number(value);
   return Number.isFinite(n) ? n : null;
@@ -37,7 +48,7 @@ function numeric(value: unknown): number | null {
 
 function formatLarge(value: unknown): string {
   const n = numeric(value);
-  if (n === null) return "n/a";
+  if (n === null) return "-";
   const abs = Math.abs(n);
   if (abs >= 1_000_000_000_000) return `${(n / 1_000_000_000_000).toFixed(1)}T`;
   if (abs >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`;
@@ -47,14 +58,14 @@ function formatLarge(value: unknown): string {
 
 function formatPercent(value: unknown): string {
   const n = numeric(value);
-  if (n === null) return "n/a";
+  if (n === null) return "-";
   const pct = Math.abs(n) <= 1 ? n * 100 : n;
   return `${pct.toFixed(1)}%`;
 }
 
 function formatMultiple(value: unknown): string {
   const n = numeric(value);
-  if (n === null || n <= 0) return "n/a";
+  if (n === null || n <= 0) return "-";
   return `${n.toFixed(1)}x`;
 }
 
@@ -176,10 +187,11 @@ function sectionMeta(title: string) {
 }
 
 function MarketMarkdown({ text }: { text: string }) {
+  const normalized = normalizeTableMissingValues(text);
   return (
     <div className="hib-markdown hib-market-markdown min-w-0 max-w-full text-sm leading-relaxed text-zinc-200">
       <ReactMarkdown remarkPlugins={[remarkGfm]} components={marketMarkdownComponents}>
-        {text}
+        {normalized}
       </ReactMarkdown>
     </div>
   );
@@ -320,7 +332,7 @@ function MarketDataComparison({ market, ticker }: { market: MarketReviewPayload;
                 <tr key={`${row.ticker || row.company_name}-${idx}`}>
                   <td className="hib-market-table-cell font-mono text-xs">{row.rank}</td>
                   <td className="hib-market-table-cell">
-                    <span className="block font-mono font-semibold">{row.ticker || "N/A"}</span>
+                    <span className="block font-mono font-semibold">{row.ticker || "-"}</span>
                     <span className="block text-[color:var(--text-muted)]">{row.company_name || "Unnamed company"}</span>
                   </td>
                   <td className="hib-market-table-cell font-mono">{formatLarge(info.marketCap)}</td>

--- a/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
@@ -1,7 +1,18 @@
 "use client";
 
-import { Store } from "lucide-react";
+import {
+  BarChart3,
+  Building2,
+  ChartNoAxesColumn,
+  Layers3,
+  Network,
+  ShieldAlert,
+  Store,
+  Target,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import ReactMarkdown from "react-markdown";
+import type { Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 
 import { ReportChipRow } from "@/components/dashboard-chrome";
@@ -19,18 +30,171 @@ function markdownText(value: unknown): string {
   return String(value || "").trim();
 }
 
+function numeric(value: unknown): number | null {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function formatLarge(value: unknown): string {
+  const n = numeric(value);
+  if (n === null) return "n/a";
+  const abs = Math.abs(n);
+  if (abs >= 1_000_000_000_000) return `${(n / 1_000_000_000_000).toFixed(1)}T`;
+  if (abs >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`;
+  if (abs >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  return n.toLocaleString(undefined, { maximumFractionDigits: 0 });
+}
+
+function formatPercent(value: unknown): string {
+  const n = numeric(value);
+  if (n === null) return "n/a";
+  const pct = Math.abs(n) <= 1 ? n * 100 : n;
+  return `${pct.toFixed(1)}%`;
+}
+
+function formatMultiple(value: unknown): string {
+  const n = numeric(value);
+  if (n === null || n <= 0) return "n/a";
+  return `${n.toFixed(1)}x`;
+}
+
+function infoRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+type MarketSection = {
+  title: string;
+  body: string;
+};
+
+type MarketSectionMeta = {
+  key?: string;
+  eyebrow: string;
+  icon: LucideIcon;
+  wide?: boolean;
+};
+
+const SECTION_META: MarketSectionMeta[] = [
+  {
+    key: "market definition",
+    eyebrow: "Where The Company Really Plays",
+    icon: Store,
+  },
+  {
+    key: "ranked competitor map",
+    eyebrow: "Strategic Overlap",
+    icon: Network,
+  },
+  {
+    key: "financial comparison",
+    eyebrow: "Exact Reported Data",
+    icon: BarChart3,
+    wide: true,
+  },
+  {
+    key: "product and customer overlap",
+    eyebrow: "Product Surface",
+    icon: Layers3,
+  },
+  {
+    key: "competitive positioning",
+    eyebrow: "Who Has The Edge",
+    icon: Building2,
+  },
+  {
+    key: "market structure and risks",
+    eyebrow: "Pressure Points",
+    icon: ShieldAlert,
+  },
+  {
+    key: "valuation implications",
+    eyebrow: "Investor Read-Through",
+    icon: Target,
+    wide: true,
+  },
+];
+
+const marketMarkdownComponents: Components = {
+  table({ node: _node, ...props }) {
+    return (
+      <div className="hib-market-table-wrap">
+        <table className="hib-market-table" {...props} />
+      </div>
+    );
+  },
+  th({ node: _node, ...props }) {
+    return <th className="hib-market-table-head" {...props} />;
+  },
+  td({ node: _node, ...props }) {
+    return <td className="hib-market-table-cell" {...props} />;
+  },
+  a({ node: _node, ...props }) {
+    return <a className="font-semibold text-[color:var(--info)] underline-offset-4 hover:underline" {...props} />;
+  },
+};
+
+function splitMarketSections(text: string): MarketSection[] {
+  const src = markdownText(text).replace(/\r\n/g, "\n");
+  if (!src) return [];
+
+  const lines = src.split("\n");
+  const sections: MarketSection[] = [];
+  let currentTitle = "Market Review";
+  let currentBody: string[] = [];
+  let sawSection = false;
+
+  const flush = () => {
+    const body = currentBody.join("\n").trim();
+    if (body || currentTitle !== "Market Review") {
+      sections.push({ title: currentTitle, body });
+    }
+    currentBody = [];
+  };
+
+  for (const line of lines) {
+    const match = line.match(/^##\s+(.+?)\s*$/);
+    if (match) {
+      if (sawSection || currentBody.join("\n").trim()) flush();
+      currentTitle = match[1].trim();
+      sawSection = true;
+      continue;
+    }
+    currentBody.push(line);
+  }
+  flush();
+
+  return sections.filter((section) => section.body || section.title);
+}
+
+function sectionMeta(title: string) {
+  const normalized = title.trim().toLowerCase();
+  return SECTION_META.find((item) => item.key ? normalized.includes(item.key) : false) || {
+    eyebrow: "Market Intelligence",
+    icon: ChartNoAxesColumn,
+    wide: false,
+  };
+}
+
+function MarketMarkdown({ text }: { text: string }) {
+  return (
+    <div className="hib-markdown hib-market-markdown min-w-0 max-w-full text-sm leading-relaxed text-zinc-200">
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={marketMarkdownComponents}>
+        {text}
+      </ReactMarkdown>
+    </div>
+  );
+}
+
 function MarkdownPanel({ title, text, emptyText }: { title: string; text: string; emptyText: string }) {
   const body = markdownText(text);
   return (
-    <section className="rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
+    <section className="min-w-0 overflow-hidden rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
       <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
-        <h2 className="text-xs font-semibold uppercase tracking-[0.16em] text-zinc-300">{title}</h2>
+        <h2 className="min-w-0 break-words text-xs font-semibold uppercase tracking-[0.16em] text-zinc-300">{title}</h2>
         <SmallCopyButton text={body} label={`Copy ${title}`} />
       </div>
       {body ? (
-        <div className="hib-markdown text-sm leading-relaxed text-zinc-200">
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>{body}</ReactMarkdown>
-        </div>
+        <MarketMarkdown text={body} />
       ) : (
         <p className="text-sm text-zinc-500">{emptyText}</p>
       )}
@@ -38,8 +202,144 @@ function MarkdownPanel({ title, text, emptyText }: { title: string; text: string
   );
 }
 
+function MarketReviewSections({ text }: { text: string }) {
+  const sections = splitMarketSections(text);
+  if (!sections.length) {
+    return (
+      <section className="min-w-0 overflow-hidden rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
+        <h2 className="text-xs font-semibold uppercase tracking-[0.16em] text-zinc-300">Competitor Market Review</h2>
+        <p className="mt-3 text-sm text-zinc-500">No competitor market review was stored for this report.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="min-w-0">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--text-muted)]">
+            Competitor Market Review
+          </p>
+          <h2 className="font-display text-xl text-[color:var(--text-primary)]">Market Intelligence Map</h2>
+        </div>
+        <SmallCopyButton text={text} label="Copy Competitor Market Review" />
+      </div>
+      <div className="grid min-w-0 gap-3 lg:grid-cols-2">
+        {sections.map((section, idx) => {
+          const meta = sectionMeta(section.title);
+          const Icon = meta.icon;
+          return (
+            <article
+              key={`${section.title}-${idx}`}
+              className={[
+                "min-w-0 overflow-hidden rounded-2xl border border-white/10 bg-zinc-950/70 p-4",
+                meta.wide ? "lg:col-span-2" : "",
+              ].join(" ")}
+            >
+              <div className="mb-3 flex min-w-0 items-start gap-3">
+                <div className="shrink-0 rounded-xl border border-white/10 bg-black/25 p-2 text-[color:var(--accent)]">
+                  <Icon size={18} />
+                </div>
+                <div className="min-w-0">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[color:var(--text-muted)]">
+                    {meta.eyebrow}
+                  </p>
+                  <h3 className="break-words font-display text-lg text-[color:var(--text-primary)]">{section.title}</h3>
+                </div>
+              </div>
+              <MarketMarkdown text={section.body} />
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
 function competitorRows(payload: MarketReviewPayload | undefined) {
   return Array.isArray(payload?.competitors) ? payload.competitors.slice(0, 5) : [];
+}
+
+function MarketDataComparison({ market, ticker }: { market: MarketReviewPayload; ticker: string }) {
+  const original = market.original_company || {};
+  const originalInfo = infoRecord(original.info);
+  const rows = [
+    {
+      rank: "Own",
+      ticker: original.ticker || ticker,
+      company_name: original.company_name || ticker,
+      info: originalInfo,
+    },
+    ...competitorRows(market).map((row) => ({
+      rank: row.rank ? `#${row.rank}` : "Peer",
+      ticker: row.ticker || "",
+      company_name: row.company_name || "",
+      info: infoRecord(row.info),
+    })),
+  ].filter((row) => row.ticker || row.company_name || Object.keys(row.info).length);
+
+  if (!rows.length || rows.every((row) => !Object.keys(row.info).length)) return null;
+
+  return (
+    <section className="min-w-0 overflow-hidden rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
+      <div className="mb-3 flex min-w-0 items-start gap-3">
+        <div className="shrink-0 rounded-xl border border-white/10 bg-black/25 p-2 text-[color:var(--accent)]">
+          <BarChart3 size={18} />
+        </div>
+        <div className="min-w-0">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[color:var(--text-muted)]">
+            Exact Data Layer
+          </p>
+          <h2 className="break-words font-display text-lg text-[color:var(--text-primary)]">
+            Original Company vs Public Peers
+          </h2>
+        </div>
+      </div>
+
+      <div className="hib-market-table-wrap">
+        <table className="hib-market-table">
+          <thead>
+            <tr>
+              <th className="hib-market-table-head">Rank</th>
+              <th className="hib-market-table-head">Company</th>
+              <th className="hib-market-table-head">Market Cap</th>
+              <th className="hib-market-table-head">EV</th>
+              <th className="hib-market-table-head">Revenue</th>
+              <th className="hib-market-table-head">Rev Growth</th>
+              <th className="hib-market-table-head">Gross Margin</th>
+              <th className="hib-market-table-head">EBITDA Margin</th>
+              <th className="hib-market-table-head">Net Margin</th>
+              <th className="hib-market-table-head">P/E</th>
+              <th className="hib-market-table-head">EV/Revenue</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, idx) => {
+              const info = row.info;
+              return (
+                <tr key={`${row.ticker || row.company_name}-${idx}`}>
+                  <td className="hib-market-table-cell font-mono text-xs">{row.rank}</td>
+                  <td className="hib-market-table-cell">
+                    <span className="block font-mono font-semibold">{row.ticker || "N/A"}</span>
+                    <span className="block text-[color:var(--text-muted)]">{row.company_name || "Unnamed company"}</span>
+                  </td>
+                  <td className="hib-market-table-cell font-mono">{formatLarge(info.marketCap)}</td>
+                  <td className="hib-market-table-cell font-mono">{formatLarge(info.enterpriseValue)}</td>
+                  <td className="hib-market-table-cell font-mono">{formatLarge(info.totalRevenue)}</td>
+                  <td className="hib-market-table-cell font-mono">{formatPercent(info.revenueGrowth)}</td>
+                  <td className="hib-market-table-cell font-mono">{formatPercent(info.grossMargins)}</td>
+                  <td className="hib-market-table-cell font-mono">{formatPercent(info.ebitdaMargins)}</td>
+                  <td className="hib-market-table-cell font-mono">{formatPercent(info.profitMargins)}</td>
+                  <td className="hib-market-table-cell font-mono">{formatMultiple(info.trailingPE)}</td>
+                  <td className="hib-market-table-cell font-mono">{formatMultiple(info.enterpriseToRevenue)}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
 }
 
 export function MarketClient({ ticker, data, reportsForTicker, resolvedReportId }: MarketClientProps) {
@@ -53,14 +353,14 @@ export function MarketClient({ ticker, data, reportsForTicker, resolvedReportId 
   const error = markdownText(market.error);
 
   return (
-    <div>
+    <div className="min-w-0">
       <ReportChipRow ticker={ticker} reports={reportsForTicker} currentReportId={resolvedReportId} />
 
       <header className="mb-4 flex flex-wrap items-end justify-between gap-3">
-        <div>
+        <div className="min-w-0">
           <p className="text-xs uppercase tracking-[0.2em] text-zinc-500">{ticker}</p>
           <h1 className="font-display text-2xl text-zinc-100">Market</h1>
-          <p className="mt-1 text-sm text-zinc-400">{marketName}</p>
+          <p className="mt-1 max-w-full break-words text-sm text-zinc-400">{marketName}</p>
         </div>
         <div className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-zinc-950/70 px-3 py-2 text-xs text-zinc-300">
           <Store size={14} />
@@ -69,7 +369,7 @@ export function MarketClient({ ticker, data, reportsForTicker, resolvedReportId 
       </header>
 
       {!hasReview ? (
-        <section className="mb-4 rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
+        <section className="mb-4 min-w-0 overflow-hidden rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
           <h2 className="text-xs font-semibold uppercase tracking-[0.16em] text-zinc-300">Market Review</h2>
           <p className="mt-3 text-sm text-zinc-500">
             This report was generated before the competitor market review agent was added. Run a fresh report to build this tab.
@@ -79,22 +379,22 @@ export function MarketClient({ ticker, data, reportsForTicker, resolvedReportId 
       ) : null}
 
       {rows.length ? (
-        <section className="mb-4 rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
+        <section className="mb-4 min-w-0 overflow-hidden rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
           <h2 className="text-xs font-semibold uppercase tracking-[0.16em] text-zinc-300">Closest Public Companies</h2>
           <div className="mt-3 grid gap-2 md:grid-cols-2 xl:grid-cols-3">
             {rows.map((row, idx) => (
-              <article key={`${row.ticker || "competitor"}-${idx}`} className="rounded-xl border border-white/10 bg-black/25 p-3">
+              <article key={`${row.ticker || "competitor"}-${idx}`} className="min-w-0 overflow-hidden rounded-xl border border-white/10 bg-black/25 p-3">
                 <div className="flex items-start justify-between gap-3">
-                  <div>
-                    <p className="font-mono text-sm font-semibold text-zinc-100">{row.ticker || "N/A"}</p>
-                    <p className="text-sm text-zinc-300">{row.company_name || "Unnamed company"}</p>
+                  <div className="min-w-0">
+                    <p className="break-words font-mono text-sm font-semibold text-zinc-100">{row.ticker || "N/A"}</p>
+                    <p className="break-words text-sm text-zinc-300">{row.company_name || "Unnamed company"}</p>
                   </div>
                   <span className="rounded-full border border-white/10 px-2 py-0.5 text-[10px] uppercase tracking-[0.14em] text-zinc-400">
                     #{row.rank || idx + 1}
                   </span>
                 </div>
                 {row.similarity_rationale ? (
-                  <p className="mt-2 text-xs leading-relaxed text-zinc-400">{row.similarity_rationale}</p>
+                  <p className="mt-2 break-words text-xs leading-relaxed text-zinc-400">{row.similarity_rationale}</p>
                 ) : null}
               </article>
             ))}
@@ -103,11 +403,8 @@ export function MarketClient({ ticker, data, reportsForTicker, resolvedReportId 
       ) : null}
 
       <div className="grid gap-4">
-        <MarkdownPanel
-          title="Competitor Market Review"
-          text={reviewMarkdown}
-          emptyText="No competitor market review was stored for this report."
-        />
+        <MarketDataComparison market={market} ticker={ticker} />
+        <MarketReviewSections text={reviewMarkdown} />
         <MarkdownPanel
           title="Current Market Agent"
           text={marketAgentMarkdown}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -686,10 +686,10 @@ html[data-theme="light"] .hib-bear-prob-value {
 }
 .hib-market-table {
   width: 100%;
-  min-width: 42rem;
+  min-width: 52rem;
   border-collapse: separate;
   border-spacing: 0;
-  font-size: 0.78rem;
+  font-size: 0.74rem;
   line-height: 1.35;
 }
 .hib-market-table-head {
@@ -705,10 +705,12 @@ html[data-theme="light"] .hib-bear-prob-value {
 }
 .hib-market-table-cell,
 .hib-market-table-head {
-  max-width: 18rem;
+  max-width: 20rem;
   padding: 0.7rem 0.75rem;
   vertical-align: top;
-  overflow-wrap: anywhere;
+  overflow-wrap: normal;
+  word-break: normal;
+  hyphens: none;
 }
 .hib-market-table-cell {
   border-bottom: 1px solid var(--border-subtle);

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -661,6 +661,65 @@ html[data-theme="light"] .hib-bear-prob-value {
   margin: 0.8rem 0;
   border-color: rgba(148, 163, 184, 0.45);
 }
+.hib-market-markdown {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+.hib-market-markdown > * {
+  max-width: 100%;
+}
+.hib-market-markdown pre {
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
+}
+.hib-market-markdown code {
+  white-space: pre-wrap;
+}
+.hib-market-table-wrap {
+  margin: 0.85rem 0;
+  max-width: 100%;
+  overflow-x: auto;
+  border: 1px solid var(--border-subtle);
+  border-radius: 0.75rem;
+  background: color-mix(in srgb, var(--surface-elevated) 78%, transparent);
+}
+.hib-market-table {
+  width: 100%;
+  min-width: 42rem;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: 0.78rem;
+  line-height: 1.35;
+}
+.hib-market-table-head {
+  position: sticky;
+  top: 0;
+  border-bottom: 1px solid var(--border-strong);
+  background: var(--surface-overlay);
+  color: var(--text-secondary);
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-align: left;
+  text-transform: uppercase;
+}
+.hib-market-table-cell,
+.hib-market-table-head {
+  max-width: 18rem;
+  padding: 0.7rem 0.75rem;
+  vertical-align: top;
+  overflow-wrap: anywhere;
+}
+.hib-market-table-cell {
+  border-bottom: 1px solid var(--border-subtle);
+  color: var(--text-primary);
+}
+.hib-market-table tbody tr:last-child .hib-market-table-cell {
+  border-bottom: 0;
+}
+.hib-market-table tbody tr:hover .hib-market-table-cell {
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+}
 
 .font-display {
   font-family: var(--font-space-grotesk), sans-serif;

--- a/frontend/src/lib/dashboard-types.ts
+++ b/frontend/src/lib/dashboard-types.ts
@@ -67,10 +67,18 @@ export type MarketReviewPayload = {
   status?: "success" | "unavailable" | "error" | string;
   generated_at?: string | null;
   name_of_market?: string;
+  original_company?: {
+    ticker?: string;
+    company_name?: string;
+    info?: Record<string, unknown>;
+    annual_financials?: string;
+  };
   competitors?: Array<{
     rank?: number;
     ticker?: string;
     company_name?: string;
+    info?: Record<string, unknown>;
+    annual_financials?: string;
     similarity_rationale?: string;
     overlap_notes?: string;
     confidence?: string | number | null;

--- a/src/ai_hedge/competitor_market_review.py
+++ b/src/ai_hedge/competitor_market_review.py
@@ -412,7 +412,7 @@ Rules:
 - Use the original company and competitor annual income-statement data when available; explicitly say when data is unavailable.
 - Compare business model, scale, profitability, growth, pricing power, cyclicality, and competitive intensity.
 - Prefer Markdown tables for ranked competitors, financial comparison, product/customer overlap, and any exact-data comparison.
-- Make tables compact and directly useful: include tickers, latest available annual figures, growth or margin cues when present, and clear "n/a" cells when data is missing.
+- Make tables compact and directly useful: include tickers, latest available annual figures, growth or margin cues when present, and clear "-" cells when data is missing.
 - Do not make buy/sell/hold recommendations.
 - Do not include raw JSON.
 """.strip()

--- a/src/ai_hedge/competitor_market_review.py
+++ b/src/ai_hedge/competitor_market_review.py
@@ -228,6 +228,29 @@ def _fetch_annual_with_retries(
     raise RuntimeError(f"Annual financial table unavailable for {ticker}: {last_error}")
 
 
+def build_original_company_context(
+    *,
+    ticker: str,
+    info_dict: Dict[str, Any],
+    annual_table_fetcher: Optional[AnnualTableFetcher] = None,
+) -> Dict[str, Any]:
+    info = info_dict.get("info") if isinstance(info_dict, dict) else {}
+    if not isinstance(info, dict):
+        info = {}
+    info_data = {"info": info}
+    fetch_annual = annual_table_fetcher or _default_annual_table_fetcher
+    try:
+        annual_financials = fetch_annual(ticker, info_data)
+    except Exception as exc:
+        annual_financials = f"### Annual Income Statement\nUnavailable: {type(exc).__name__}: {str(exc)[:300]}\n\n"
+    return {
+        "ticker": ticker.upper().strip(),
+        "company_name": str(info.get("shortName") or info.get("longName") or "").strip(),
+        "info": _compact_info_for_llm(info),
+        "annual_financials": annual_financials,
+    }
+
+
 def build_discovery_prompt(ticker: str, info: Dict[str, Any]) -> str:
     original_country = str(info.get("country") or "").strip()
     suffix_guidance = COUNTRY_SUFFIX_GUIDANCE.get(_country_key(original_country))
@@ -363,9 +386,11 @@ You are a senior buy-side market analyst writing a dashboard-ready market review
 You receive:
 - the original ticker
 - the market name
+- original company info_dict["info"]
+- original company annual income-statement table
 - ranked public competitors
 - normalized competitor info produced by the same info engine used for the original company
-- annual income-statement tables produced by the same financial table engine used for the original company
+- competitor annual income-statement tables produced by the same financial table engine
 
 Payload:
 {json.dumps(payload, ensure_ascii=False, default=str)}
@@ -383,8 +408,11 @@ Required sections:
 
 Rules:
 - Focus on what matters to investors and valuation.
-- Use the competitor financials when available; explicitly say when data is unavailable.
+- Include the original company in the financial and strategic comparison wherever the payload provides data.
+- Use the original company and competitor annual income-statement data when available; explicitly say when data is unavailable.
 - Compare business model, scale, profitability, growth, pricing power, cyclicality, and competitive intensity.
+- Prefer Markdown tables for ranked competitors, financial comparison, product/customer overlap, and any exact-data comparison.
+- Make tables compact and directly useful: include tickers, latest available annual figures, growth or margin cues when present, and clear "n/a" cells when data is missing.
 - Do not make buy/sell/hold recommendations.
 - Do not include raw JSON.
 """.strip()
@@ -434,10 +462,12 @@ def run_competitor_market_review(
         raise RuntimeError("Missing DEEPSEEK_API_KEY for competitor market review.")
 
     discovery = discover_competitors(ticker=ticker, info_dict=info_dict, api_key=key)
+    original_company = build_original_company_context(ticker=ticker, info_dict=info_dict)
     competitors = collect_competitor_context(discovery=discovery, original_ticker=ticker)
     review_payload = {
         "ticker": ticker.upper().strip(),
         "name_of_market": discovery.get("name_of_market") or "",
+        "original_company": original_company,
         "competitors": competitors,
     }
     review_markdown = generate_market_review(payload=review_payload, api_key=key)
@@ -446,6 +476,7 @@ def run_competitor_market_review(
         "ticker": ticker.upper().strip(),
         "generated_at": _utc_now(),
         "name_of_market": discovery.get("name_of_market") or "",
+        "original_company": original_company,
         "competitors": competitors,
         "review_markdown": review_markdown,
         "error": "",

--- a/src/ai_hedge/dashboard.py
+++ b/src/ai_hedge/dashboard.py
@@ -320,11 +320,15 @@ def _normalize_market_review_payload(
     competitors = raw.get("competitors")
     if not isinstance(competitors, list):
         competitors = []
+    original_company = raw.get("original_company")
+    if not isinstance(original_company, dict):
+        original_company = {}
     status = str(raw.get("status") or ("success" if competitor_text else "unavailable")).strip() or "unavailable"
     return {
         "status": status,
         "generated_at": raw.get("generated_at"),
         "name_of_market": str(raw.get("name_of_market") or "").strip(),
+        "original_company": original_company,
         "competitors": competitors,
         "review_markdown": competitor_text,
         "market_agent_markdown": market_agent_text,

--- a/src/ai_hedge/runner.py
+++ b/src/ai_hedge/runner.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from .dashboard import (
+    _extract_analysis_section,
     build_dashboard_appendix_text,
     build_dashboard_payload,
     deterministic_red_flags,
@@ -115,6 +116,36 @@ def _append_progress(progress_file: Optional[str], message: str) -> None:
             fh.write(f"{message.strip()}\n")
     except Exception:
         pass
+
+
+def _attach_market_agent_markdown(
+    *,
+    payload: Dict[str, Any],
+    analysis_text: str,
+    out_dir: Path,
+    ticker: str,
+    market_review_json: str = "",
+) -> tuple[Dict[str, Any], str]:
+    raw = payload if isinstance(payload, dict) else {}
+    market_agent_text = _extract_analysis_section(analysis_text, "Market Analysis")
+    if market_agent_text:
+        raw["market_agent_markdown"] = market_agent_text
+        raw.setdefault("status", "success")
+        raw.setdefault("ticker", ticker.upper().strip())
+
+    if not raw:
+        return raw, market_review_json
+
+    target = Path(market_review_json) if market_review_json else out_dir / f"{ticker}_market_review.json"
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(
+            json.dumps(raw, ensure_ascii=False, indent=2, default=str),
+            encoding="utf-8",
+        )
+        return raw, str(target.resolve())
+    except Exception:
+        return raw, market_review_json
 
 
 def _first_float(value) -> Optional[float]:
@@ -1679,6 +1710,14 @@ def _run_ticker_valuation_impl(
             regular_text = merged_analysis_text.strip()
     except Exception as analysis_merge_err:
         notes.append(f"Full analysis text merge failed: {analysis_merge_err}")
+
+    market_review_payload, market_review_json = _attach_market_agent_markdown(
+        payload=market_review_payload,
+        analysis_text=regular_text,
+        out_dir=out_dir,
+        ticker=ticker,
+        market_review_json=market_review_json,
+    )
 
     try:
         analysis_duration_minutes = round((time.perf_counter() - run_started) / 60.0, 2)

--- a/tests/test_competitor_market_review.py
+++ b/tests/test_competitor_market_review.py
@@ -152,6 +152,92 @@ def test_default_annual_table_fetcher_uses_financials_and_csv_engine(monkeypatch
     assert "Reporting_Period,Revenue" in table
 
 
+def test_build_original_company_context_uses_info_and_annual_income_statement():
+    annual_calls = []
+
+    def fake_annual(ticker, info_data):
+        annual_calls.append((ticker, info_data["info"]["financial_currency_to_USD"]))
+        return "### Annual Income Statement\n```csv\nRevenue,Net Income\n100,30\n```\n\n"
+
+    context = cmr.build_original_company_context(
+        ticker="CHKP",
+        info_dict={
+            "info": {
+                "shortName": "Check Point",
+                "symbol": "CHKP",
+                "marketCap": 123,
+                "financial_currency_to_USD": 1,
+                "longBusinessSummary": "Cybersecurity platform.",
+            }
+        },
+        annual_table_fetcher=fake_annual,
+    )
+
+    assert annual_calls == [("CHKP", 1)]
+    assert context["ticker"] == "CHKP"
+    assert context["company_name"] == "Check Point"
+    assert context["info"]["marketCap"] == 123
+    assert "Revenue,Net Income" in context["annual_financials"]
+
+
+def test_review_prompt_requires_original_company_financial_comparison():
+    prompt = cmr.build_review_prompt(
+        {
+            "ticker": "CHKP",
+            "name_of_market": "Enterprise Cybersecurity",
+            "original_company": {
+                "ticker": "CHKP",
+                "info": {"shortName": "Check Point", "marketCap": 123},
+                "annual_financials": "### Annual Income Statement\n```csv\nRevenue\n```",
+            },
+            "competitors": [{"ticker": "PANW", "annual_financials": "### Annual Income Statement\nNot available"}],
+        }
+    )
+
+    assert 'original company info_dict["info"]' in prompt
+    assert "original company annual income-statement table" in prompt
+    assert "Include the original company in the financial and strategic comparison" in prompt
+    assert '"original_company"' in prompt
+
+
+def test_run_competitor_market_review_includes_original_company_payload(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(
+        cmr,
+        "discover_competitors",
+        lambda **_kwargs: {"name_of_market": "Enterprise Cybersecurity", "competitors": []},
+    )
+    monkeypatch.setattr(cmr, "collect_competitor_context", lambda **_kwargs: [{"ticker": "PANW"}])
+    monkeypatch.setattr(
+        cmr,
+        "build_original_company_context",
+        lambda **_kwargs: {
+            "ticker": "CHKP",
+            "info": {"shortName": "Check Point"},
+            "annual_financials": "### Annual Income Statement\n```csv\nRevenue\n```",
+        },
+    )
+
+    def fake_generate_market_review(*, payload, api_key):
+        captured["payload"] = payload
+        captured["api_key"] = api_key
+        return "review"
+
+    monkeypatch.setattr(cmr, "generate_market_review", fake_generate_market_review)
+
+    out = cmr.run_competitor_market_review(
+        ticker="CHKP",
+        info_dict={"info": {"shortName": "Check Point"}},
+        api_key="key",
+    )
+
+    assert captured["payload"]["original_company"]["ticker"] == "CHKP"
+    assert "Revenue" in captured["payload"]["original_company"]["annual_financials"]
+    assert captured["payload"]["competitors"] == [{"ticker": "PANW"}]
+    assert out["original_company"]["ticker"] == "CHKP"
+
+
 def test_result_degrades_to_unavailable_and_writes_sidecar(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
 

--- a/tests/test_competitor_market_review.py
+++ b/tests/test_competitor_market_review.py
@@ -197,6 +197,7 @@ def test_review_prompt_requires_original_company_financial_comparison():
     assert 'original company info_dict["info"]' in prompt
     assert "original company annual income-statement table" in prompt
     assert "Include the original company in the financial and strategic comparison" in prompt
+    assert 'clear "-" cells when data is missing' in prompt
     assert '"original_company"' in prompt
 
 

--- a/tests/test_runner_fallback.py
+++ b/tests/test_runner_fallback.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 from ai_hedge import runner
 
 
@@ -45,3 +47,31 @@ def test_build_sec_sources_footer_for_sec_reports():
     assert "Source: SEC" in footer
     assert "Annual report date: 2026-02-10" in footer
     assert "Quarterly report date: 2026-05-05" in footer
+
+
+def test_attach_market_agent_markdown_persists_analysis_section(tmp_path):
+    analysis_text = """
+# What It Does:
+Company context.
+
+# Market Analysis:
+This is the exact market-agent body.
+
+It should be copied as-is.
+
+# SWOT Analysis:
+Next section.
+""".strip()
+
+    payload, json_path = runner._attach_market_agent_markdown(
+        payload={"status": "success", "review_markdown": "competitor text"},
+        analysis_text=analysis_text,
+        out_dir=tmp_path,
+        ticker="CHKP",
+    )
+
+    expected = "This is the exact market-agent body.\n\nIt should be copied as-is."
+    assert payload["market_agent_markdown"] == expected
+    stored = json.loads((tmp_path / "CHKP_market_review.json").read_text(encoding="utf-8"))
+    assert json_path.endswith("CHKP_market_review.json")
+    assert stored["market_agent_markdown"] == expected


### PR DESCRIPTION
## Summary

- Enrich the competitor market review prompt payload with the original company info_dict[info] plus original annual income-statement data, so peer comparisons can include the analyzed ticker.
- Preserve Market Agent text from the analysis file in the market review/dashboard payload and render the competitor review section-by-section instead of one large Markdown block.
- Add a Market tab exact-data comparison table and styled, mobile-safe Markdown/table rendering.
- Render missing table data as `-` and prevent mid-word breaks inside all Market tab tables while preserving horizontal scroll.

## Preview

URL: https://pr-95-hedge-in-a-box-site.fly.dev

Verified: `https://pr-95-hedge-in-a-box-site.fly.dev/dashboard/CHKP/market` returned HTTP 200 and contained the new Market page / Exact Data Layer / Market table markup after the latest deploy.

## Test plan

- [x] `python -m py_compile src\ai_hedge\competitor_market_review.py src\ai_hedge\dashboard.py src\ai_hedge\runner.py`
- [x] `PYTHONPATH=src python -m pytest tests\test_competitor_market_review.py tests\test_runner_fallback.py -q --basetemp=.codex-pytest-market-tab3`
- [x] `PYTHONPATH=src python -m pytest tests\test_competitor_market_review.py -q --basetemp=.codex-pytest-market-tab4`
- [x] `npm run build` in `frontend/`
- [x] Site Preview workflow passed for PR #95 after latest push
- [x] Preview CHKP Market route returned HTTP 200 and includes `Exact Data Layer` + `hib-market-table`

## Notes for reviewer

- Existing reports render with the new UI, but rerunning a ticker is required to generate the new original-company market-review payload.
- The Next build completed successfully and still shows the pre-existing Turbopack tracing warning from `next.config.ts` / dream-team chat route.