### PR TITLE
[codex] Fix dashboard issue polish

### DIFF
--- a/frontend/src/app/(app)/dashboard/[ticker]/sec-qa/sec-qa-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/sec-qa/sec-qa-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Copy, FileText, ShieldCheck } from "lucide-react";
+import { FileText, ShieldCheck } from "lucide-react";
 
 import { ReportChipRow } from "@/components/dashboard-chrome";
 import { SmallCopyButton } from "@/components/hedge-dashboard";
@@ -107,14 +107,7 @@ export function SecQaClient({
                     </div>
                     <h2 className="min-w-0 text-base font-semibold leading-snug text-[color:var(--text-primary)]">{question}</h2>
                   </div>
-                  <button
-                    type="button"
-                    aria-label={`Copy SEC Q&A ${idx + 1}`}
-                    onClick={() => navigator.clipboard?.writeText(answerCopyText(row, idx + 1))}
-                    className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-white/15 bg-white/5 text-[color:var(--text-secondary)] transition hover:border-white/30 hover:text-[color:var(--text-primary)]"
-                  >
-                    <Copy size={13} />
-                  </button>
+                  <SmallCopyButton text={answerCopyText(row, idx + 1)} label={`Copy SEC Q&A ${idx + 1}`} iconOnly />
                 </div>
 
                 <div className="space-y-3 pl-0 sm:pl-11">

--- a/frontend/src/app/api/run-analysis/route.ts
+++ b/frontend/src/app/api/run-analysis/route.ts
@@ -102,7 +102,7 @@ export async function POST(req: Request) {
     attributed: false,
     runner_pid: null,
     worker_pid: null,
-    llm_total_estimated: 30,
+    llm_total_estimated: 45,
     llm_completed: 0,
     llm_progress_pct: 0,
     llm_calls_note: "Estimated total calls for one full valuation + dashboard extraction run.",

--- a/frontend/src/components/hedge-dashboard.tsx
+++ b/frontend/src/components/hedge-dashboard.tsx
@@ -40,6 +40,7 @@ const METHOD_METRIC_LABELS: Record<string, string> = {
   pe_multiple: "P/E Multiple",
   revenue_3y: "Revenue (3Y)",
   ev_sales_multiple: "EV/Sales Multiple",
+  representative_ev_current: "Representative EV",
   target_market_cap: "Target Market Cap",
   bull_probability: "Bull Probability",
   base_probability: "Base Probability",
@@ -70,6 +71,7 @@ const MONEY_METRIC_KEYS = new Set([
   "bear_net_income",
   "net_income_3y",
   "revenue_3y",
+  "representative_ev_current",
   "fcf_next_year",
 ]);
 
@@ -96,6 +98,7 @@ const METHOD_METRIC_ORDER: Record<string, string[]> = {
     "bull_probability",
     "base_probability",
     "bear_probability",
+    "representative_ev_current",
     "fcf_next_year",
     "growth_rate",
     "wacc",
@@ -118,6 +121,7 @@ const METHOD_METRIC_ORDER: Record<string, string[]> = {
     "bull_probability",
     "base_probability",
     "bear_probability",
+    "representative_ev_current",
     "ev_sales_multiple",
     "revenue_3y",
   ],
@@ -436,8 +440,8 @@ export function SmallCopyButton({
       disabled={!hasText || busy}
       title={label}
       aria-label={label}
-      className={`inline-flex items-center rounded-full border border-white/15 bg-white/5 text-[10px] font-semibold uppercase tracking-[0.12em] text-zinc-300 transition hover:border-white/35 hover:text-zinc-100 disabled:cursor-not-allowed disabled:border-white/10 disabled:text-zinc-500 ${
-        iconOnly ? "h-7 w-7 justify-center p-0" : "gap-1 px-2 py-1"
+      className={`inline-flex items-center border border-white/15 bg-white/5 text-[10px] font-semibold uppercase tracking-[0.12em] text-zinc-300 transition hover:border-white/35 hover:text-zinc-100 disabled:cursor-not-allowed disabled:border-white/10 disabled:text-zinc-500 ${
+        iconOnly ? "h-8 w-8 justify-center rounded-lg p-0" : "gap-1 rounded-full px-2 py-1"
       } ${className}`}
     >
       {copied ? <Check size={10} /> : <Copy size={10} />}

--- a/scripts/site_run.py
+++ b/scripts/site_run.py
@@ -76,12 +76,12 @@ def _job_id_from_status(existing_status: Dict[str, Any], output_dir: str) -> str
 
 
 def _estimate_total_llm_calls() -> int:
-    raw = str(os.getenv("SITE_RUN_LLM_TOTAL_ESTIMATE", "30") or "30").strip()
+    raw = str(os.getenv("SITE_RUN_LLM_TOTAL_ESTIMATE", "45") or "45").strip()
     try:
         n = int(raw)
         return max(1, n)
     except Exception:
-        return 30
+        return 45
 
 
 def _looks_like_material_success_result(result: Any) -> bool:

--- a/src/ai_hedge/dashboard.py
+++ b/src/ai_hedge/dashboard.py
@@ -791,6 +791,7 @@ def _method_metric_snapshot(method_name: str, items: List[Dict[str, Any]]) -> Di
             "bull_probability": avg_scenario_value("bull", 0),
             "base_probability": avg_scenario_value("base", 0),
             "bear_probability": avg_scenario_value("bear", 0),
+            "representative_ev_current": avg_num("representative_ev_current"),
             "fcf_next_year": avg_mid("fcf_next_year"),
             "growth_rate": avg_mid("g"),
             "wacc": avg_mid("WACC"),
@@ -816,6 +817,7 @@ def _method_metric_snapshot(method_name: str, items: List[Dict[str, Any]]) -> Di
             "bull_probability": avg_scenario_value("bull", 0),
             "base_probability": avg_scenario_value("base", 0),
             "bear_probability": avg_scenario_value("bear", 0),
+            "representative_ev_current": avg_num("representative_ev_current"),
             "revenue_3y": coalesce(avg_num("revenue_3y"), avg_weighted_scenario_value(1)),
             "ev_sales_multiple": avg_mid("ev_sales_multiple"),
         }


### PR DESCRIPTION
﻿## Summary

- Surface `representative_ev_current` in Scenario DCF and Revenue Scenario dashboard metrics so users can see the EV anchor behind EV-to-equity math.
- Update site-run progress estimation from 30 to 45 expected LLM calls to better match the current expanded pipeline.
- Fix SEC Q&A per-answer copy by routing it through the shared copy button/fallback, and standardize icon-only copy button sizing across SEC Q&A and Bull vs Bear KPI/questions panels.

## Preview

URL: https://pr-101-hedge-in-a-box-site.fly.dev

## Test plan

- [x] `python -m py_compile src\ai_hedge\dashboard.py scripts\site_run.py`
- [x] `npx eslint 'src/app/(app)/dashboard/[ticker]/sec-qa/sec-qa-client.tsx' 'src/app/(app)/dashboard/[ticker]/scenarios/scenarios-client.tsx'`
- [x] `git diff --check`
- [x] Local route smoke: `http://127.0.0.1:3000/dashboard/AAPL/sec-qa` returned `200`
- [x] Local route smoke: `http://127.0.0.1:3000/dashboard/AAPL/scenarios` returned `200`
- [x] Preview route smoke: `https://pr-101-hedge-in-a-box-site.fly.dev/api/health` returned `200`
- [x] Preview route smoke: `https://pr-101-hedge-in-a-box-site.fly.dev/dashboard/AAPL/sec-qa` returned `200`
- [x] Preview route smoke: `https://pr-101-hedge-in-a-box-site.fly.dev/dashboard/AAPL/scenarios` returned `200`

## Notes for reviewer

- Full `npx tsc --noEmit --pretty false` still fails on pre-existing unrelated optional `decision_card` test typing errors in `src/lib/hit-rate-aggregate.test.ts` and `src/lib/ticker-summary-aggregate.test.ts`.
- In-app browser click verification was unavailable in this Codex session, so local and preview route smoke checks were used instead.
