### PR TITLE
[codex] Polish copy button sizing

### DIFF
--- a/frontend/src/components/hedge-dashboard.tsx
+++ b/frontend/src/components/hedge-dashboard.tsx
@@ -440,11 +440,11 @@ export function SmallCopyButton({
       disabled={!hasText || busy}
       title={label}
       aria-label={label}
-      className={`inline-flex items-center border border-white/15 bg-white/5 text-[10px] font-semibold uppercase tracking-[0.12em] text-zinc-300 transition hover:border-white/35 hover:text-zinc-100 disabled:cursor-not-allowed disabled:border-white/10 disabled:text-zinc-500 ${
-        iconOnly ? "h-8 w-8 justify-center rounded-lg p-0" : "gap-1 rounded-full px-2 py-1"
+      className={`inline-flex shrink-0 items-center border border-white/15 bg-white/5 text-[10px] font-semibold uppercase tracking-[0.12em] text-zinc-300 transition hover:border-white/35 hover:bg-white/10 hover:text-zinc-100 disabled:cursor-not-allowed disabled:border-white/10 disabled:text-zinc-500 ${
+        iconOnly ? "h-12 w-12 justify-center rounded-xl p-0" : "min-h-9 gap-1.5 rounded-xl px-3 py-2"
       } ${className}`}
     >
-      {copied ? <Check size={10} /> : <Copy size={10} />}
+      {copied ? <Check size={iconOnly ? 16 : 12} /> : <Copy size={iconOnly ? 16 : 12} />}
       {iconOnly ? <span className="sr-only">{copied ? "Copied" : "Copy"}</span> : <span>{copied ? "Copied" : "Copy"}</span>}
     </button>
   );


### PR DESCRIPTION
﻿## Summary

- Standardize the shared dashboard copy button so icon-only copy controls render as a larger fixed square instead of a thin compressed button.
- Apply the change through `SmallCopyButton`, covering SEC Q&A row buttons, Bull/Bear scenario buttons, KPI copy, Dream Team copy, and the text copy buttons that reuse the component.

## Preview

URL: https://pr-102-hedge-in-a-box-site.fly.dev

## Test plan

- [x] `npm run build` from `frontend/`.
- [x] Local route smoke checks: `GET /dashboard/ASTS/scenarios` and `GET /dashboard/ASTS/sec-qa` returned 200 on `127.0.0.1:3000`.
- [x] Confirmed `/dashboard/ASTS/scenarios` rendered the new `h-12 w-12` copy button class from the running local app.
- [x] Preview route smoke checks: `GET /dashboard/ASTS/scenarios` and `GET /dashboard/ASTS/sec-qa` returned 200 on the PR preview.
- [x] Confirmed `/dashboard/ASTS/scenarios` rendered the new `h-12 w-12` copy button class on the PR preview.

## Notes for reviewer

- `npm run lint` is currently blocked by existing app-wide React Compiler/ESLint errors unrelated to this PR; this change did not introduce new lint-specific logic.
- No local/preview ASTS dashboard artifact currently renders populated SEC Q&A answers, so the SEC Q&A question-button behavior is covered through the shared `SmallCopyButton` component and should be visually confirmed with preview data that includes SEC Q&A rows.
