### PR TITLE
Simplify market tab comparison view

### DIFF
--- a/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
@@ -3,9 +3,13 @@
 import {
   BarChart3,
   Building2,
+  Layers3,
   Store,
   TrendingUp,
 } from "lucide-react";
+import ReactMarkdown from "react-markdown";
+import type { Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
 
 import { ReportChipRow } from "@/components/dashboard-chrome";
 import type { DashboardPayload, MarketReviewPayload, ReportListItem } from "@/lib/dashboard-types";
@@ -62,6 +66,22 @@ function infoRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
 }
 
+const marketMarkdownComponents: Components = {
+  table({ node: _node, ...props }) {
+    return (
+      <div className="hib-market-table-wrap">
+        <table className="hib-market-table" {...props} />
+      </div>
+    );
+  },
+  th({ node: _node, ...props }) {
+    return <th className="hib-market-table-head" {...props} />;
+  },
+  td({ node: _node, ...props }) {
+    return <td className="hib-market-table-cell" {...props} />;
+  },
+};
+
 type ComparisonRow = {
   rank: string;
   ticker: string;
@@ -75,6 +95,52 @@ function compactText(value: unknown, maxLength = 190): string {
   const clean = markdownText(value).replace(/\s+/g, " ");
   if (clean.length <= maxLength) return clean;
   return `${clean.slice(0, maxLength - 1).trimEnd()}...`;
+}
+
+function markdownSection(text: string, sectionName: string): string {
+  const source = markdownText(text).replace(/\r\n/g, "\n");
+  if (!source) return "";
+
+  const target = sectionName.trim().toLowerCase();
+  const lines = source.split("\n");
+  const body: string[] = [];
+  let collecting = false;
+
+  for (const line of lines) {
+    const heading = line.match(/^##\s+(.+?)\s*$/);
+    if (heading) {
+      if (collecting) break;
+      collecting = heading[1].trim().toLowerCase() === target;
+      continue;
+    }
+    if (collecting) body.push(line);
+  }
+
+  return body.join("\n").trim();
+}
+
+function markdownTables(text: string): string[] {
+  const lines = markdownText(text).replace(/\r\n/g, "\n").split("\n");
+  const tables: string[] = [];
+  let block: string[] = [];
+
+  const flush = () => {
+    if (block.length >= 2 && block.some((line) => /\|\s*:?-{3,}:?\s*\|/.test(line))) {
+      tables.push(block.join("\n").trim());
+    }
+    block = [];
+  };
+
+  for (const line of lines) {
+    if (line.includes("|")) {
+      block.push(line);
+    } else {
+      flush();
+    }
+  }
+  flush();
+
+  return tables;
 }
 
 function buildComparisonRows(market: MarketReviewPayload, ticker: string): ComparisonRow[] {
@@ -154,6 +220,68 @@ function PeerStrategyTable({ market, ticker }: { market: MarketReviewPayload; ti
           </tbody>
         </table>
       </div>
+    </section>
+  );
+}
+
+function ProductOverlapTable({ market }: { market: MarketReviewPayload }) {
+  const section = markdownSection(String(market.review_markdown || ""), "Product And Customer Overlap");
+  const tables = markdownTables(section);
+  const rows = competitorRows(market).filter((row) => markdownText(row.overlap_notes));
+
+  if (!tables.length && !rows.length) return null;
+
+  return (
+    <section className="min-w-0 overflow-hidden rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
+      <div className="mb-3 flex min-w-0 items-start gap-3">
+        <div className="shrink-0 rounded-xl border border-white/10 bg-black/25 p-2 text-[color:var(--accent)]">
+          <Layers3 size={18} />
+        </div>
+        <div className="min-w-0">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[color:var(--text-muted)]">
+            Product Overlap
+          </p>
+          <h2 className="break-words font-display text-lg text-[color:var(--text-primary)]">
+            Where They Compete
+          </h2>
+        </div>
+      </div>
+
+      {tables.length ? (
+        <div className="grid gap-3">
+          {tables.slice(0, 2).map((table, idx) => (
+            <div key={`product-overlap-${idx}`} className="min-w-0">
+              <ReactMarkdown remarkPlugins={[remarkGfm]} components={marketMarkdownComponents}>
+                {table}
+              </ReactMarkdown>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="hib-market-table-wrap">
+          <table className="hib-market-table">
+            <thead>
+              <tr>
+                <th className="hib-market-table-head">Company</th>
+                <th className="hib-market-table-head">Product / Customer Overlap</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row, idx) => (
+                <tr key={`${row.ticker || row.company_name}-${idx}`}>
+                  <td className="hib-market-table-cell">
+                    <span className="font-mono font-semibold">{row.ticker || "-"}</span>
+                    <span className="block text-[color:var(--text-muted)]">{row.company_name || "Unnamed company"}</span>
+                  </td>
+                  <td className="hib-market-table-cell max-w-[44rem] whitespace-normal break-words leading-relaxed">
+                    {compactText(row.overlap_notes, 420)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
     </section>
   );
 }
@@ -306,6 +434,7 @@ export function MarketClient({ ticker, data, reportsForTicker, resolvedReportId 
 
       <div className="grid gap-4">
         <PeerStrategyTable market={market} ticker={ticker} />
+        <ProductOverlapTable market={market} />
         <FinancialScaleTable market={market} ticker={ticker} />
         <MarginValuationTable market={market} ticker={ticker} />
       </div>

--- a/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
@@ -3,14 +3,9 @@
 import {
   BarChart3,
   Building2,
-  ChartNoAxesColumn,
-  Layers3,
-  Network,
-  ShieldAlert,
+  Info,
   Store,
-  Target,
 } from "lucide-react";
-import type { LucideIcon } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import type { Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -78,53 +73,6 @@ type MarketSection = {
   body: string;
 };
 
-type MarketSectionMeta = {
-  key?: string;
-  eyebrow: string;
-  icon: LucideIcon;
-  wide?: boolean;
-};
-
-const SECTION_META: MarketSectionMeta[] = [
-  {
-    key: "market definition",
-    eyebrow: "Market Scope",
-    icon: Store,
-  },
-  {
-    key: "ranked competitor map",
-    eyebrow: "Strategic Overlap",
-    icon: Network,
-  },
-  {
-    key: "financial comparison",
-    eyebrow: "Reported Metrics",
-    icon: BarChart3,
-    wide: true,
-  },
-  {
-    key: "product and customer overlap",
-    eyebrow: "Product Surface",
-    icon: Layers3,
-  },
-  {
-    key: "competitive positioning",
-    eyebrow: "Relative Position",
-    icon: Building2,
-  },
-  {
-    key: "market structure and risks",
-    eyebrow: "Pressure Points",
-    icon: ShieldAlert,
-  },
-  {
-    key: "valuation implications",
-    eyebrow: "Investor Read-Through",
-    icon: Target,
-    wide: true,
-  },
-];
-
 const marketMarkdownComponents: Components = {
   table({ node: _node, ...props }) {
     return (
@@ -142,6 +90,16 @@ const marketMarkdownComponents: Components = {
   a({ node: _node, ...props }) {
     return <a className="font-semibold text-[color:var(--info)] underline-offset-4 hover:underline" {...props} />;
   },
+};
+
+type ComparisonRow = {
+  rank: string;
+  ticker: string;
+  company_name: string;
+  info: Record<string, unknown>;
+  description: string;
+  rationale?: string;
+  confidence?: string | number | null;
 };
 
 function splitMarketSections(text: string): MarketSection[] {
@@ -177,15 +135,6 @@ function splitMarketSections(text: string): MarketSection[] {
   return sections.filter((section) => section.body || section.title);
 }
 
-function sectionMeta(title: string) {
-  const normalized = title.trim().toLowerCase();
-  return SECTION_META.find((item) => item.key ? normalized.includes(item.key) : false) || {
-    eyebrow: "Market Intelligence",
-    icon: ChartNoAxesColumn,
-    wide: false,
-  };
-}
-
 function MarketMarkdown({ text }: { text: string }) {
   const normalized = normalizeTableMissingValues(text);
   return (
@@ -197,24 +146,203 @@ function MarketMarkdown({ text }: { text: string }) {
   );
 }
 
-function MarkdownPanel({ title, text, emptyText }: { title: string; text: string; emptyText: string }) {
-  const body = markdownText(text);
+function compactText(value: unknown, maxLength = 190): string {
+  const clean = markdownText(value).replace(/\s+/g, " ");
+  if (clean.length <= maxLength) return clean;
+  return `${clean.slice(0, maxLength - 1).trimEnd()}...`;
+}
+
+function companyDescription(info: Record<string, unknown>, fallback: unknown): string {
+  return compactText(
+    info.longBusinessSummary ||
+      info.businessSummary ||
+      info.description ||
+      info.longName ||
+      fallback,
+    320
+  );
+}
+
+function buildComparisonRows(market: MarketReviewPayload, ticker: string): ComparisonRow[] {
+  const original = market.original_company || {};
+  const originalInfo = infoRecord(original.info);
+  return [
+    {
+      rank: "Own",
+      ticker: String(original.ticker || ticker),
+      company_name: String(original.company_name || ticker),
+      info: originalInfo,
+      description: companyDescription(originalInfo, market.name_of_market),
+    },
+    ...competitorRows(market).map((row) => {
+      const info = infoRecord(row.info);
+      return {
+        rank: row.rank ? `#${row.rank}` : "Peer",
+        ticker: String(row.ticker || ""),
+        company_name: String(row.company_name || ""),
+        info,
+        description: companyDescription(info, row.similarity_rationale || row.overlap_notes),
+        rationale: compactText(row.similarity_rationale || row.overlap_notes, 150),
+        confidence: row.confidence,
+      };
+    }),
+  ].filter((row) => row.ticker || row.company_name || Object.keys(row.info).length);
+}
+
+function InfoHint({ label, text }: { label: string; text: string }) {
+  if (!text) return null;
+  return (
+    <span className="relative inline-flex align-middle">
+      <button
+        type="button"
+        title={text}
+        aria-label={label}
+        className="ml-1 inline-flex size-5 items-center justify-center rounded-full border border-white/10 bg-black/25 text-[color:var(--info)]"
+      >
+        <Info size={12} />
+      </button>
+    </span>
+  );
+}
+
+function sectionRank(title: string): number {
+  const normalized = title.toLowerCase();
+  if (normalized.includes("financial comparison")) return 0;
+  if (normalized.includes("ranked competitor")) return 1;
+  if (normalized.includes("product") || normalized.includes("customer")) return 2;
+  if (normalized.includes("valuation")) return 3;
+  if (normalized.includes("competitive positioning")) return 4;
+  return 9;
+}
+
+function extractMarkdownTables(body: string): string[] {
+  const lines = markdownText(body).replace(/\r\n/g, "\n").split("\n");
+  const tables: string[] = [];
+  let block: string[] = [];
+
+  const flush = () => {
+    if (block.length >= 2 && block.some((line) => /\|\s*:?-{3,}:?\s*\|/.test(line))) {
+      tables.push(block.join("\n").trim());
+    }
+    block = [];
+  };
+
+  for (const line of lines) {
+    if (line.includes("|")) {
+      block.push(line);
+    } else {
+      flush();
+    }
+  }
+  flush();
+
+  return tables;
+}
+
+function stripMarkdownTables(body: string): string {
+  return markdownText(body)
+    .replace(/\r\n/g, "\n")
+    .split("\n")
+    .filter((line) => !line.includes("|"))
+    .join("\n");
+}
+
+function cleanIdea(value: string): string {
+  return compactText(
+    value
+      .replace(/^[-*]\s+/, "")
+      .replace(/^#+\s+/, "")
+      .replace(/\*\*/g, "")
+      .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1"),
+    170
+  );
+}
+
+function extractKeyIdeas(sections: MarketSection[]): string[] {
+  const ranked = [...sections].sort((a, b) => sectionRank(a.title) - sectionRank(b.title));
+  const ideas: string[] = [];
+
+  for (const section of ranked) {
+    const text = stripMarkdownTables(section.body);
+    const candidates = text
+      .split(/\n+|(?<=\.)\s+/)
+      .map(cleanIdea)
+      .filter((line) => line.length >= 40 && !line.toLowerCase().startsWith("n/a"));
+
+    for (const candidate of candidates) {
+      if (!ideas.some((idea) => idea.toLowerCase() === candidate.toLowerCase())) {
+        ideas.push(candidate);
+      }
+      if (ideas.length >= 4) return ideas;
+    }
+  }
+
+  return ideas;
+}
+
+function extractImportantTables(sections: MarketSection[]) {
+  return [...sections]
+    .sort((a, b) => sectionRank(a.title) - sectionRank(b.title))
+    .flatMap((section) => extractMarkdownTables(section.body).slice(0, 1).map((table) => ({
+      title: section.title,
+      table,
+    })))
+    .slice(0, 2);
+}
+
+function PeerOverviewTable({ market, ticker }: { market: MarketReviewPayload; ticker: string }) {
+  const rows = buildComparisonRows(market, ticker);
+  if (rows.length <= 1) return null;
+
   return (
     <section className="min-w-0 overflow-hidden rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
-      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
-        <h2 className="min-w-0 break-words text-xs font-semibold uppercase tracking-[0.16em] text-zinc-300">{title}</h2>
-        <SmallCopyButton text={body} label={`Copy ${title}`} />
+      <div className="mb-3 flex min-w-0 items-start gap-3">
+        <div className="shrink-0 rounded-xl border border-white/10 bg-black/25 p-2 text-[color:var(--accent)]">
+          <Building2 size={18} />
+        </div>
+        <div className="min-w-0">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[color:var(--text-muted)]">
+            Peer Set
+          </p>
+          <h2 className="break-words font-display text-lg text-[color:var(--text-primary)]">
+            Closest Public Comparables
+          </h2>
+        </div>
       </div>
-      {body ? (
-        <MarketMarkdown text={body} />
-      ) : (
-        <p className="text-sm text-zinc-500">{emptyText}</p>
-      )}
+
+      <div className="hib-market-table-wrap">
+        <table className="hib-market-table">
+          <thead>
+            <tr>
+              <th className="hib-market-table-head">Rank</th>
+              <th className="hib-market-table-head">Company</th>
+              <th className="hib-market-table-head">Why It Matters</th>
+              <th className="hib-market-table-head">Confidence</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.slice(1).map((row, idx) => (
+              <tr key={`${row.ticker || row.company_name}-${idx}`}>
+                <td className="hib-market-table-cell font-mono text-xs">{row.rank}</td>
+                <td className="hib-market-table-cell">
+                  <span className="font-mono font-semibold">
+                    {row.ticker || "-"}
+                    <InfoHint label={`About ${row.company_name || row.ticker}`} text={row.description} />
+                  </span>
+                  <span className="block text-[color:var(--text-muted)]">{row.company_name || "Unnamed company"}</span>
+                </td>
+                <td className="hib-market-table-cell">{row.rationale || "-"}</td>
+                <td className="hib-market-table-cell font-mono">{row.confidence ?? "-"}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </section>
   );
 }
 
-function MarketReviewSections({ text }: { text: string }) {
+function MarketReviewEssentials({ text }: { text: string }) {
   const sections = splitMarketSections(text);
   if (!sections.length) {
     return (
@@ -225,45 +353,43 @@ function MarketReviewSections({ text }: { text: string }) {
     );
   }
 
+  const ideas = extractKeyIdeas(sections);
+  const tables = extractImportantTables(sections);
+
   return (
-    <section className="min-w-0">
+    <section className="min-w-0 overflow-hidden rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
       <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
         <div>
           <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--text-muted)]">
-            Peer Market Review
+            Condensed Review
           </p>
-          <h2 className="font-display text-xl text-[color:var(--text-primary)]">Competitive Landscape</h2>
+          <h2 className="font-display text-xl text-[color:var(--text-primary)]">Key Read-Throughs</h2>
         </div>
-        <SmallCopyButton text={text} label="Copy Peer Market Review" />
+        <SmallCopyButton text={text} label="Copy Full Peer Market Review" />
       </div>
-      <div className="grid min-w-0 gap-3 lg:grid-cols-2">
-        {sections.map((section, idx) => {
-          const meta = sectionMeta(section.title);
-          const Icon = meta.icon;
-          return (
-            <article
-              key={`${section.title}-${idx}`}
-              className={[
-                "min-w-0 overflow-hidden rounded-2xl border border-white/10 bg-zinc-950/70 p-4",
-                meta.wide ? "lg:col-span-2" : "",
-              ].join(" ")}
-            >
-              <div className="mb-3 flex min-w-0 items-start gap-3">
-                <div className="shrink-0 rounded-xl border border-white/10 bg-black/25 p-2 text-[color:var(--accent)]">
-                  <Icon size={18} />
-                </div>
-                <div className="min-w-0">
-                  <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[color:var(--text-muted)]">
-                    {meta.eyebrow}
-                  </p>
-                  <h3 className="break-words font-display text-lg text-[color:var(--text-primary)]">{section.title}</h3>
-                </div>
-              </div>
-              <MarketMarkdown text={section.body} />
-            </article>
-          );
-        })}
-      </div>
+
+      {ideas.length ? (
+        <div className="grid gap-2 md:grid-cols-2">
+          {ideas.map((idea, idx) => (
+            <p key={`${idea}-${idx}`} className="min-w-0 rounded-xl border border-white/10 bg-black/25 p-3 text-sm leading-relaxed text-[color:var(--text-secondary)]">
+              {idea}
+            </p>
+          ))}
+        </div>
+      ) : null}
+
+      {tables.length ? (
+        <div className="mt-4 grid gap-4">
+          {tables.map((item, idx) => (
+            <div key={`${item.title}-${idx}`} className="min-w-0">
+              <h3 className="mb-2 break-words text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--text-muted)]">
+                {item.title}
+              </h3>
+              <MarketMarkdown text={item.table} />
+            </div>
+          ))}
+        </div>
+      ) : null}
     </section>
   );
 }
@@ -273,22 +399,7 @@ function competitorRows(payload: MarketReviewPayload | undefined) {
 }
 
 function MarketDataComparison({ market, ticker }: { market: MarketReviewPayload; ticker: string }) {
-  const original = market.original_company || {};
-  const originalInfo = infoRecord(original.info);
-  const rows = [
-    {
-      rank: "Own",
-      ticker: original.ticker || ticker,
-      company_name: original.company_name || ticker,
-      info: originalInfo,
-    },
-    ...competitorRows(market).map((row) => ({
-      rank: row.rank ? `#${row.rank}` : "Peer",
-      ticker: row.ticker || "",
-      company_name: row.company_name || "",
-      info: infoRecord(row.info),
-    })),
-  ].filter((row) => row.ticker || row.company_name || Object.keys(row.info).length);
+  const rows = buildComparisonRows(market, ticker);
 
   if (!rows.length || rows.every((row) => !Object.keys(row.info).length)) return null;
 
@@ -332,7 +443,10 @@ function MarketDataComparison({ market, ticker }: { market: MarketReviewPayload;
                 <tr key={`${row.ticker || row.company_name}-${idx}`}>
                   <td className="hib-market-table-cell font-mono text-xs">{row.rank}</td>
                   <td className="hib-market-table-cell">
-                    <span className="block font-mono font-semibold">{row.ticker || "-"}</span>
+                    <span className="font-mono font-semibold">
+                      {row.ticker || "-"}
+                      <InfoHint label={`About ${row.company_name || row.ticker}`} text={row.description} />
+                    </span>
                     <span className="block text-[color:var(--text-muted)]">{row.company_name || "Unnamed company"}</span>
                   </td>
                   <td className="hib-market-table-cell font-mono">{formatLarge(info.marketCap)}</td>
@@ -358,9 +472,8 @@ export function MarketClient({ ticker, data, reportsForTicker, resolvedReportId 
   const market = data.market_review || {};
   const rows = competitorRows(market);
   const reviewMarkdown = markdownText(market.review_markdown);
-  const marketAgentMarkdown = markdownText(market.market_agent_markdown);
   const status = String(market.status || "unavailable");
-  const hasReview = Boolean(reviewMarkdown || marketAgentMarkdown || rows.length);
+  const hasReview = Boolean(reviewMarkdown || rows.length);
   const marketName = markdownText(market.name_of_market) || "Market context";
   const error = markdownText(market.error);
 
@@ -391,37 +504,12 @@ export function MarketClient({ ticker, data, reportsForTicker, resolvedReportId 
       ) : null}
 
       {rows.length ? (
-        <section className="mb-4 min-w-0 overflow-hidden rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
-          <h2 className="text-xs font-semibold uppercase tracking-[0.16em] text-zinc-300">Closest Public Peers</h2>
-          <div className="mt-3 grid gap-2 md:grid-cols-2 xl:grid-cols-3">
-            {rows.map((row, idx) => (
-              <article key={`${row.ticker || "competitor"}-${idx}`} className="min-w-0 overflow-hidden rounded-xl border border-white/10 bg-black/25 p-3">
-                <div className="flex items-start justify-between gap-3">
-                  <div className="min-w-0">
-                    <p className="break-words font-mono text-sm font-semibold text-zinc-100">{row.ticker || "N/A"}</p>
-                    <p className="break-words text-sm text-zinc-300">{row.company_name || "Unnamed company"}</p>
-                  </div>
-                  <span className="rounded-full border border-white/10 px-2 py-0.5 text-[10px] uppercase tracking-[0.14em] text-zinc-400">
-                    #{row.rank || idx + 1}
-                  </span>
-                </div>
-                {row.similarity_rationale ? (
-                  <p className="mt-2 break-words text-xs leading-relaxed text-zinc-400">{row.similarity_rationale}</p>
-                ) : null}
-              </article>
-            ))}
-          </div>
-        </section>
+        <PeerOverviewTable market={market} ticker={ticker} />
       ) : null}
 
       <div className="grid gap-4">
         <MarketDataComparison market={market} ticker={ticker} />
-        <MarketReviewSections text={reviewMarkdown} />
-        <MarkdownPanel
-          title="Market Analysis"
-          text={marketAgentMarkdown}
-          emptyText="No current market-agent text was found for this report."
-        />
+        <MarketReviewEssentials text={reviewMarkdown} />
       </div>
     </div>
   );

--- a/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
@@ -410,6 +410,7 @@ export function MarketClient({ ticker, data, reportsForTicker, resolvedReportId 
   const market = data.market_review || {};
   const rows = competitorRows(market);
   const status = String(market.status || "unavailable");
+  const showStatus = status.trim().toLowerCase() !== "success";
   const hasReview = Boolean(rows.length);
   const marketName = markdownText(market.name_of_market) || "Market context";
   const error = markdownText(market.error);
@@ -424,10 +425,12 @@ export function MarketClient({ ticker, data, reportsForTicker, resolvedReportId 
           <h1 className="font-display text-2xl text-zinc-100">Market</h1>
           <p className="mt-1 max-w-full break-words text-sm text-zinc-400">{marketName}</p>
         </div>
-        <div className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-zinc-950/70 px-3 py-2 text-xs text-zinc-300">
-          <Store size={14} />
-          <span className="font-semibold uppercase tracking-[0.14em]">{status}</span>
-        </div>
+        {showStatus ? (
+          <div className="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-zinc-950/70 px-3 py-2 text-xs text-zinc-300">
+            <Store size={14} />
+            <span className="font-semibold uppercase tracking-[0.14em]">{status}</span>
+          </div>
+        ) : null}
       </header>
 
       {!hasReview ? (

--- a/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import {
+  BarChart3,
   Building2,
   Store,
+  TrendingUp,
 } from "lucide-react";
 
 import { ReportChipRow } from "@/components/dashboard-chrome";
@@ -92,16 +94,25 @@ function buildComparisonRows(market: MarketReviewPayload, ticker: string): Compa
         ticker: String(row.ticker || ""),
         company_name: String(row.company_name || ""),
         info,
-        rationale: compactText(row.similarity_rationale || row.overlap_notes, 150),
+        rationale: compactText(row.similarity_rationale || row.overlap_notes, 360),
         confidence: row.confidence,
       };
     }),
   ].filter((row) => row.ticker || row.company_name || Object.keys(row.info).length);
 }
 
-function PeerComparisonMatrix({ market, ticker }: { market: MarketReviewPayload; ticker: string }) {
+function CompanyCell({ row }: { row: ComparisonRow }) {
+  return (
+    <td className="hib-market-table-cell">
+      <span className="font-mono font-semibold">{row.ticker || "-"}</span>
+      <span className="block text-[color:var(--text-muted)]">{row.company_name || "Unnamed company"}</span>
+    </td>
+  );
+}
+
+function PeerStrategyTable({ market, ticker }: { market: MarketReviewPayload; ticker: string }) {
   const rows = buildComparisonRows(market, ticker);
-  if (!rows.length) return null;
+  if (rows.length <= 1) return null;
 
   return (
     <section className="min-w-0 overflow-hidden rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
@@ -111,10 +122,10 @@ function PeerComparisonMatrix({ market, ticker }: { market: MarketReviewPayload;
         </div>
         <div className="min-w-0">
           <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[color:var(--text-muted)]">
-            Peer Matrix
+            Peer Set
           </p>
           <h2 className="break-words font-display text-lg text-[color:var(--text-primary)]">
-            Competitive And Financial Comparison
+            Strategic Comparable Map
           </h2>
         </div>
       </div>
@@ -127,9 +138,105 @@ function PeerComparisonMatrix({ market, ticker }: { market: MarketReviewPayload;
               <th className="hib-market-table-head">Company</th>
               <th className="hib-market-table-head">Comparable Basis</th>
               <th className="hib-market-table-head">Resemblance</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.slice(1).map((row, idx) => (
+              <tr key={`${row.ticker || row.company_name}-${idx}`}>
+                <td className="hib-market-table-cell font-mono text-xs">{row.rank}</td>
+                <CompanyCell row={row} />
+                <td className="hib-market-table-cell max-w-[42rem] whitespace-normal break-words leading-relaxed">
+                  {row.rationale || "-"}
+                </td>
+                <td className="hib-market-table-cell font-mono">{formatResemblance(row.confidence)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+function FinancialScaleTable({ market, ticker }: { market: MarketReviewPayload; ticker: string }) {
+  const rows = buildComparisonRows(market, ticker);
+  if (!rows.length || rows.every((row) => !Object.keys(row.info).length)) return null;
+
+  return (
+    <section className="min-w-0 overflow-hidden rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
+      <div className="mb-3 flex min-w-0 items-start gap-3">
+        <div className="shrink-0 rounded-xl border border-white/10 bg-black/25 p-2 text-[color:var(--accent)]">
+          <BarChart3 size={18} />
+        </div>
+        <div className="min-w-0">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[color:var(--text-muted)]">
+            Financial Scale
+          </p>
+          <h2 className="break-words font-display text-lg text-[color:var(--text-primary)]">
+            Size And Growth
+          </h2>
+        </div>
+      </div>
+
+      <div className="hib-market-table-wrap">
+        <table className="hib-market-table">
+          <thead>
+            <tr>
+              <th className="hib-market-table-head">Rank</th>
+              <th className="hib-market-table-head">Company</th>
               <th className="hib-market-table-head">Market Cap</th>
+              <th className="hib-market-table-head">EV</th>
               <th className="hib-market-table-head">Revenue</th>
               <th className="hib-market-table-head">Rev Growth</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, idx) => {
+              const info = row.info;
+              return (
+                <tr key={`${row.ticker || row.company_name}-${idx}`}>
+                  <td className="hib-market-table-cell font-mono text-xs">{row.rank}</td>
+                  <CompanyCell row={row} />
+                  <td className="hib-market-table-cell font-mono">{formatLarge(info.marketCap)}</td>
+                  <td className="hib-market-table-cell font-mono">{formatLarge(info.enterpriseValue)}</td>
+                  <td className="hib-market-table-cell font-mono">{formatLarge(info.totalRevenue)}</td>
+                  <td className="hib-market-table-cell font-mono">{formatPercent(info.revenueGrowth)}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+function MarginValuationTable({ market, ticker }: { market: MarketReviewPayload; ticker: string }) {
+  const rows = buildComparisonRows(market, ticker);
+  if (!rows.length || rows.every((row) => !Object.keys(row.info).length)) return null;
+
+  return (
+    <section className="min-w-0 overflow-hidden rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
+      <div className="mb-3 flex min-w-0 items-start gap-3">
+        <div className="shrink-0 rounded-xl border border-white/10 bg-black/25 p-2 text-[color:var(--accent)]">
+          <TrendingUp size={18} />
+        </div>
+        <div className="min-w-0">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[color:var(--text-muted)]">
+            Profitability And Multiples
+          </p>
+          <h2 className="break-words font-display text-lg text-[color:var(--text-primary)]">
+            Margins And Valuation
+          </h2>
+        </div>
+      </div>
+
+      <div className="hib-market-table-wrap">
+        <table className="hib-market-table">
+          <thead>
+            <tr>
+              <th className="hib-market-table-head">Rank</th>
+              <th className="hib-market-table-head">Company</th>
               <th className="hib-market-table-head">Gross Margin</th>
               <th className="hib-market-table-head">EBITDA Margin</th>
               <th className="hib-market-table-head">Net Margin</th>
@@ -143,15 +250,7 @@ function PeerComparisonMatrix({ market, ticker }: { market: MarketReviewPayload;
               return (
                 <tr key={`${row.ticker || row.company_name}-${idx}`}>
                   <td className="hib-market-table-cell font-mono text-xs">{row.rank}</td>
-                  <td className="hib-market-table-cell">
-                    <span className="font-mono font-semibold">{row.ticker || "-"}</span>
-                    <span className="block text-[color:var(--text-muted)]">{row.company_name || "Unnamed company"}</span>
-                  </td>
-                  <td className="hib-market-table-cell">{row.rationale || (idx === 0 ? "Original company" : "-")}</td>
-                  <td className="hib-market-table-cell font-mono">{idx === 0 ? "100%" : formatResemblance(row.confidence)}</td>
-                  <td className="hib-market-table-cell font-mono">{formatLarge(info.marketCap)}</td>
-                  <td className="hib-market-table-cell font-mono">{formatLarge(info.totalRevenue)}</td>
-                  <td className="hib-market-table-cell font-mono">{formatPercent(info.revenueGrowth)}</td>
+                  <CompanyCell row={row} />
                   <td className="hib-market-table-cell font-mono">{formatPercent(info.grossMargins)}</td>
                   <td className="hib-market-table-cell font-mono">{formatPercent(info.ebitdaMargins)}</td>
                   <td className="hib-market-table-cell font-mono">{formatPercent(info.profitMargins)}</td>
@@ -206,7 +305,9 @@ export function MarketClient({ ticker, data, reportsForTicker, resolvedReportId 
       ) : null}
 
       <div className="grid gap-4">
-        <PeerComparisonMatrix market={market} ticker={ticker} />
+        <PeerStrategyTable market={market} ticker={ticker} />
+        <FinancialScaleTable market={market} ticker={ticker} />
+        <MarginValuationTable market={market} ticker={ticker} />
       </div>
     </div>
   );

--- a/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
@@ -160,7 +160,7 @@ function buildComparisonRows(market: MarketReviewPayload, ticker: string): Compa
         ticker: String(row.ticker || ""),
         company_name: String(row.company_name || ""),
         info,
-        rationale: compactText(row.similarity_rationale || row.overlap_notes, 360),
+        rationale: markdownText(row.similarity_rationale || row.overlap_notes),
         confidence: row.confidence,
       };
     }),

--- a/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
@@ -3,15 +3,10 @@
 import {
   BarChart3,
   Building2,
-  Info,
   Store,
 } from "lucide-react";
-import ReactMarkdown from "react-markdown";
-import type { Components } from "react-markdown";
-import remarkGfm from "remark-gfm";
 
 import { ReportChipRow } from "@/components/dashboard-chrome";
-import { SmallCopyButton } from "@/components/hedge-dashboard";
 import type { DashboardPayload, MarketReviewPayload, ReportListItem } from "@/lib/dashboard-types";
 
 type MarketClientProps = {
@@ -23,17 +18,6 @@ type MarketClientProps = {
 
 function markdownText(value: unknown): string {
   return String(value || "").trim();
-}
-
-function normalizeTableMissingValues(text: string): string {
-  return String(text || "")
-    .split("\n")
-    .map((line) => (
-      line.includes("|")
-        ? line.replace(/(\|\s*)(?:n\/a|N\/A)(\s*(?=\|))/g, "$1-$2")
-        : line
-    ))
-    .join("\n");
 }
 
 function numeric(value: unknown): number | null {
@@ -68,99 +52,19 @@ function infoRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
 }
 
-type MarketSection = {
-  title: string;
-  body: string;
-};
-
-const marketMarkdownComponents: Components = {
-  table({ node: _node, ...props }) {
-    return (
-      <div className="hib-market-table-wrap">
-        <table className="hib-market-table" {...props} />
-      </div>
-    );
-  },
-  th({ node: _node, ...props }) {
-    return <th className="hib-market-table-head" {...props} />;
-  },
-  td({ node: _node, ...props }) {
-    return <td className="hib-market-table-cell" {...props} />;
-  },
-  a({ node: _node, ...props }) {
-    return <a className="font-semibold text-[color:var(--info)] underline-offset-4 hover:underline" {...props} />;
-  },
-};
-
 type ComparisonRow = {
   rank: string;
   ticker: string;
   company_name: string;
   info: Record<string, unknown>;
-  description: string;
   rationale?: string;
   confidence?: string | number | null;
 };
-
-function splitMarketSections(text: string): MarketSection[] {
-  const src = markdownText(text).replace(/\r\n/g, "\n");
-  if (!src) return [];
-
-  const lines = src.split("\n");
-  const sections: MarketSection[] = [];
-  let currentTitle = "Market Review";
-  let currentBody: string[] = [];
-  let sawSection = false;
-
-  const flush = () => {
-    const body = currentBody.join("\n").trim();
-    if (body || currentTitle !== "Market Review") {
-      sections.push({ title: currentTitle, body });
-    }
-    currentBody = [];
-  };
-
-  for (const line of lines) {
-    const match = line.match(/^##\s+(.+?)\s*$/);
-    if (match) {
-      if (sawSection || currentBody.join("\n").trim()) flush();
-      currentTitle = match[1].trim();
-      sawSection = true;
-      continue;
-    }
-    currentBody.push(line);
-  }
-  flush();
-
-  return sections.filter((section) => section.body || section.title);
-}
-
-function MarketMarkdown({ text }: { text: string }) {
-  const normalized = normalizeTableMissingValues(text);
-  return (
-    <div className="hib-markdown hib-market-markdown min-w-0 max-w-full text-sm leading-relaxed text-zinc-200">
-      <ReactMarkdown remarkPlugins={[remarkGfm]} components={marketMarkdownComponents}>
-        {normalized}
-      </ReactMarkdown>
-    </div>
-  );
-}
 
 function compactText(value: unknown, maxLength = 190): string {
   const clean = markdownText(value).replace(/\s+/g, " ");
   if (clean.length <= maxLength) return clean;
   return `${clean.slice(0, maxLength - 1).trimEnd()}...`;
-}
-
-function companyDescription(info: Record<string, unknown>, fallback: unknown): string {
-  return compactText(
-    info.longBusinessSummary ||
-      info.businessSummary ||
-      info.description ||
-      info.longName ||
-      fallback,
-    320
-  );
 }
 
 function buildComparisonRows(market: MarketReviewPayload, ticker: string): ComparisonRow[] {
@@ -172,7 +76,6 @@ function buildComparisonRows(market: MarketReviewPayload, ticker: string): Compa
       ticker: String(original.ticker || ticker),
       company_name: String(original.company_name || ticker),
       info: originalInfo,
-      description: companyDescription(originalInfo, market.name_of_market),
     },
     ...competitorRows(market).map((row) => {
       const info = infoRecord(row.info);
@@ -181,113 +84,11 @@ function buildComparisonRows(market: MarketReviewPayload, ticker: string): Compa
         ticker: String(row.ticker || ""),
         company_name: String(row.company_name || ""),
         info,
-        description: companyDescription(info, row.similarity_rationale || row.overlap_notes),
         rationale: compactText(row.similarity_rationale || row.overlap_notes, 150),
         confidence: row.confidence,
       };
     }),
   ].filter((row) => row.ticker || row.company_name || Object.keys(row.info).length);
-}
-
-function InfoHint({ label, text }: { label: string; text: string }) {
-  if (!text) return null;
-  return (
-    <span className="relative inline-flex align-middle">
-      <button
-        type="button"
-        title={text}
-        aria-label={label}
-        className="ml-1 inline-flex size-5 items-center justify-center rounded-full border border-white/10 bg-black/25 text-[color:var(--info)]"
-      >
-        <Info size={12} />
-      </button>
-    </span>
-  );
-}
-
-function sectionRank(title: string): number {
-  const normalized = title.toLowerCase();
-  if (normalized.includes("financial comparison")) return 0;
-  if (normalized.includes("ranked competitor")) return 1;
-  if (normalized.includes("product") || normalized.includes("customer")) return 2;
-  if (normalized.includes("valuation")) return 3;
-  if (normalized.includes("competitive positioning")) return 4;
-  return 9;
-}
-
-function extractMarkdownTables(body: string): string[] {
-  const lines = markdownText(body).replace(/\r\n/g, "\n").split("\n");
-  const tables: string[] = [];
-  let block: string[] = [];
-
-  const flush = () => {
-    if (block.length >= 2 && block.some((line) => /\|\s*:?-{3,}:?\s*\|/.test(line))) {
-      tables.push(block.join("\n").trim());
-    }
-    block = [];
-  };
-
-  for (const line of lines) {
-    if (line.includes("|")) {
-      block.push(line);
-    } else {
-      flush();
-    }
-  }
-  flush();
-
-  return tables;
-}
-
-function stripMarkdownTables(body: string): string {
-  return markdownText(body)
-    .replace(/\r\n/g, "\n")
-    .split("\n")
-    .filter((line) => !line.includes("|"))
-    .join("\n");
-}
-
-function cleanIdea(value: string): string {
-  return compactText(
-    value
-      .replace(/^[-*]\s+/, "")
-      .replace(/^#+\s+/, "")
-      .replace(/\*\*/g, "")
-      .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1"),
-    170
-  );
-}
-
-function extractKeyIdeas(sections: MarketSection[]): string[] {
-  const ranked = [...sections].sort((a, b) => sectionRank(a.title) - sectionRank(b.title));
-  const ideas: string[] = [];
-
-  for (const section of ranked) {
-    const text = stripMarkdownTables(section.body);
-    const candidates = text
-      .split(/\n+|(?<=\.)\s+/)
-      .map(cleanIdea)
-      .filter((line) => line.length >= 40 && !line.toLowerCase().startsWith("n/a"));
-
-    for (const candidate of candidates) {
-      if (!ideas.some((idea) => idea.toLowerCase() === candidate.toLowerCase())) {
-        ideas.push(candidate);
-      }
-      if (ideas.length >= 4) return ideas;
-    }
-  }
-
-  return ideas;
-}
-
-function extractImportantTables(sections: MarketSection[]) {
-  return [...sections]
-    .sort((a, b) => sectionRank(a.title) - sectionRank(b.title))
-    .flatMap((section) => extractMarkdownTables(section.body).slice(0, 1).map((table) => ({
-      title: section.title,
-      table,
-    })))
-    .slice(0, 2);
 }
 
 function PeerOverviewTable({ market, ticker }: { market: MarketReviewPayload; ticker: string }) {
@@ -316,8 +117,8 @@ function PeerOverviewTable({ market, ticker }: { market: MarketReviewPayload; ti
             <tr>
               <th className="hib-market-table-head">Rank</th>
               <th className="hib-market-table-head">Company</th>
-              <th className="hib-market-table-head">Why It Matters</th>
-              <th className="hib-market-table-head">Confidence</th>
+              <th className="hib-market-table-head">Comparable Basis</th>
+              <th className="hib-market-table-head">Resemblance</th>
             </tr>
           </thead>
           <tbody>
@@ -325,10 +126,7 @@ function PeerOverviewTable({ market, ticker }: { market: MarketReviewPayload; ti
               <tr key={`${row.ticker || row.company_name}-${idx}`}>
                 <td className="hib-market-table-cell font-mono text-xs">{row.rank}</td>
                 <td className="hib-market-table-cell">
-                  <span className="font-mono font-semibold">
-                    {row.ticker || "-"}
-                    <InfoHint label={`About ${row.company_name || row.ticker}`} text={row.description} />
-                  </span>
+                  <span className="font-mono font-semibold">{row.ticker || "-"}</span>
                   <span className="block text-[color:var(--text-muted)]">{row.company_name || "Unnamed company"}</span>
                 </td>
                 <td className="hib-market-table-cell">{row.rationale || "-"}</td>
@@ -338,58 +136,6 @@ function PeerOverviewTable({ market, ticker }: { market: MarketReviewPayload; ti
           </tbody>
         </table>
       </div>
-    </section>
-  );
-}
-
-function MarketReviewEssentials({ text }: { text: string }) {
-  const sections = splitMarketSections(text);
-  if (!sections.length) {
-    return (
-      <section className="min-w-0 overflow-hidden rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
-        <h2 className="text-xs font-semibold uppercase tracking-[0.16em] text-zinc-300">Peer Market Review</h2>
-        <p className="mt-3 text-sm text-zinc-500">No competitor market review was stored for this report.</p>
-      </section>
-    );
-  }
-
-  const ideas = extractKeyIdeas(sections);
-  const tables = extractImportantTables(sections);
-
-  return (
-    <section className="min-w-0 overflow-hidden rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
-      <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--text-muted)]">
-            Condensed Review
-          </p>
-          <h2 className="font-display text-xl text-[color:var(--text-primary)]">Key Read-Throughs</h2>
-        </div>
-        <SmallCopyButton text={text} label="Copy Full Peer Market Review" />
-      </div>
-
-      {ideas.length ? (
-        <div className="grid gap-2 md:grid-cols-2">
-          {ideas.map((idea, idx) => (
-            <p key={`${idea}-${idx}`} className="min-w-0 rounded-xl border border-white/10 bg-black/25 p-3 text-sm leading-relaxed text-[color:var(--text-secondary)]">
-              {idea}
-            </p>
-          ))}
-        </div>
-      ) : null}
-
-      {tables.length ? (
-        <div className="mt-4 grid gap-4">
-          {tables.map((item, idx) => (
-            <div key={`${item.title}-${idx}`} className="min-w-0">
-              <h3 className="mb-2 break-words text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--text-muted)]">
-                {item.title}
-              </h3>
-              <MarketMarkdown text={item.table} />
-            </div>
-          ))}
-        </div>
-      ) : null}
     </section>
   );
 }
@@ -443,10 +189,7 @@ function MarketDataComparison({ market, ticker }: { market: MarketReviewPayload;
                 <tr key={`${row.ticker || row.company_name}-${idx}`}>
                   <td className="hib-market-table-cell font-mono text-xs">{row.rank}</td>
                   <td className="hib-market-table-cell">
-                    <span className="font-mono font-semibold">
-                      {row.ticker || "-"}
-                      <InfoHint label={`About ${row.company_name || row.ticker}`} text={row.description} />
-                    </span>
+                    <span className="font-mono font-semibold">{row.ticker || "-"}</span>
                     <span className="block text-[color:var(--text-muted)]">{row.company_name || "Unnamed company"}</span>
                   </td>
                   <td className="hib-market-table-cell font-mono">{formatLarge(info.marketCap)}</td>
@@ -471,9 +214,8 @@ function MarketDataComparison({ market, ticker }: { market: MarketReviewPayload;
 export function MarketClient({ ticker, data, reportsForTicker, resolvedReportId }: MarketClientProps) {
   const market = data.market_review || {};
   const rows = competitorRows(market);
-  const reviewMarkdown = markdownText(market.review_markdown);
   const status = String(market.status || "unavailable");
-  const hasReview = Boolean(reviewMarkdown || rows.length);
+  const hasReview = Boolean(rows.length);
   const marketName = markdownText(market.name_of_market) || "Market context";
   const error = markdownText(market.error);
 
@@ -509,7 +251,6 @@ export function MarketClient({ ticker, data, reportsForTicker, resolvedReportId 
 
       <div className="grid gap-4">
         <MarketDataComparison market={market} ticker={ticker} />
-        <MarketReviewEssentials text={reviewMarkdown} />
       </div>
     </div>
   );

--- a/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-  BarChart3,
   Building2,
   Store,
 } from "lucide-react";
@@ -48,6 +47,15 @@ function formatMultiple(value: unknown): string {
   return `${n.toFixed(1)}x`;
 }
 
+function formatResemblance(value: unknown): string {
+  const text = markdownText(value);
+  if (!text) return "-";
+  const n = Number(text);
+  if (!Number.isFinite(n)) return text;
+  if (n > 0 && n <= 1) return `${Math.round(n * 100)}%`;
+  return `${Math.round(n)}%`;
+}
+
 function infoRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
 }
@@ -91,9 +99,9 @@ function buildComparisonRows(market: MarketReviewPayload, ticker: string): Compa
   ].filter((row) => row.ticker || row.company_name || Object.keys(row.info).length);
 }
 
-function PeerOverviewTable({ market, ticker }: { market: MarketReviewPayload; ticker: string }) {
+function PeerComparisonMatrix({ market, ticker }: { market: MarketReviewPayload; ticker: string }) {
   const rows = buildComparisonRows(market, ticker);
-  if (rows.length <= 1) return null;
+  if (!rows.length) return null;
 
   return (
     <section className="min-w-0 overflow-hidden rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
@@ -103,10 +111,10 @@ function PeerOverviewTable({ market, ticker }: { market: MarketReviewPayload; ti
         </div>
         <div className="min-w-0">
           <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[color:var(--text-muted)]">
-            Peer Set
+            Peer Matrix
           </p>
           <h2 className="break-words font-display text-lg text-[color:var(--text-primary)]">
-            Closest Public Comparables
+            Competitive And Financial Comparison
           </h2>
         </div>
       </div>
@@ -119,60 +127,7 @@ function PeerOverviewTable({ market, ticker }: { market: MarketReviewPayload; ti
               <th className="hib-market-table-head">Company</th>
               <th className="hib-market-table-head">Comparable Basis</th>
               <th className="hib-market-table-head">Resemblance</th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.slice(1).map((row, idx) => (
-              <tr key={`${row.ticker || row.company_name}-${idx}`}>
-                <td className="hib-market-table-cell font-mono text-xs">{row.rank}</td>
-                <td className="hib-market-table-cell">
-                  <span className="font-mono font-semibold">{row.ticker || "-"}</span>
-                  <span className="block text-[color:var(--text-muted)]">{row.company_name || "Unnamed company"}</span>
-                </td>
-                <td className="hib-market-table-cell">{row.rationale || "-"}</td>
-                <td className="hib-market-table-cell font-mono">{row.confidence ?? "-"}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </section>
-  );
-}
-
-function competitorRows(payload: MarketReviewPayload | undefined) {
-  return Array.isArray(payload?.competitors) ? payload.competitors.slice(0, 5) : [];
-}
-
-function MarketDataComparison({ market, ticker }: { market: MarketReviewPayload; ticker: string }) {
-  const rows = buildComparisonRows(market, ticker);
-
-  if (!rows.length || rows.every((row) => !Object.keys(row.info).length)) return null;
-
-  return (
-    <section className="min-w-0 overflow-hidden rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
-      <div className="mb-3 flex min-w-0 items-start gap-3">
-        <div className="shrink-0 rounded-xl border border-white/10 bg-black/25 p-2 text-[color:var(--accent)]">
-          <BarChart3 size={18} />
-        </div>
-        <div className="min-w-0">
-          <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[color:var(--text-muted)]">
-            Peer Comparison
-          </p>
-          <h2 className="break-words font-display text-lg text-[color:var(--text-primary)]">
-            Original Company vs Public Peers
-          </h2>
-        </div>
-      </div>
-
-      <div className="hib-market-table-wrap">
-        <table className="hib-market-table">
-          <thead>
-            <tr>
-              <th className="hib-market-table-head">Rank</th>
-              <th className="hib-market-table-head">Company</th>
               <th className="hib-market-table-head">Market Cap</th>
-              <th className="hib-market-table-head">EV</th>
               <th className="hib-market-table-head">Revenue</th>
               <th className="hib-market-table-head">Rev Growth</th>
               <th className="hib-market-table-head">Gross Margin</th>
@@ -192,8 +147,9 @@ function MarketDataComparison({ market, ticker }: { market: MarketReviewPayload;
                     <span className="font-mono font-semibold">{row.ticker || "-"}</span>
                     <span className="block text-[color:var(--text-muted)]">{row.company_name || "Unnamed company"}</span>
                   </td>
+                  <td className="hib-market-table-cell">{row.rationale || (idx === 0 ? "Original company" : "-")}</td>
+                  <td className="hib-market-table-cell font-mono">{idx === 0 ? "100%" : formatResemblance(row.confidence)}</td>
                   <td className="hib-market-table-cell font-mono">{formatLarge(info.marketCap)}</td>
-                  <td className="hib-market-table-cell font-mono">{formatLarge(info.enterpriseValue)}</td>
                   <td className="hib-market-table-cell font-mono">{formatLarge(info.totalRevenue)}</td>
                   <td className="hib-market-table-cell font-mono">{formatPercent(info.revenueGrowth)}</td>
                   <td className="hib-market-table-cell font-mono">{formatPercent(info.grossMargins)}</td>
@@ -209,6 +165,10 @@ function MarketDataComparison({ market, ticker }: { market: MarketReviewPayload;
       </div>
     </section>
   );
+}
+
+function competitorRows(payload: MarketReviewPayload | undefined) {
+  return Array.isArray(payload?.competitors) ? payload.competitors.slice(0, 5) : [];
 }
 
 export function MarketClient({ ticker, data, reportsForTicker, resolvedReportId }: MarketClientProps) {
@@ -245,12 +205,8 @@ export function MarketClient({ ticker, data, reportsForTicker, resolvedReportId 
         </section>
       ) : null}
 
-      {rows.length ? (
-        <PeerOverviewTable market={market} ticker={ticker} />
-      ) : null}
-
       <div className="grid gap-4">
-        <MarketDataComparison market={market} ticker={ticker} />
+        <PeerComparisonMatrix market={market} ticker={ticker} />
       </div>
     </div>
   );

--- a/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
@@ -314,7 +314,7 @@ function FinancialScaleTable({ market, ticker }: { market: MarketReviewPayload; 
               <th className="hib-market-table-head">Company</th>
               <th className="hib-market-table-head">Market Cap</th>
               <th className="hib-market-table-head">EV</th>
-              <th className="hib-market-table-head">Revenue</th>
+              <th className="hib-market-table-head">Revenue (TTM)</th>
               <th className="hib-market-table-head">Rev Growth</th>
             </tr>
           </thead>
@@ -365,11 +365,11 @@ function MarginValuationTable({ market, ticker }: { market: MarketReviewPayload;
             <tr>
               <th className="hib-market-table-head">Rank</th>
               <th className="hib-market-table-head">Company</th>
-              <th className="hib-market-table-head">Gross Margin</th>
-              <th className="hib-market-table-head">EBITDA Margin</th>
-              <th className="hib-market-table-head">Net Margin</th>
-              <th className="hib-market-table-head">P/E</th>
-              <th className="hib-market-table-head">EV/Revenue</th>
+              <th className="hib-market-table-head">Gross Margin (TTM)</th>
+              <th className="hib-market-table-head">EBITDA Margin (TTM)</th>
+              <th className="hib-market-table-head">Net Margin (TTM)</th>
+              <th className="hib-market-table-head">P/E (TTM)</th>
+              <th className="hib-market-table-head">EV/Revenue (TTM)</th>
             </tr>
           </thead>
           <tbody>

--- a/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
@@ -197,12 +197,20 @@ function PeerStrategyTable({ market, ticker }: { market: MarketReviewPayload; ti
       </div>
 
       <div className="hib-market-table-wrap">
-        <table className="hib-market-table">
+        <table className="hib-market-table min-w-[58rem] table-fixed">
+          <colgroup>
+            <col className="w-[5rem]" />
+            <col className="w-[14rem]" />
+            <col className="w-[32rem]" />
+            <col className="w-[7rem]" />
+          </colgroup>
           <thead>
             <tr>
               <th className="hib-market-table-head">Rank</th>
               <th className="hib-market-table-head">Company</th>
-              <th className="hib-market-table-head">Comparable Basis</th>
+              <th className="hib-market-table-head">
+                <span className="whitespace-nowrap">Comparable Basis</span>
+              </th>
               <th className="hib-market-table-head">Resemblance</th>
             </tr>
           </thead>


### PR DESCRIPTION
﻿## Summary

- Simplifies the Market tab into a table-first layout without the old standalone market-analysis box.
- Restores a richer multi-table comparison view: Strategic Comparable Map, Product Overlap / Where They Compete, Size And Growth, and Margins And Valuation.
- Keeps the qualitative `Comparable Basis` column readable, restores the product/customer overlap markdown tables, and labels only trailing-period financial headers with `(TTM)`.

## Preview

URL: https://pr-97-hedge-in-a-box-site.fly.dev

## Test plan

- [x] `npm run build`
- [x] Site Preview deployed successfully after latest commit.
- [x] Verified `https://pr-97-hedge-in-a-box-site.fly.dev/dashboard/AAPL/market` returns HTTP 200.
- [x] Verified `https://pr-97-hedge-in-a-box-site.fly.dev/api/health` returns HTTP 200 / `ok`.

## Notes for reviewer

- UI-only change. The market review payload, saved analysis artifacts, and legacy market-agent text generation are intentionally untouched.
