### PR TITLE
[codex] Add SEC Q&A dashboard tab

### DIFF
--- a/frontend/src/app/(app)/dashboard/[ticker]/scenarios/scenarios-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/scenarios/scenarios-client.tsx
@@ -16,6 +16,18 @@ type SwotData = {
   threats: string[];
 };
 
+type WatchlistKpi = {
+  name?: string;
+  why_it_matters?: string;
+  direction_to_watch?: string;
+};
+
+type MainThesisDoc = {
+  valuation_revolves_around?: string;
+  main_questions?: string[];
+  kpis?: WatchlistKpi[];
+};
+
 function SwotAccordion({ swot }: { swot: SwotData }) {
   const [open, setOpen] = useState(false);
   const sections: Array<{ key: keyof SwotData; label: string; tone: string }> = [
@@ -127,6 +139,78 @@ function ScenarioColumn({
   );
 }
 
+function MainThesisPanel({
+  questions,
+  kpis,
+  doc,
+}: {
+  questions: string[];
+  kpis: WatchlistKpi[];
+  doc?: MainThesisDoc;
+}) {
+  const thesisLine = doc?.valuation_revolves_around || "";
+  const questionItems = questions.length ? questions : doc?.main_questions || [];
+  const kpiItems = kpis.length ? kpis : doc?.kpis || [];
+  if (!thesisLine && !questionItems.length && !kpiItems.length) return null;
+
+  const copyText = [
+    thesisLine,
+    "",
+    "Main questions",
+    ...questionItems.map((item, idx) => `${idx + 1}. ${item}`),
+    "",
+    "KPIs to watch",
+    ...kpiItems.map((item, idx) => {
+      const name = item.name || "KPI";
+      const details = [item.why_it_matters, item.direction_to_watch].filter(Boolean).join(" ");
+      return `${idx + 1}. ${name}${details ? ` - ${details}` : ""}`;
+    }),
+  ].join("\n").trim();
+
+  return (
+    <section className="mt-4 rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div>
+          <h2 className="font-display text-lg text-zinc-100">Main Thesis & KPIs</h2>
+          {thesisLine ? <p className="mt-1 text-sm text-zinc-300">{thesisLine}</p> : null}
+        </div>
+        <SmallCopyButton text={copyText} label="Copy Main Thesis & KPIs" iconOnly />
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-[0.95fr_1.05fr]">
+        {questionItems.length ? (
+          <div>
+            <p className="mb-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-zinc-400">Valuation Questions</p>
+            <ol className="space-y-2 text-sm text-zinc-200">
+              {questionItems.map((question, idx) => (
+                <li key={`question-${idx}`} className="flex gap-2">
+                  <span className="mt-0.5 min-w-5 text-xs font-semibold text-zinc-500">{idx + 1}.</span>
+                  <span>{question}</span>
+                </li>
+              ))}
+            </ol>
+          </div>
+        ) : null}
+
+        {kpiItems.length ? (
+          <div>
+            <p className="mb-2 text-[10px] font-semibold uppercase tracking-[0.18em] text-zinc-400">KPI Watchlist</p>
+            <div className="space-y-2">
+              {kpiItems.map((item, idx) => (
+                <div key={`kpi-${idx}`} className="rounded-xl border border-white/10 bg-zinc-900/50 p-3">
+                  <p className="text-sm font-semibold text-zinc-100">{item.name || "KPI"}</p>
+                  {item.why_it_matters ? <p className="mt-1 text-xs text-zinc-300">{item.why_it_matters}</p> : null}
+                  {item.direction_to_watch ? <p className="mt-1 text-xs text-zinc-500">{item.direction_to_watch}</p> : null}
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
 export type ScenariosClientProps = {
   ticker: string;
   data: DashboardPayload;
@@ -144,6 +228,9 @@ export function ScenariosClient({
   const matrix = data.analysis_matrix || { bull_case_reasons: [], bear_case_reasons: [], documents: undefined };
   const bullReasons = matrix.bull_case_reasons || matrix.documents?.bull_case?.reasons || [];
   const bearReasons = matrix.bear_case_reasons || matrix.documents?.bear_case?.reasons || [];
+  const mainThesisDoc = matrix.documents?.main_thesis;
+  const mainQuestions = matrix.main_thesis_questions || mainThesisDoc?.main_questions || [];
+  const watchlistKpis = matrix.watchlist_kpis || mainThesisDoc?.kpis || [];
 
   const metricMeans = data.valuation_hub.all_values?.metric_means || [];
   function probFor(label: string): number | null {
@@ -176,6 +263,7 @@ export function ScenariosClient({
         <ScenarioColumn title="Bull Case" tone="bull" reasons={bullReasons} probability={bullProb} doc={matrix.documents?.bull_case} />
         <ScenarioColumn title="Bear Case" tone="bear" reasons={bearReasons} probability={bearProb} doc={matrix.documents?.bear_case} />
       </div>
+      <MainThesisPanel questions={mainQuestions} kpis={watchlistKpis} doc={mainThesisDoc} />
     </div>
   );
 }

--- a/frontend/src/app/(app)/dashboard/[ticker]/sec-qa/page.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/sec-qa/page.tsx
@@ -1,0 +1,38 @@
+import { DashboardError } from "@/components/dashboard-chrome";
+import { loadTickerData } from "@/lib/dashboard-server";
+
+import { SecQaClient } from "./sec-qa-client";
+
+export default async function DashboardSecQaPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ ticker: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const { ticker } = await params;
+  const search = (await searchParams) ?? {};
+  const reportId = typeof search.report === "string" ? search.report : undefined;
+
+  let resolved;
+  try {
+    resolved = await loadTickerData(ticker, reportId);
+  } catch (err) {
+    const upper = decodeURIComponent(String(ticker || "")).toUpperCase();
+    return <DashboardError error={(err as Error)?.message || "Failed to load dashboard"} ticker={upper} />;
+  }
+
+  const { ticker: upper, data, reportsForTicker, resolvedReportId } = resolved;
+  if (!data) {
+    return <DashboardError error="No data" ticker={upper} />;
+  }
+
+  return (
+    <SecQaClient
+      ticker={upper}
+      data={data}
+      reportsForTicker={reportsForTicker}
+      resolvedReportId={resolvedReportId}
+    />
+  );
+}

--- a/frontend/src/app/(app)/dashboard/[ticker]/sec-qa/sec-qa-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/sec-qa/sec-qa-client.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { Copy, FileText, ShieldCheck } from "lucide-react";
+
+import { ReportChipRow } from "@/components/dashboard-chrome";
+import { SmallCopyButton } from "@/components/hedge-dashboard";
+import type { DashboardPayload, ReportListItem, SecQnaPayload } from "@/lib/dashboard-types";
+
+type SecAnswer = NonNullable<SecQnaPayload["answers"]>[number];
+
+function cleanText(value: unknown): string {
+  return String(value || "").replace(/~~/g, "").trim();
+}
+
+function confidenceClass(confidence: string): string {
+  const normalized = confidence.toLowerCase();
+  if (normalized === "high") return "border-[color:var(--success)] text-[color:var(--success)]";
+  if (normalized === "medium") return "border-[color:var(--warning)] text-[color:var(--warning)]";
+  if (normalized === "low") return "border-[color:var(--text-muted)] text-[color:var(--text-muted)]";
+  return "border-[color:var(--border-strong)] text-[color:var(--text-muted)]";
+}
+
+function answerCopyText(row: SecAnswer, index: number): string {
+  const refs = Array.isArray(row.filing_refs) ? row.filing_refs.filter(Boolean).join(", ") : "";
+  return [
+    `${index}. ${cleanText(row.question)}`,
+    "",
+    cleanText(row.answer),
+    row.evidence ? `Evidence: ${cleanText(row.evidence)}` : "",
+    refs ? `Filing refs: ${refs}` : "",
+    row.confidence ? `Confidence: ${cleanText(row.confidence)}` : "",
+  ].filter(Boolean).join("\n");
+}
+
+function buildAllCopyText(rows: SecAnswer[]): string {
+  return rows.map((row, idx) => answerCopyText(row, idx + 1)).join("\n\n");
+}
+
+function EmptySecQa({ status, error }: { status: string; error: string }) {
+  return (
+    <section className="rounded-2xl border border-white/10 bg-zinc-950/70 p-5">
+      <div className="flex items-start gap-3">
+        <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-white/10 bg-white/5 text-[color:var(--text-muted)]">
+          <FileText size={16} />
+        </div>
+        <div>
+          <h2 className="font-display text-lg text-[color:var(--text-primary)]">SEC Q&A unavailable</h2>
+          <p className="mt-1 text-sm text-[color:var(--text-secondary)]">
+            {error || (status === "unavailable" ? "This report was generated before the SEC Q&A dashboard tab was added." : "No filing Q&A was generated for this report.")}
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export type SecQaClientProps = {
+  ticker: string;
+  data: DashboardPayload;
+  reportsForTicker: ReportListItem[];
+  resolvedReportId: string;
+};
+
+export function SecQaClient({
+  ticker,
+  data,
+  reportsForTicker,
+  resolvedReportId,
+}: SecQaClientProps) {
+  const upper = ticker;
+  const secQna = data.sec_qna || {};
+  const rows = Array.isArray(secQna.answers) ? secQna.answers : [];
+  const errors = Array.isArray(secQna.errors) ? secQna.errors.filter(Boolean) : [];
+  const status = cleanText(secQna.status || "unavailable");
+  const allCopyText = buildAllCopyText(rows);
+
+  return (
+    <div>
+      <ReportChipRow ticker={upper} reports={reportsForTicker} currentReportId={resolvedReportId} />
+      <header className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="font-display text-2xl text-[color:var(--text-primary)]">SEC Q&A</h1>
+          <p className="text-xs uppercase tracking-[0.18em] text-[color:var(--text-muted)]">{upper} - filing diligence</p>
+        </div>
+        {rows.length ? (
+          <SmallCopyButton text={allCopyText} label="Copy SEC Q&A" iconOnly />
+        ) : null}
+      </header>
+
+      {!rows.length ? (
+        <EmptySecQa status={status} error={errors[0] || ""} />
+      ) : (
+        <div className="space-y-3">
+          {rows.map((row, idx) => {
+            const question = cleanText(row.question) || "Question unavailable";
+            const answer = cleanText(row.answer) || "Not disclosed in the provided filings.";
+            const evidence = cleanText(row.evidence);
+            const confidence = cleanText(row.confidence);
+            const refs = Array.isArray(row.filing_refs) ? row.filing_refs.filter(Boolean) : [];
+
+            return (
+              <article key={`${question}-${idx}`} className="rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
+                <div className="mb-3 flex items-start justify-between gap-3">
+                  <div className="flex min-w-0 gap-3">
+                    <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-white/10 bg-white/5 text-xs font-semibold text-[color:var(--text-muted)]">
+                      {idx + 1}
+                    </div>
+                    <h2 className="min-w-0 text-base font-semibold leading-snug text-[color:var(--text-primary)]">{question}</h2>
+                  </div>
+                  <button
+                    type="button"
+                    aria-label={`Copy SEC Q&A ${idx + 1}`}
+                    onClick={() => navigator.clipboard?.writeText(answerCopyText(row, idx + 1))}
+                    className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-white/15 bg-white/5 text-[color:var(--text-secondary)] transition hover:border-white/30 hover:text-[color:var(--text-primary)]"
+                  >
+                    <Copy size={13} />
+                  </button>
+                </div>
+
+                <div className="space-y-3 pl-0 sm:pl-11">
+                  <p className="text-sm leading-relaxed text-[color:var(--text-secondary)]">{answer}</p>
+
+                  {evidence ? (
+                    <div className="rounded-xl border border-white/10 bg-zinc-900/50 p-3">
+                      <p className="mb-1 flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--text-muted)]">
+                        <ShieldCheck size={12} />
+                        Evidence
+                      </p>
+                      <p className="text-xs leading-relaxed text-[color:var(--text-secondary)]">{evidence}</p>
+                    </div>
+                  ) : null}
+
+                  <div className="flex flex-wrap items-center gap-2">
+                    {confidence ? (
+                      <span className={`rounded-full border px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.14em] ${confidenceClass(confidence)}`}>
+                        {confidence}
+                      </span>
+                    ) : null}
+                    {refs.map((ref) => (
+                      <span key={ref} className="rounded-full border border-white/10 bg-white/5 px-2 py-1 text-[10px] font-medium text-[color:var(--text-muted)]">
+                        {ref}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/shell/topbar.tsx
+++ b/frontend/src/components/shell/topbar.tsx
@@ -3,7 +3,7 @@
 import { Suspense } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
-import { BarChart3, CandlestickChart, Download, FileText, Menu, Scale, Store, Users } from "lucide-react";
+import { BarChart3, CandlestickChart, Download, FileQuestion, FileText, Menu, Scale, Store, Users } from "lucide-react";
 import type { ComponentType } from "react";
 
 import { AuthMenu } from "@/components/shell/auth-menu";
@@ -16,6 +16,7 @@ const SECTIONS: SectionItem[] = [
   { slug: "valuation", label: "Valuation", icon: BarChart3 },
   { slug: "market", label: "Market", icon: Store },
   { slug: "scenarios", label: "Bull vs Bear", icon: Scale },
+  { slug: "sec-qa", label: "SEC Q&A", icon: FileQuestion },
   { slug: "technical-analysis", label: "Technical Analysis", icon: CandlestickChart },
   { slug: "dream-team", label: "Dream Team", icon: Users },
   { slug: "download", label: "Download", icon: Download },

--- a/frontend/src/lib/dashboard-fallback.ts
+++ b/frontend/src/lib/dashboard-fallback.ts
@@ -21,6 +21,8 @@ export function createFallbackDashboard(ticker: string): DashboardPayload {
         "No structured dashboard summary exists yet for this ticker. Run the valuation pipeline again to generate Executive Summary, Bull Case, and Bear Case from analysis + SEC + reports.",
       bull_case_reasons: [],
       bear_case_reasons: [],
+      main_thesis_questions: [],
+      watchlist_kpis: [],
       key_insights: [],
       bull_insights: [],
       red_flag_insights: [],
@@ -40,6 +42,13 @@ export function createFallbackDashboard(ticker: string): DashboardPayload {
           company: tk,
           document_type: "bear_case",
           reasons: [],
+        },
+        main_thesis: {
+          company: tk,
+          document_type: "main_thesis_kpis",
+          valuation_revolves_around: "",
+          main_questions: [],
+          kpis: [],
         },
       },
       swot: {
@@ -95,6 +104,14 @@ export function createFallbackDashboard(ticker: string): DashboardPayload {
       review_markdown: "",
       market_agent_markdown: "",
       error: "Market review is not available for this report yet.",
+    },
+    sec_qna: {
+      status: "unavailable",
+      ticker: tk,
+      text: "",
+      questions: [],
+      answers: [],
+      errors: [],
     },
     artifacts: {},
     downloads: {

--- a/frontend/src/lib/dashboard-types.ts
+++ b/frontend/src/lib/dashboard-types.ts
@@ -90,6 +90,21 @@ export type MarketReviewPayload = {
   error?: string;
 };
 
+export type SecQnaPayload = {
+  status?: "success" | "unavailable" | "failed" | "error" | string;
+  ticker?: string;
+  text?: string;
+  questions?: string[];
+  answers?: Array<{
+    question?: string;
+    answer?: string;
+    evidence?: string;
+    filing_refs?: string[];
+    confidence?: string;
+  }>;
+  errors?: string[];
+};
+
 export type DashboardPayload = {
   dashboard_version?: string;
   generated_at?: string;
@@ -129,6 +144,12 @@ export type DashboardPayload = {
     executive_summary_markdown: string;
     bull_case_reasons?: string[];
     bear_case_reasons?: string[];
+    main_thesis_questions?: string[];
+    watchlist_kpis?: Array<{
+      name?: string;
+      why_it_matters?: string;
+      direction_to_watch?: string;
+    }>;
     key_insights: string[];
     bull_insights: string[];
     red_flag_insights: string[];
@@ -154,6 +175,17 @@ export type DashboardPayload = {
         company?: string;
         document_type?: string;
         reasons?: string[];
+      };
+      main_thesis?: {
+        company?: string;
+        document_type?: string;
+        valuation_revolves_around?: string;
+        main_questions?: string[];
+        kpis?: Array<{
+          name?: string;
+          why_it_matters?: string;
+          direction_to_watch?: string;
+        }>;
       };
     };
     structural_shift?: {
@@ -289,6 +321,7 @@ export type DashboardPayload = {
   };
   trading_agents?: TradingAgentsPayload;
   market_review?: MarketReviewPayload;
+  sec_qna?: SecQnaPayload;
   filings?: {
     annual?: {
       available?: boolean;

--- a/src/ai_hedge/dashboard.py
+++ b/src/ai_hedge/dashboard.py
@@ -55,12 +55,14 @@ INSTRUCTION_BULL_CASE = """
 Build a strong "bull case" for the company.
 
 Goal:
-Extract and present up to 10-15 clear, high-quality reasons why this company could be a good investment.
+Extract and present the 4-7 most important, high-quality reasons why this company could be a good investment.
 
 Important requirements:
 - Each point must be specific, meaningful, and grounded in the provided materials
 - Focus on business quality, growth potential, market opportunity, competitive positioning, and financial trajectory
 - Include both current strengths and future upside
+- Select only the most important supported points; do not include every possible positive bullet
+- Order reasons by importance, with the strongest and most valuation-relevant point first
 - Prefer insight over obvious statements
 - If the evidence is ordinary, mixed, or thin, say so plainly.
 - Do not force a non-obvious insight when the provided materials do not support one.
@@ -97,7 +99,8 @@ Do NOT:
 - give a final recommendation
 - write long explanations
 - include filler or weak points just to reach the count
-- include 10 reasons if fewer than 10 are genuinely supported
+- include more than 7 reasons
+- include 4 reasons if fewer than 4 are genuinely supported
 
 Return JSON in exactly this structure:
 
@@ -108,7 +111,7 @@ Return JSON in exactly this structure:
     "<reason 1>",
     "<reason 2>",
     "<reason 3>",
-    "... up to 10-15 total"
+    "... 4-7 total, ranked strongest first"
   ]
 }
 """.strip()
@@ -118,11 +121,13 @@ INSTRUCTION_BEAR_CASE = """
 Build a strong "bear case" for the company.
 
 Goal:
-Extract and present up to 10-15 clear, high-quality reasons why this company could be a bad investment.
+Extract and present the 4-7 most important, high-quality reasons why this company could be a bad investment.
 
 Important requirements:
 - Focus on real risks, weaknesses, and red flags
 - Each point must be specific, concrete, and grounded in the provided materials
+- Select only the most important supported risks; do not include every possible negative bullet
+- Order reasons by importance, with the strongest and most valuation-relevant risk first
 - Prefer serious risks over minor concerns
 - Be skeptical and critical, like a short-seller or risk manager
 - If the evidence is ordinary, mixed, or thin, say so plainly.
@@ -162,7 +167,8 @@ Do NOT:
 - give a final recommendation
 - write long explanations
 - include weak or obvious risks just to fill space
-- include 10 risks if fewer than 10 are genuinely supported
+- include more than 7 risks
+- include 4 risks if fewer than 4 are genuinely supported
 
 Return JSON in exactly this structure:
 
@@ -173,7 +179,52 @@ Return JSON in exactly this structure:
     "<reason 1>",
     "<reason 2>",
     "<reason 3>",
-    "... up to 10-15 total"
+    "... 4-7 total, ranked strongest first"
+  ]
+}
+""".strip()
+
+
+INSTRUCTION_MAIN_THESIS_KPIS = """
+Build the stock's "main thesis and KPI watchlist" for the dashboard.
+
+Goal:
+Extract the 1-3 most important questions an investor must answer about this stock, and the 3-7 most important KPIs to monitor to understand where the company is going.
+
+Important requirements:
+- Think like a sharp portfolio manager setting up the real debate on the stock
+- The questions should frame what valuation mainly revolves around, not generic business questions
+- Start each question with "Can", "Will", "Is", "Does", "How", or "What" when natural
+- Each question must be answerable by future evidence, numbers, execution, or market behavior
+- Prioritize questions that would most change the intrinsic value, multiple, or margin of safety
+- Order questions by importance, with the most valuation-critical question first
+- KPIs must be concrete signals to watch, not vague ideas
+- KPIs may be financial, operating, customer, margin, cash-flow, balance-sheet, market-share, pricing, retention, regulatory, or execution metrics
+- For each KPI, explain why it matters and what direction or threshold would be good or bad when the materials support it
+- Order KPIs by importance, with the most thesis-critical KPI first
+- Use only the provided materials; do not invent company-specific metrics that are not supported
+- If the evidence is thin, prefer broad but still concrete KPIs that can be tracked from future reports
+- Keep every field concise, readable, and investor-grade
+- Distinguish evidence from inference when needed
+- Do not give a target price, final recommendation, or portfolio action
+
+Return JSON in exactly this structure:
+
+{
+  "company": "<ticker or company name if clearly known>",
+  "document_type": "main_thesis_kpis",
+  "valuation_revolves_around": "<one concise sentence beginning with 'The questions surrounding valuation revolve around...'>",
+  "main_questions": [
+    "<question 1>",
+    "<question 2>",
+    "<question 3>"
+  ],
+  "kpis": [
+    {
+      "name": "<short KPI name>",
+      "why_it_matters": "<why this KPI is thesis-relevant>",
+      "direction_to_watch": "<what improving or worsening evidence would look like>"
+    }
   ]
 }
 """.strip()
@@ -249,14 +300,40 @@ def _parse_json_blob(text: str) -> Dict[str, Any]:
     return {}
 
 
-def _as_str_list(value: Any, max_items: int = 12) -> List[str]:
+def _as_str_list(value: Any, max_items: Optional[int] = 12) -> List[str]:
     if not isinstance(value, list):
         return []
     out: List[str] = []
-    for item in value[:max_items]:
+    items = value if max_items is None else value[:max_items]
+    for item in items:
         txt = str(item or "").strip()
         if txt:
             out.append(txt)
+    return out
+
+
+def _as_kpi_list(value: Any, max_items: Optional[int] = 7) -> List[Dict[str, str]]:
+    if not isinstance(value, list):
+        return []
+    out: List[Dict[str, str]] = []
+    items = value if max_items is None else value[:max_items]
+    for item in items:
+        if isinstance(item, dict):
+            name = str(item.get("name") or item.get("metric") or item.get("kpi") or "").strip()
+            why = str(item.get("why_it_matters") or item.get("why") or item.get("importance") or "").strip()
+            direction = str(item.get("direction_to_watch") or item.get("watch") or item.get("trend_to_watch") or "").strip()
+        else:
+            name = str(item or "").strip()
+            why = ""
+            direction = ""
+        if name or why or direction:
+            out.append(
+                {
+                    "name": name,
+                    "why_it_matters": why,
+                    "direction_to_watch": direction,
+                }
+            )
     return out
 
 
@@ -852,15 +929,25 @@ def _fallback_qualitative_sections(
         "document_type": "bear_case",
         "reasons": bear_reasons[:15],
     }
+    main_thesis_doc = {
+        "company": "",
+        "document_type": "main_thesis_kpis",
+        "valuation_revolves_around": "",
+        "main_questions": [],
+        "kpis": [],
+    }
     return {
         "documents": {
             "executive_summary": exec_doc,
             "bull_case": bull_doc,
             "bear_case": bear_doc,
+            "main_thesis": main_thesis_doc,
         },
         "executive_summary_markdown": exec_summary,
         "bull_case_reasons": _as_str_list(bull_doc.get("reasons"), max_items=15),
         "bear_case_reasons": _as_str_list(bear_doc.get("reasons"), max_items=15),
+        "main_thesis_questions": [],
+        "watchlist_kpis": [],
         "key_insights": [],
         "bull_insights": _as_str_list(bull_doc.get("reasons"), max_items=10),
         "red_flags": [],
@@ -986,6 +1073,16 @@ def _has_reasons(doc: Dict[str, Any]) -> bool:
     return bool(_as_str_list(doc.get("reasons"), max_items=1))
 
 
+def _has_main_thesis(doc: Dict[str, Any]) -> bool:
+    if not isinstance(doc, dict):
+        return False
+    return bool(
+        _first_non_empty(doc.get("valuation_revolves_around"))
+        or _as_str_list(doc.get("main_questions"), max_items=1)
+        or _as_kpi_list(doc.get("kpis"), max_items=1)
+    )
+
+
 def generate_dashboard_sections(
     *,
     ticker: str,
@@ -997,7 +1094,7 @@ def generate_dashboard_sections(
 ) -> Dict[str, Any]:
     merged_text = (analysis_text or "").strip()
     if sec_short_text:
-        merged_text = f"{merged_text}\n\n# SEC Short Analysis Context\n{sec_short_text}"
+        merged_text = f"{merged_text}\n\n# SEC Summary Context\n{sec_short_text}"
 
     if not enable_llm_extractions:
         out = _fallback_qualitative_sections(
@@ -1026,6 +1123,7 @@ def generate_dashboard_sections(
     exec_doc: Dict[str, Any] = {}
     bull_doc: Dict[str, Any] = {}
     bear_doc: Dict[str, Any] = {}
+    main_thesis_doc: Dict[str, Any] = {}
     for _ in range(max_attempts):
         try:
             cand_exec = _run_json_extraction_prompt(
@@ -1063,7 +1161,19 @@ def generate_dashboard_sections(
         except Exception:
             pass
 
-        if _has_exec_summary(exec_doc) and _has_reasons(bull_doc) and _has_reasons(bear_doc):
+        try:
+            cand_main_thesis = _run_json_extraction_prompt(
+                ticker=ticker,
+                financial_dict=financial_dict,
+                text=merged_text,
+                instruction=INSTRUCTION_MAIN_THESIS_KPIS,
+            )
+            if _has_main_thesis(cand_main_thesis):
+                main_thesis_doc = cand_main_thesis
+        except Exception:
+            pass
+
+        if _has_exec_summary(exec_doc) and _has_reasons(bull_doc) and _has_reasons(bear_doc) and _has_main_thesis(main_thesis_doc):
             break
 
     fallback = _fallback_qualitative_sections(
@@ -1079,16 +1189,22 @@ def generate_dashboard_sections(
         bull_doc = fallback_docs.get("bull_case", {}) if isinstance(fallback_docs.get("bull_case"), dict) else {}
     if not _has_reasons(bear_doc):
         bear_doc = fallback_docs.get("bear_case", {}) if isinstance(fallback_docs.get("bear_case"), dict) else {}
+    if not _has_main_thesis(main_thesis_doc):
+        main_thesis_doc = fallback_docs.get("main_thesis", {}) if isinstance(fallback_docs.get("main_thesis"), dict) else {}
 
-    bull_reasons = _as_str_list(bull_doc.get("reasons"), max_items=15)
-    bear_reasons = _as_str_list(bear_doc.get("reasons"), max_items=15)
+    bull_reasons = _as_str_list(bull_doc.get("reasons"), max_items=None)
+    bear_reasons = _as_str_list(bear_doc.get("reasons"), max_items=None)
+    main_questions = _as_str_list(main_thesis_doc.get("main_questions"), max_items=None)
+    watchlist_kpis = _as_kpi_list(main_thesis_doc.get("kpis"), max_items=None)
+    main_thesis_doc["main_questions"] = main_questions
+    main_thesis_doc["kpis"] = watchlist_kpis
 
     executive_summary = _first_non_empty(exec_doc.get("executive_summary"), exec_doc.get("executive_summary_markdown"))
     if not executive_summary:
         executive_summary = "Executive summary extraction was empty."
 
     source = "llm"
-    if not (_has_exec_summary(exec_doc) and _has_reasons(bull_doc) and _has_reasons(bear_doc)):
+    if not (_has_exec_summary(exec_doc) and _has_reasons(bull_doc) and _has_reasons(bear_doc) and _has_main_thesis(main_thesis_doc)):
         source = "mixed_fallback"
 
     return {
@@ -1096,10 +1212,13 @@ def generate_dashboard_sections(
             "executive_summary": exec_doc,
             "bull_case": bull_doc,
             "bear_case": bear_doc,
+            "main_thesis": main_thesis_doc,
         },
         "executive_summary_markdown": executive_summary,
         "bull_case_reasons": bull_reasons,
         "bear_case_reasons": bear_reasons,
+        "main_thesis_questions": main_questions,
+        "watchlist_kpis": watchlist_kpis,
         "key_insights": [],
         "bull_insights": bull_reasons[:10],
         "red_flags": [],
@@ -1113,6 +1232,7 @@ def build_dashboard_appendix_text(ticker: str, qualitative: Dict[str, Any]) -> s
     exec_doc = docs.get("executive_summary", {}) if isinstance(docs.get("executive_summary"), dict) else {}
     bull_doc = docs.get("bull_case", {}) if isinstance(docs.get("bull_case"), dict) else {}
     bear_doc = docs.get("bear_case", {}) if isinstance(docs.get("bear_case"), dict) else {}
+    main_thesis_doc = docs.get("main_thesis", {}) if isinstance(docs.get("main_thesis"), dict) else {}
 
     lines: List[str] = [
         f"# Dashboard Extraction Pack ({ticker})",
@@ -1138,6 +1258,27 @@ def build_dashboard_appendix_text(ticker: str, qualitative: Dict[str, Any]) -> s
         bear_reasons = _as_str_list(qualitative.get("bear_case_reasons"), max_items=15)
     for item in bear_reasons:
         lines.append(f"- {item}")
+
+    lines.extend(["", "## Main Thesis Questions"])
+    valuation_revolves = _first_non_empty(main_thesis_doc.get("valuation_revolves_around"))
+    if valuation_revolves:
+        lines.append(valuation_revolves)
+    main_questions = _as_str_list(main_thesis_doc.get("main_questions"), max_items=None)
+    if not main_questions:
+        main_questions = _as_str_list(qualitative.get("main_thesis_questions"), max_items=None)
+    for item in main_questions:
+        lines.append(f"- {item}")
+
+    lines.extend(["", "## KPI Watchlist"])
+    watchlist_kpis = _as_kpi_list(main_thesis_doc.get("kpis"), max_items=None)
+    if not watchlist_kpis:
+        watchlist_kpis = _as_kpi_list(qualitative.get("watchlist_kpis"), max_items=None)
+    for item in watchlist_kpis:
+        name = item.get("name", "").strip()
+        why = item.get("why_it_matters", "").strip()
+        direction = item.get("direction_to_watch", "").strip()
+        detail = " ".join(part for part in [why, direction] if part).strip()
+        lines.append(f"- {name}: {detail}" if name and detail else f"- {name or detail}")
 
     return "\n".join(lines).strip() + "\n"
 
@@ -1499,6 +1640,7 @@ def build_dashboard_payload(
     analysis_text: str,
     sec_short_text: str,
     artifacts: Dict[str, str],
+    sec_qna: Optional[Dict[str, Any]] = None,
     technical_analysis: Optional[Dict[str, Any]] = None,
     trading_agents: Optional[Dict[str, Any]] = None,
     market_review: Optional[Dict[str, Any]] = None,
@@ -1530,6 +1672,14 @@ def build_dashboard_payload(
         deterministic_red_flags=deterministic_red_flags,
         enable_llm_extractions=enable_llm_extractions,
     )
+    sec_qna_payload = sec_qna if isinstance(sec_qna, dict) else {
+        "status": "unavailable",
+        "ticker": ticker,
+        "text": "",
+        "questions": [],
+        "answers": [],
+        "errors": [],
+    }
 
     method_details = explain_payload.get("methods", {}) if isinstance(explain_payload, dict) else {}
     aggregate_targets = explain_payload.get("aggregate_targets", {}) if isinstance(explain_payload, dict) else {}
@@ -1698,6 +1848,8 @@ def build_dashboard_payload(
             "executive_summary_markdown": qualitative.get("executive_summary_markdown", ""),
             "bull_case_reasons": qualitative.get("bull_case_reasons", []),
             "bear_case_reasons": qualitative.get("bear_case_reasons", []),
+            "main_thesis_questions": qualitative.get("main_thesis_questions", []),
+            "watchlist_kpis": qualitative.get("watchlist_kpis", []),
             "key_insights": qualitative.get("key_insights", []),
             "bull_insights": qualitative.get("bull_insights", []),
             "red_flag_insights": [],
@@ -1747,6 +1899,7 @@ def build_dashboard_payload(
         "technical_analysis": technical_analysis if isinstance(technical_analysis, dict) else {},
         "trading_agents": trading_agents if isinstance(trading_agents, dict) else {},
         "market_review": _normalize_market_review_payload(market_review, analysis_text=analysis_text),
+        "sec_qna": sec_qna_payload,
         "filings": filings if isinstance(filings, dict) else {},
         "artifacts": artifacts,
     }

--- a/src/ai_hedge/runner.py
+++ b/src/ai_hedge/runner.py
@@ -1419,21 +1419,30 @@ def _run_ticker_valuation_impl(
         }
         notes.append(f"TradingAgents research lens failed to start: {trading_agents_start_err}")
 
+    sec_qna_payload: Dict[str, Any] = {
+        "status": "unavailable",
+        "ticker": ticker,
+        "text": "",
+        "questions": [],
+        "answers": [],
+        "errors": [],
+    }
+
     # SEC/MAYA pre-score Q&A: run only when filing text exists.
     if _has_filing_text(files_dict):
         try:
             from .service import build_sec_question_answer_text
 
             with _obs.llm_context(stage="sec.qa"):
-                sec_qna_out = build_sec_question_answer_text(
+                sec_qna_payload = build_sec_question_answer_text(
                     ticker=ticker,
                     analysis_text=regular_text,
                     files_dict=files_dict,
                     financial_dict=financial_dict,
                 )
-            sec_qna_errors = [str(e) for e in sec_qna_out.get("errors", [])]
-            sec_qna_text = str(sec_qna_out.get("text", "") or "").strip()
-            if sec_qna_out.get("status") == "success" and sec_qna_text:
+            sec_qna_errors = [str(e) for e in sec_qna_payload.get("errors", [])]
+            sec_qna_text = str(sec_qna_payload.get("text", "") or "").strip()
+            if sec_qna_payload.get("status") == "success" and sec_qna_text:
                 legacy.append_text_to_file(
                     text=sec_qna_text,
                     header="SEC Pre-Score Questions & Answers",
@@ -1450,7 +1459,7 @@ def _run_ticker_valuation_impl(
     if not _has_filing_text(files_dict):
         legacy.append_text_to_file(
             text="No filing text available in files_dict (SEC/MAYA). Continuing with regular analysis only.",
-            header="SEC Short Analysis Context (Warning)",
+            header="SEC Summary (Warning)",
         )
         sec_fallback_used = True
         sec_fallback_message = "Filing download/parse failed or no filing text available; continuing without filing context."
@@ -1476,41 +1485,41 @@ def _run_ticker_valuation_impl(
                 sec_short_text = sec_candidate
                 legacy.append_text_to_file(
                     text=sec_short_text,
-                    header="SEC Short Analysis Context",
+                    header="SEC Summary",
                 )
-                print(f"SEC short analysis generated successfully for {ticker}")
+                print(f"SEC summary generated successfully for {ticker}")
 
                 if sec_errors:
                     legacy.append_text_to_file(
                         text="\n".join(sec_errors[:3]),
-                        header="SEC Short Analysis Notes",
+                        header="SEC Summary Notes",
                     )
                     notes.extend(sec_errors[:3])
             else:
-                warn = "\n".join(sec_errors[:3]) if sec_errors else "SEC short analysis generation failed."
+                warn = "\n".join(sec_errors[:3]) if sec_errors else "SEC summary generation failed."
                 legacy.append_text_to_file(
                     text=warn,
-                    header="SEC Short Analysis Context (Warning)",
+                    header="SEC Summary (Warning)",
                 )
                 sec_fallback_used = True
                 sec_fallback_message = "Filing download/parse failed or no filing text available; continuing without filing context."
                 notes.append(
-                    "SEC short analysis failed or was empty. "
+                    "SEC summary failed or was empty. "
                     "Valuation fallback applied: using regular analysis text for the combined pass."
                 )
                 if sec_errors:
                     notes.extend(sec_errors[:3])
         except Exception as sec_exc:
-            warn_text = f"SEC short analysis generation failed: {sec_exc}"
+            warn_text = f"SEC summary generation failed: {sec_exc}"
             legacy.append_text_to_file(
                 text=warn_text,
-                header="SEC Short Analysis Context (Warning)",
+                header="SEC Summary (Warning)",
             )
-            print(f"Warning: SEC short analysis generation failed for {ticker}.")
+            print(f"Warning: SEC summary generation failed for {ticker}.")
             sec_fallback_used = True
             sec_fallback_message = "Filing download/parse failed or no filing text available; continuing without filing context."
             notes.append(
-                "SEC short analysis generation raised an exception. "
+                "SEC summary generation raised an exception. "
                 "Valuation fallback applied: using regular analysis text for the combined pass."
             )
             notes.append(warn_text)
@@ -1731,6 +1740,7 @@ def _run_ticker_valuation_impl(
             explain_payload=explain_payload,
             analysis_text=regular_text,
             sec_short_text=sec_short_text,
+            sec_qna=sec_qna_payload,
             qualitative_sections=qualitative_sections,
             technical_analysis=technical_analysis_payload,
             trading_agents=trading_agents_payload,

--- a/src/ai_hedge/service.py
+++ b/src/ai_hedge/service.py
@@ -406,7 +406,7 @@ def _looks_like_table_line(line: str) -> bool:
 
 def _format_short_sec_output(answer: str) -> str:
     """
-    Normalize SEC short output so each bullet is its own row with spacing.
+    Normalize SEC summary output so each bullet is its own row with spacing.
     """
     lines = (answer or "").splitlines()
     out: List[str] = []
@@ -632,9 +632,33 @@ def _normalize_question_list(payload: Dict[str, Any]) -> List[str]:
     return out
 
 
+def _normalize_sec_answer_rows(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+    raw_rows = payload.get("answers", [])
+    if not isinstance(raw_rows, list):
+        return []
+    out: List[Dict[str, Any]] = []
+    for row in raw_rows:
+        if not isinstance(row, dict):
+            continue
+        filing_refs = row.get("filing_refs", [])
+        if not isinstance(filing_refs, list):
+            filing_refs = []
+        normalized = {
+            "question": str(row.get("question", "") or "").strip(),
+            "answer": str(row.get("answer", "") or "").strip(),
+            "evidence": str(row.get("evidence", "") or "").strip(),
+            "filing_refs": [str(x).strip() for x in filing_refs if str(x).strip()],
+            "confidence": str(row.get("confidence", "") or "").strip(),
+        }
+        if normalized["question"] or normalized["answer"]:
+            out.append(normalized)
+        if len(out) >= 12:
+            break
+    return out
+
+
 def _format_sec_qna_markdown(questions: List[str], answers_payload: Dict[str, Any]) -> str:
-    answer_rows = answers_payload.get("answers", [])
-    rows: List[Dict[str, Any]] = answer_rows if isinstance(answer_rows, list) else []
+    rows = _normalize_sec_answer_rows(answers_payload)
     lines: List[str] = [
         "## SEC Pre-Score Q&A",
     ]
@@ -685,6 +709,7 @@ def build_sec_question_answer_text(
         "ticker": ticker_u,
         "text": "",
         "questions": [],
+        "answers": [],
         "errors": errors,
     }
 
@@ -769,6 +794,7 @@ def build_sec_question_answer_text(
             short_answer=False,
         )
         answers_obj = _parse_json_object_from_text(raw_answers)
+        answer_rows = _normalize_sec_answer_rows(answers_obj)
         qna_markdown = _format_sec_qna_markdown(questions, answers_obj)
         if not qna_markdown:
             errors.append("Failed to generate SEC Q&A markdown.")
@@ -776,6 +802,7 @@ def build_sec_question_answer_text(
 
         out["status"] = "success"
         out["questions"] = questions
+        out["answers"] = answer_rows
         out["text"] = qna_markdown
         return out
     except Exception as exc:
@@ -791,7 +818,7 @@ def build_sec_short_analysis_text(
     financial_dict: Dict[str, Any],
 ) -> Dict[str, object]:
     """
-    Build SEC-short analysis text from in-memory dicts.
+    Build SEC summary text from in-memory dicts.
 
     Returns:
       {
@@ -829,7 +856,7 @@ def build_sec_short_analysis_text(
             out["text"] = text
         return out
     except Exception as exc:
-        errors.append(f"Unhandled SEC short builder error: {exc}")
+        errors.append(f"Unhandled SEC summary builder error: {exc}")
         errors.append(traceback.format_exc(limit=3))
         return out
 
@@ -884,7 +911,7 @@ def _run_sec_analysis(
             return result
 
         header = (
-            f"# {ticker_u} - {'SEC Short' if short_mode else 'SEC Full'} Analysis\n\n"
+            f"# {ticker_u} - {'SEC Summary' if short_mode else 'SEC Full'} Analysis\n\n"
             "This report is based strictly on official filing text + info_dict['info'] + financial_dict['All Reports'].\n\n"
             "\n\n"
         )


### PR DESCRIPTION
﻿## Summary

- Adds a new SEC Q&A dashboard tab that renders structured SEC pre-score filing questions and answers with evidence, filing refs, confidence labels, and copy actions.
- Renames user-facing `SEC Short Analysis` headers to `SEC Summary` so the PDF/analysis output does not imply shorting the stock.
- Extends dashboard extraction with ranked Bull/Bear bullets plus Main Thesis & KPIs, and includes those sections in the dashboard appendix seen by valuators and PDFs.

## Preview

URL: pending - preview workflow should deploy `pr-<N>-hedge-in-a-box-site.fly.dev` for this frontend PR.

## Test plan

- [x] `python -m compileall src/ai_hedge/dashboard.py src/ai_hedge/runner.py src/ai_hedge/service.py`
- [x] `npm run lint -- "src/app/(app)/dashboard/[ticker]/sec-qa/page.tsx" "src/app/(app)/dashboard/[ticker]/sec-qa/sec-qa-client.tsx" "src/components/shell/topbar.tsx" "src/lib/dashboard-types.ts" "src/lib/dashboard-fallback.ts"`
- [x] `npm run build`
- [x] Local route smoke check: `http://127.0.0.1:3000/dashboard/AAPL/sec-qa` returned `200`

## Notes for reviewer

- Existing reports may not have `sec_qna`; the new tab intentionally shows an unavailable state for those reports.
- `npm run build` passed with the existing unrelated Turbopack warning about `next.config.ts` tracing via the dream-team chat route.
- Preview URL still needs verification once the GitHub preview workflow posts it.
