### PR TITLE
[codex] Calibrate analysis prompts

### DIFF
--- a/src/ai_hedge/competitor_market_review.py
+++ b/src/ai_hedge/competitor_market_review.py
@@ -115,6 +115,12 @@ def normalize_competitors(
                 "company_name": str(item.get("company_name") or item.get("name") or "").strip(),
                 "similarity_rationale": str(item.get("similarity_rationale") or item.get("rationale") or "").strip(),
                 "overlap_notes": str(item.get("overlap_notes") or item.get("product_overlap") or "").strip(),
+                "direct_revenue_overlap": str(item.get("direct_revenue_overlap") or "").strip(),
+                "customer_overlap": str(item.get("customer_overlap") or "").strip(),
+                "business_model_overlap": str(item.get("business_model_overlap") or "").strip(),
+                "geography_overlap": str(item.get("geography_overlap") or "").strip(),
+                "similarity_score": item.get("similarity_score"),
+                "disqualifier_check": str(item.get("disqualifier_check") or "").strip(),
                 "country": country,
                 "exchange": str(item.get("exchange") or item.get("listing_exchange") or "").strip(),
                 "confidence": item.get("confidence"),
@@ -275,6 +281,10 @@ You are a senior public-equity industry analyst.
 Your task is to identify public companies most similar to the original company.
 Use the company's business description, sector, industry, products, customers, geography, and revenue model.
 
+Think in two passes before producing the JSON:
+1. Define the narrow investable market the original company actually competes in.
+2. Rank public companies by real business overlap, not by broad sector similarity.
+
 Original ticker: {ticker}
 Original country: {original_country or "Unknown"}
 Original company info_dict["info"]:
@@ -292,6 +302,12 @@ Return ONLY valid JSON with this exact shape:
       "exchange": "listing exchange",
       "similarity_rationale": "why this public company is similar",
       "overlap_notes": "products, customers, or business model overlap",
+      "direct_revenue_overlap": "high|medium|low - explain whether the companies make money from the same products/services",
+      "customer_overlap": "high|medium|low - explain whether they sell to the same buyer/user group",
+      "business_model_overlap": "high|medium|low - explain whether pricing, delivery model, and unit economics are comparable",
+      "geography_overlap": "high|medium|low - explain whether listing geography or operating geography improves comparability",
+      "similarity_score": 0,
+      "disqualifier_check": "state if this is a direct competitor, adjacent peer, supplier/customer, conglomerate segment, or weak broad-sector match",
       "confidence": "high|medium|low"
     }}
   ]
@@ -303,9 +319,15 @@ Rules:
 - Rank from most similar to least similar.
 - Return a ranked list of all strong public-company matches you can identify. It is okay to return more than 5.
 - The next stage will use only the top 5 ranked companies for financial enrichment, so put the best matches first.
+- Score similarity from 0 to 100. Use 80-100 for direct competitors, 60-79 for strong adjacent public peers, 40-59 for imperfect but useful comparables, and below 40 only when no better public peers exist.
+- Prefer direct revenue and customer overlap over generic sector, theme, or technology overlap.
+- Exclude ETFs, funds, indexes, private companies, suppliers/customers that are not competitors, and conglomerates where the comparable business is only a small or unclear segment.
+- If you include an adjacent peer rather than a direct competitor, say that clearly in "disqualifier_check" and rank it below direct competitors.
+- If the company operates in several markets, prioritize the market that appears most important to revenue and valuation today, not the most exciting optionality.
 - For non-US companies, use Yahoo Finance-compatible exchange suffixes.
 - {local_guidance or "For US companies, use the normal US ticker without an exchange suffix."}
 - Keep the market name specific, not a broad sector label.
+- Output JSON only. No markdown, commentary, or extra top-level keys.
 """.strip()
 
 
@@ -413,8 +435,21 @@ Rules:
 - Compare business model, scale, profitability, growth, pricing power, cyclicality, and competitive intensity.
 - Prefer Markdown tables for ranked competitors, financial comparison, product/customer overlap, and any exact-data comparison.
 - Make tables compact and directly useful: include tickers, latest available annual figures, growth or margin cues when present, and clear "-" cells when data is missing.
+- Ground every material claim in the payload. Use only:
+  1. original company info,
+  2. original annual income-statement table,
+  3. competitor discovery fields,
+  4. normalized competitor info,
+  5. competitor annual income-statement tables.
+- If a conclusion is an analyst inference rather than a directly stated fact, label it as an inference in the sentence or table cell.
+- Do not claim precise market share, growth rate, margin rank, or competitive superiority unless the payload provides enough data to support it.
+- In the Ranked Competitor Map table, include a compact "Why comparable" or "Evidence basis" column that uses the discovery overlap fields.
+- In the Financial Comparison table, include the original company plus competitors; use "-" for unavailable data and avoid filling gaps from memory.
+- In Product And Customer Overlap, separate direct competitors from adjacent comparables, suppliers/customers, or conglomerate segment peers when relevant.
+- In Valuation Implications, translate the peer comparison into valuation-relevant questions and risks; do not produce a target price or recommendation.
 - Do not make buy/sell/hold recommendations.
 - Do not include raw JSON.
+- Do not mention these instructions.
 """.strip()
 
 

--- a/src/ai_hedge/dashboard.py
+++ b/src/ai_hedge/dashboard.py
@@ -55,13 +55,18 @@ INSTRUCTION_BULL_CASE = """
 Build a strong "bull case" for the company.
 
 Goal:
-Extract and present 10-15 clear, high-quality reasons why this company could be a good investment.
+Extract and present up to 10-15 clear, high-quality reasons why this company could be a good investment.
 
 Important requirements:
 - Each point must be specific, meaningful, and grounded in the provided materials
 - Focus on business quality, growth potential, market opportunity, competitive positioning, and financial trajectory
 - Include both current strengths and future upside
 - Prefer insight over obvious statements
+- If the evidence is ordinary, mixed, or thin, say so plainly.
+- Do not force a non-obvious insight when the provided materials do not support one.
+- Distinguish evidence, inference, and speculation.
+- A neutral or low-conviction conclusion is acceptable.
+- Do not make the bull case stronger than the provided data supports.
 - Avoid generic or vague bullets (e.g. "the company has potential")
 - Avoid repeating the same idea in different wording
 - Keep each bullet short, sharp, and easy to read (1-2 lines max)
@@ -92,6 +97,7 @@ Do NOT:
 - give a final recommendation
 - write long explanations
 - include filler or weak points just to reach the count
+- include 10 reasons if fewer than 10 are genuinely supported
 
 Return JSON in exactly this structure:
 
@@ -112,13 +118,18 @@ INSTRUCTION_BEAR_CASE = """
 Build a strong "bear case" for the company.
 
 Goal:
-Extract and present 10-15 clear, high-quality reasons why this company could be a bad investment.
+Extract and present up to 10-15 clear, high-quality reasons why this company could be a bad investment.
 
 Important requirements:
 - Focus on real risks, weaknesses, and red flags
 - Each point must be specific, concrete, and grounded in the provided materials
 - Prefer serious risks over minor concerns
 - Be skeptical and critical, like a short-seller or risk manager
+- If the evidence is ordinary, mixed, or thin, say so plainly.
+- Do not force a non-obvious risk when the provided materials do not support one.
+- Distinguish evidence, inference, and speculation.
+- A neutral or low-conviction conclusion is acceptable.
+- Do not make the bear case stronger than the provided data supports.
 - Avoid generic statements (e.g. "competition exists")
 - Avoid repeating the same idea in different wording
 - Keep each bullet short, sharp, and easy to read (1-2 lines max)
@@ -151,6 +162,7 @@ Do NOT:
 - give a final recommendation
 - write long explanations
 - include weak or obvious risks just to fill space
+- include 10 risks if fewer than 10 are genuinely supported
 
 Return JSON in exactly this structure:
 

--- a/src/ai_hedge/legacy_port.py
+++ b/src/ai_hedge/legacy_port.py
@@ -1433,6 +1433,17 @@ def load_text_from_file(file_path: str = "analysis.txt") -> str:
 
 
 from typing import Tuple
+
+ANALYSIS_CALIBRATION_RULES = """
+Calibration rules:
+- If the evidence is ordinary, mixed, or thin, say so plainly.
+- Do not force a non-obvious insight when the provided material does not support one.
+- Distinguish evidence, inference, and speculation.
+- A neutral or low-conviction conclusion is acceptable.
+- Do not make the thesis stronger than the provided data supports.
+""".strip()
+
+
 def what_it_does_insights_result(info_dict) -> Tuple[str, str]:
     """
     Generate a clear, plain-language explanation of what the company actually does.
@@ -1463,6 +1474,8 @@ Guidelines:
 - Explain who the customers are and what problem the company solves.
 - Translate business jargon into plain, concrete language.
 - If multiple activities exist, explain the main one first and mention others briefly.
+
+{ANALYSIS_CALIBRATION_RULES}
 
 Write 5-7 short sentences.
 """.strip()
@@ -1522,6 +1535,8 @@ Rules:
 - If valuation implies extreme expectations, articulate them clearly.
 - If governance, ownership, margins, growth, or capital structure stand out, explain the consequences.
 - Connect business model, financials, and market expectations into a single coherent story.
+
+{ANALYSIS_CALIBRATION_RULES}
 
 Output format:
 - Bullet points only.
@@ -1593,6 +1608,8 @@ What to extract:
 - Market sentiment and expectation drift
 - Emerging risks or unresolved uncertainties
 - Upside optionality implied by recurring themes
+
+{ANALYSIS_CALIBRATION_RULES}
 
 Output rules:
 - Bullet points only
@@ -1668,6 +1685,8 @@ Output requirement:
 - No tables, no mechanics, no strike-by-strike listing
 - No trading recommendations
 - Each point should clearly connect option pricing to market perception of the company
+
+{ANALYSIS_CALIBRATION_RULES}
 
 What to extract:
 - Market-implied company narrative
@@ -1759,6 +1778,8 @@ Output rules:
 - Prioritize depth, judgment, and interpretation
 - Be precise, skeptical, and professional
 - No generic textbook explanations
+
+{ANALYSIS_CALIBRATION_RULES}
 
 Input:
 Name of company: {name_of_company}
@@ -1891,6 +1912,8 @@ Output rules:
 - No generic explanations, no filler
 - If the JSONs are missing key context (e.g., dates, sample size), state how that limits confidence
 
+{ANALYSIS_CALIBRATION_RULES}
+
 Inputs:
 Price targets:
 {info_dict["price_targets"]}
@@ -2021,6 +2044,8 @@ Output requirements:
 - Separate ownership structure, institutional behavior, and insider trading insights
 - No generic explanations
 
+{ANALYSIS_CALIBRATION_RULES}
+
 Your goal is to understand who owns the company, how that is changing, and why it matters.
 """.strip()
 
@@ -2098,6 +2123,8 @@ Output rules:
 - No raw table repetition
 - No generic explanations
 - Be analytical and opinionated
+
+{ANALYSIS_CALIBRATION_RULES}
 
 Inputs:
 Company: {company_name}
@@ -2215,6 +2242,8 @@ Output rules:
 - Do not mechanically repeat numbers without interpretation
 - Be direct, analytical, and opinionated
 - Prioritize insight over completeness
+
+{ANALYSIS_CALIBRATION_RULES}
 
 Inputs:
 Company: {company_name}
@@ -2358,7 +2387,9 @@ def swot_analysis(ticker):
   * Be analytical, not descriptive.
   * Avoid repeating the input text verbatim.
   * Prioritize insight over completeness.
-  * Assume the reader is sophisticated and time-constrained."""
+  * Assume the reader is sophisticated and time-constrained.
+
+  {ANALYSIS_CALIBRATION_RULES}"""
 
   answer = deepseek_simple_text(
       api_key=DEEPSEEK_API_KEY,
@@ -2445,6 +2476,8 @@ def market_analyst(ticker):
   - Avoid repeating the input text verbatim.
   - Prioritize clarity, depth, and economic relevance over length.
 
+  {ANALYSIS_CALIBRATION_RULES}
+
   The final output should read as a **decision-grade market characterization**, not a generic industry overview.
   """
 
@@ -2499,6 +2532,8 @@ def bear_vs_bull_insights(ticker):
   - Be specific, causal, and thoughtful.
   - Write as if presenting to a skeptical investment committee.
   - The goal is not balance, but clarity of scenarios.
+
+  {ANALYSIS_CALIBRATION_RULES}
 
   Your objective is to define the upside and downside boundaries of reality for this company.
   """
@@ -2579,6 +2614,8 @@ def change_up_anaysis(ticker, change):
   2) Secondary contributing factors
   3) Whether the company is structurally stronger than 52 weeks ago
   4) Whether the magnitude of the move appears rational, stretched, or speculative
+
+  {ANALYSIS_CALIBRATION_RULES}
 
   Reason step by step and explain your reasoning clearly.
   Deliver a deep analytical narrative, not a summary.
@@ -2663,6 +2700,8 @@ def change_down_anaysis(ticker, change):
   3) Whether the business model is structurally weaker or temporarily pressured
   4) Whether the magnitude of the decline appears rational, excessive, or signaling deeper risk
 
+  {ANALYSIS_CALIBRATION_RULES}
+
   Reason step by step and explain your reasoning clearly.
   Deliver a rigorous analytical narrative, not a summary.
   """
@@ -2715,6 +2754,8 @@ def for_value_insights(financial_dict, ticker):
 
   Do not explain the company. Do not explain valuation methods.
   Just extract the truths that matter most for valuation.
+
+  {ANALYSIS_CALIBRATION_RULES}
 
   Write as if you are briefing a strong analyst who will build the valuation themselves.
   Bullets only. Quality over quantity.

--- a/src/ai_hedge/service.py
+++ b/src/ai_hedge/service.py
@@ -80,6 +80,11 @@ Analytical Principles:
 - Focus on material drivers, not trivial details
 - Avoid generic statements (e.g., "strong growth", "competitive market") unless quantified or justified
 - Use calibrated language: avoid absolute claims unless directly proven by the provided data; when uncertainty exists, state it explicitly with probability-oriented wording (for example: likely, may, could)
+- If the evidence is ordinary, mixed, or thin, say so plainly.
+- Do not force a non-obvious insight when the provided filings do not support one.
+- Distinguish evidence, inference, and speculation.
+- A neutral or low-conviction conclusion is acceptable.
+- Do not make the thesis stronger than the provided data supports.
 
 Skepticism Mandate:
 - Assume management may present an overly favorable view

--- a/src/ai_hedge/technical_analysis.py
+++ b/src/ai_hedge/technical_analysis.py
@@ -290,6 +290,11 @@ Important:
 - Separate observations from conclusions.
 - Compare weekly, daily 6-month, and recent hourly 2-month datasets.
 - Highlight agreement and disagreement between timeframes.
+- If the evidence is ordinary, mixed, or thin, say so plainly.
+- Do not force a bullish or bearish signal when the chart evidence is neutral.
+- Distinguish observed price/volume evidence from analyst inference.
+- A neutral or low-conviction conclusion is acceptable.
+- Do not make the setup stronger than the provided data supports.
 
 Additional requirements:
 - Estimate bullish and bearish probabilities based on the strength of signals.

--- a/src/ai_hedge/trading_agents_adapter.py
+++ b/src/ai_hedge/trading_agents_adapter.py
@@ -196,6 +196,11 @@ Rules:
 - Do not add a target price, score, instruction, or trading order.
 - Do not include chart or technical-analysis claims.
 - Do not mention that you are summarizing.
+- If the transcript evidence is ordinary, mixed, or thin, say so plainly.
+- Do not force a non-obvious insight when the transcript does not support one.
+- Distinguish evidence, inference, and speculation.
+- A neutral or low-conviction conclusion is acceptable.
+- Do not make the research brief stronger than the transcript supports.
 - Use Markdown with these headings exactly:
   ### Final Committee View
   ### Business And Fundamentals


### PR DESCRIPTION
﻿## Summary

- Tightened competitor discovery and Market review prompts to rank true public peers by real revenue, customer, and business-model overlap.
- Added evidence-grounding and calibration guardrails to analysis-layer prompts so ordinary, mixed, or thin evidence is stated plainly.
- Left core valuator target/score prompts untouched so valuation outputs remain decisive.

## Preview

URL: n/a - backend prompt-only changes under `src/`.

## Test plan

- [x] `$env:PYTHONPATH='src'; python -m py_compile src\ai_hedge\legacy_port.py src\ai_hedge\dashboard.py src\ai_hedge\service.py src\ai_hedge\technical_analysis.py src\ai_hedge\trading_agents_adapter.py src\ai_hedge\competitor_market_review.py`
- [x] `$env:PYTHONPATH='src'; python -m pytest -q tests/test_competitor_market_review.py tests/test_trading_agents_adapter.py --basetemp .pytest-tmp-prompt-calibration`

## Notes for reviewer

Prompt calibration was applied to analysis agents, SEC/filing synthesis, technical analysis, TradingAgents compaction, and dashboard bull/bear extraction. The valuation JSON instruction family that emits target market caps and allocation amounts was intentionally left out of scope.
