### PR TITLE
Fix market analysis section extraction

### DIFF
--- a/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
@@ -418,7 +418,7 @@ export function MarketClient({ ticker, data, reportsForTicker, resolvedReportId 
         <MarketDataComparison market={market} ticker={ticker} />
         <MarketReviewSections text={reviewMarkdown} />
         <MarkdownPanel
-          title="Current Market Agent"
+          title="Market Analysis"
           text={marketAgentMarkdown}
           emptyText="No current market-agent text was found for this report."
         />

--- a/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
@@ -88,7 +88,7 @@ type MarketSectionMeta = {
 const SECTION_META: MarketSectionMeta[] = [
   {
     key: "market definition",
-    eyebrow: "Where The Company Really Plays",
+    eyebrow: "Market Scope",
     icon: Store,
   },
   {
@@ -98,7 +98,7 @@ const SECTION_META: MarketSectionMeta[] = [
   },
   {
     key: "financial comparison",
-    eyebrow: "Exact Reported Data",
+    eyebrow: "Reported Metrics",
     icon: BarChart3,
     wide: true,
   },
@@ -109,7 +109,7 @@ const SECTION_META: MarketSectionMeta[] = [
   },
   {
     key: "competitive positioning",
-    eyebrow: "Who Has The Edge",
+    eyebrow: "Relative Position",
     icon: Building2,
   },
   {
@@ -219,7 +219,7 @@ function MarketReviewSections({ text }: { text: string }) {
   if (!sections.length) {
     return (
       <section className="min-w-0 overflow-hidden rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
-        <h2 className="text-xs font-semibold uppercase tracking-[0.16em] text-zinc-300">Competitor Market Review</h2>
+        <h2 className="text-xs font-semibold uppercase tracking-[0.16em] text-zinc-300">Peer Market Review</h2>
         <p className="mt-3 text-sm text-zinc-500">No competitor market review was stored for this report.</p>
       </section>
     );
@@ -230,11 +230,11 @@ function MarketReviewSections({ text }: { text: string }) {
       <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
         <div>
           <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--text-muted)]">
-            Competitor Market Review
+            Peer Market Review
           </p>
-          <h2 className="font-display text-xl text-[color:var(--text-primary)]">Market Intelligence Map</h2>
+          <h2 className="font-display text-xl text-[color:var(--text-primary)]">Competitive Landscape</h2>
         </div>
-        <SmallCopyButton text={text} label="Copy Competitor Market Review" />
+        <SmallCopyButton text={text} label="Copy Peer Market Review" />
       </div>
       <div className="grid min-w-0 gap-3 lg:grid-cols-2">
         {sections.map((section, idx) => {
@@ -300,7 +300,7 @@ function MarketDataComparison({ market, ticker }: { market: MarketReviewPayload;
         </div>
         <div className="min-w-0">
           <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[color:var(--text-muted)]">
-            Exact Data Layer
+            Peer Comparison
           </p>
           <h2 className="break-words font-display text-lg text-[color:var(--text-primary)]">
             Original Company vs Public Peers
@@ -392,7 +392,7 @@ export function MarketClient({ ticker, data, reportsForTicker, resolvedReportId 
 
       {rows.length ? (
         <section className="mb-4 min-w-0 overflow-hidden rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
-          <h2 className="text-xs font-semibold uppercase tracking-[0.16em] text-zinc-300">Closest Public Companies</h2>
+          <h2 className="text-xs font-semibold uppercase tracking-[0.16em] text-zinc-300">Closest Public Peers</h2>
           <div className="mt-3 grid gap-2 md:grid-cols-2 xl:grid-cols-3">
             {rows.map((row, idx) => (
               <article key={`${row.ticker || "competitor"}-${idx}`} className="min-w-0 overflow-hidden rounded-xl border border-white/10 bg-black/25 p-3">

--- a/src/ai_hedge/dashboard.py
+++ b/src/ai_hedge/dashboard.py
@@ -289,17 +289,47 @@ def _extract_analysis_section(text: str, header: str) -> str:
         return ""
     target = str(header or "").strip().rstrip(":").lower()
     lines = src.split("\n")
+    plain_headers = {
+        "what the company is doing",
+        "general information insights",
+        "news review",
+        "options insights",
+        "analyst expectations insights",
+        "holders analysis",
+        "swot analysis",
+        "market analysis",
+        "bull vs bear thesis",
+        "significant change analysis",
+        "key insights for valuation",
+        "street analysis",
+        "overall valuations",
+        "our analysts price valuations",
+        "final table",
+        "competitor market review",
+    }
+
+    def _section_heading(line: str) -> Optional[str]:
+        match = re.match(r"^\s*#{1,6}\s+(.+?)\s*:?\s*$", line)
+        if match:
+            return match.group(1).strip().rstrip(":")
+        match = re.match(r"^\s*([A-Z][A-Za-z0-9 &/().,'+-]{2,80})\s*:\s*$", line)
+        if match:
+            heading = match.group(1).strip().rstrip(":")
+            if heading.lower() in plain_headers or heading.lower().endswith(" insights"):
+                return heading
+        return None
+
     start: Optional[int] = None
     for idx, line in enumerate(lines):
-        match = re.match(r"^\s*#\s+(.+?)\s*:?\s*$", line)
-        if match and match.group(1).strip().rstrip(":").lower() == target:
+        heading = _section_heading(line)
+        if heading and heading.lower() == target:
             start = idx + 1
             break
     if start is None:
         return ""
     end = len(lines)
     for idx in range(start, len(lines)):
-        if re.match(r"^\s*#\s+.+?\s*:?\s*$", lines[idx]):
+        if _section_heading(lines[idx]):
             end = idx
             break
     return "\n".join(lines[start:end]).strip()

--- a/tests/test_runner_fallback.py
+++ b/tests/test_runner_fallback.py
@@ -75,3 +75,28 @@ Next section.
     stored = json.loads((tmp_path / "CHKP_market_review.json").read_text(encoding="utf-8"))
     assert json_path.endswith("CHKP_market_review.json")
     assert stored["market_agent_markdown"] == expected
+
+
+def test_attach_market_agent_markdown_accepts_plain_legacy_header(tmp_path):
+    analysis_text = """
+What It Does:
+Company context.
+
+Market Analysis:
+Legacy plain header body.
+
+Still in the market section.
+
+SWOT Analysis:
+Next section.
+""".strip()
+
+    payload, _json_path = runner._attach_market_agent_markdown(
+        payload={"status": "success", "review_markdown": "competitor text"},
+        analysis_text=analysis_text,
+        out_dir=tmp_path,
+        ticker="POET",
+    )
+
+    expected = "Legacy plain header body.\n\nStill in the market section."
+    assert payload["market_agent_markdown"] == expected


### PR DESCRIPTION
﻿## Summary

- Renames the market-tab box from "Current Market Agent" to "Market Analysis".
- Fixes market-agent extraction for legacy analysis files that store the section as `Market Analysis:` without a Markdown `#` prefix.
- Cleans up market-tab headers toward investor-facing labels: `Closest Public Peers`, `Peer Market Review`, `Competitive Landscape`, and `Peer Comparison`.
- Adds regression coverage for the legacy plain-header format.

## Preview

URL: https://pr-96-hedge-in-a-box-site.fly.dev

Verified: `/dashboard/POET/market` returned 200, contains `Market Analysis` / `Peer Market Review`, and no longer contains `Current Market Agent` or the older market-tab labels.

## Test plan

- [x] `PYTHONPATH=src python -m pytest tests/test_runner_fallback.py --basetemp=.codex-pytest-market-analysis`
- [x] `npm run build` from `frontend/`
- [x] Verified `_extract_analysis_section(..., "Market Analysis")` extracts non-empty text from `outputs\POET\POET_analysis.txt`, which uses the plain `Market Analysis:` header
- [x] Verified PR preview page `/dashboard/POET/market`

## Notes for reviewer

Root cause: the dashboard/runner extractor only matched Markdown H1-style headers like `# Market Analysis:`, while some report artifacts and PDFs expose the same section as a plain top-level line, `Market Analysis:`. The fallback is scoped to known report section headers to avoid treating normal prose labels as section breaks.
