### PR TITLE
Fix financials tab tables

### DIFF
--- a/frontend/src/app/(app)/dashboard/[ticker]/financials/financials-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/financials/financials-client.tsx
@@ -143,7 +143,7 @@ function FinancialTable({
           </colgroup>
           <thead className="border-b border-[color:var(--border-subtle)] text-[color:var(--text-muted)]">
             <tr>
-              <th className="sticky left-0 z-10 bg-[color:var(--surface-elevated)] px-3 py-3 text-left font-medium">Metric</th>
+              <th className="bg-[color:var(--surface-elevated)] px-3 py-3 text-left font-medium sm:sticky sm:left-0 sm:z-10">Metric</th>
               {periods.map((period) => (
                 <th key={period.key} className="px-3 py-3 text-right align-bottom font-medium">
                   <span className="block text-base leading-5 text-[color:var(--text-primary)]">{periodChip(period).replace(/\s+/g, " ")}</span>
@@ -163,7 +163,7 @@ function FinancialTable({
           <tbody>
             {rows.map((row, idx) => (
               <tr key={`${row.metric}-${idx}`} className="border-b border-[color:var(--border-subtle)] last:border-b-0">
-                <td className="sticky left-0 z-10 bg-[color:var(--surface-elevated)] px-3 py-2 font-medium text-[color:var(--text-primary)]">
+                <td className="bg-[color:var(--surface-elevated)] px-3 py-2 font-medium text-[color:var(--text-primary)] sm:sticky sm:left-0 sm:z-10">
                   {row.metric}
                 </td>
                 {periods.map((period) => (

--- a/frontend/src/app/(app)/dashboard/[ticker]/financials/financials-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/financials/financials-client.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { AlertTriangle, BadgeDollarSign, FileSpreadsheet, Info } from "lucide-react";
+import { useMemo } from "react";
 
-import type { DashboardPayload, ReportListItem } from "@/lib/dashboard-types";
 import { ReportChipRow } from "@/components/dashboard-chrome";
+import { SmallCopyButton } from "@/components/hedge-dashboard";
+import type { DashboardPayload, ReportListItem } from "@/lib/dashboard-types";
 
 type FinancialPeriod = {
   key?: string;
@@ -20,17 +22,45 @@ type FinancialRow = {
   note?: string;
 };
 
+type CurrentMetric = {
+  metric?: string;
+  kind?: string;
+  value?: number | null;
+  quality?: string;
+  note?: string;
+};
+
+const BALANCE_METRICS = new Set([
+  "Total Assets",
+  "Customers / Accounts Receivable",
+  "Inventory",
+  "Liquid Assets: Cash, Cash Equivalents, and Short-Term Investments",
+  "Total Liabilities",
+  "Total Shareholders' Equity",
+  "Total Debt: Short-Term and Long-Term",
+  "Net Liquidity: Liquid Assets Less Debt",
+  "Equity-to-Assets Ratio",
+]);
+
+const SNAPSHOT_METRICS = new Set([
+  "Market Capitalization",
+  "Enterprise Value (EV)",
+  "Price-to-Book Ratio (P/B)",
+  "Price-to-Earnings Ratio (P/E)",
+]);
+
 function asList(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
   return value.map((v) => String(v || "").trim()).filter(Boolean);
 }
 
 function fmtValue(value: unknown, kind?: string): string {
+  if (value === null || value === undefined || value === "") return "-";
   const n = Number(value);
   if (!Number.isFinite(n)) return "-";
   const type = String(kind || "").toLowerCase();
   if (type === "percent") return `${(n * 100).toFixed(1)}%`;
-  if (type === "ratio") return `${n.toFixed(2)}x`;
+  if (type === "ratio") return n.toFixed(2);
   if (Math.abs(n) >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`;
   if (Math.abs(n) >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (Math.abs(n) >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
@@ -39,15 +69,121 @@ function fmtValue(value: unknown, kind?: string): string {
 
 function qualityClass(value?: string): string {
   const q = String(value || "").toLowerCase();
-  if (q === "reported") return "border-emerald-400/35 text-emerald-200";
-  if (q === "derived" || q === "mixed") return "border-sky-400/30 text-sky-200";
-  if (q === "unavailable") return "border-zinc-500/30 text-zinc-400";
-  return "border-white/10 text-zinc-300";
+  if (q === "reported") return "border-[color:var(--success)] text-[color:var(--success)]";
+  if (q === "derived" || q === "mixed") return "border-[color:var(--info)] text-[color:var(--info)]";
+  if (q === "unavailable") return "border-[color:var(--border-strong)] text-[color:var(--text-muted)]";
+  return "border-[color:var(--border-subtle)] text-[color:var(--text-secondary)]";
 }
 
 function periodChip(period: FinancialPeriod): string {
-  const type = String(period.period_type || "").toLowerCase() === "annual" ? "FY" : "Q";
-  return `${type} ${period.label || period.date || period.key || ""}`.replace(/^FY FY\s+/i, "FY ").replace(/^Q Q/i, "Q");
+  const raw = String(period.label || period.date || period.key || "").trim();
+  const prefix = String(period.period_type || "").toLowerCase() === "annual" ? "FY" : "Q";
+  return `${prefix} ${raw}`.replace(/^FY FY\s+/i, "FY ").replace(/^Q Q/i, "Q");
+}
+
+function dateParts(date?: string): string[] {
+  const parts = String(date || "").split("-");
+  return parts.length === 3 ? parts : [String(date || "")];
+}
+
+function tableCopyText(title: string, periods: FinancialPeriod[], rows: FinancialRow[]): string {
+  const header = ["Metric", ...periods.map((p) => `${periodChip(p)} ${p.date || ""}`.trim()), "Quality", "Note"];
+  const lines = [title, header.join("\t")];
+  for (const row of rows) {
+    lines.push([
+      row.metric || "",
+      ...periods.map((period) => fmtValue(row.values?.[String(period.key || "")], row.kind)),
+      row.quality || "",
+      row.note || "",
+    ].join("\t"));
+  }
+  return lines.join("\n");
+}
+
+function snapshotCopyText(metrics: CurrentMetric[]): string {
+  const lines = ["Current Snapshot", ["Metric", "Value", "Quality", "Note"].join("\t")];
+  for (const metric of metrics) {
+    lines.push([metric.metric || "", fmtValue(metric.value, metric.kind), metric.quality || "", metric.note || ""].join("\t"));
+  }
+  return lines.join("\n");
+}
+
+function FinancialTable({
+  title,
+  subtitle,
+  periods,
+  rows,
+}: {
+  title: string;
+  subtitle: string;
+  periods: FinancialPeriod[];
+  rows: FinancialRow[];
+}) {
+  if (!rows.length) return null;
+  const copyText = tableCopyText(title, periods, rows);
+
+  return (
+    <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-semibold uppercase tracking-[0.16em] text-[color:var(--text-secondary)]">{title}</h2>
+          <p className="mt-1 text-sm text-[color:var(--text-muted)]">{subtitle}</p>
+        </div>
+        <SmallCopyButton text={copyText} label={`Copy ${title}`} />
+      </div>
+      <div className="overflow-auto rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)]">
+        <table className="w-full min-w-[1180px] table-fixed text-sm">
+          <colgroup>
+            <col className="w-[260px]" />
+            {periods.map((period) => (
+              <col key={period.key} className="w-[112px]" />
+            ))}
+            <col className="w-[116px]" />
+            <col className="w-[340px]" />
+          </colgroup>
+          <thead className="border-b border-[color:var(--border-subtle)] text-[color:var(--text-muted)]">
+            <tr>
+              <th className="sticky left-0 z-10 bg-[color:var(--surface-elevated)] px-3 py-3 text-left font-medium">Metric</th>
+              {periods.map((period) => (
+                <th key={period.key} className="px-3 py-3 text-right align-bottom font-medium">
+                  <span className="block text-base leading-5 text-[color:var(--text-primary)]">{periodChip(period).replace(/\s+/g, " ")}</span>
+                  <span className="mt-1 block font-mono text-[11px] leading-4 text-[color:var(--text-muted)]">
+                    {dateParts(period.date).map((part) => (
+                      <span key={`${period.key}-${part}`} className="block">
+                        {part}
+                      </span>
+                    ))}
+                  </span>
+                </th>
+              ))}
+              <th className="px-3 py-3 text-left align-bottom font-medium">Quality</th>
+              <th className="px-3 py-3 text-left align-bottom font-medium">Note</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, idx) => (
+              <tr key={`${row.metric}-${idx}`} className="border-b border-[color:var(--border-subtle)] last:border-b-0">
+                <td className="sticky left-0 z-10 bg-[color:var(--surface-elevated)] px-3 py-2 font-medium text-[color:var(--text-primary)]">
+                  {row.metric}
+                </td>
+                {periods.map((period) => (
+                  <td key={`${row.metric}-${period.key}`} className="px-3 py-2 text-right font-mono text-[color:var(--text-primary)]">
+                    {fmtValue(row.values?.[String(period.key || "")], row.kind)}
+                  </td>
+                ))}
+                <td className="px-3 py-2">
+                  <span className={`rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-[0.12em] ${qualityClass(row.quality)}`}>
+                    {row.quality || "mixed"}
+                  </span>
+                </td>
+                <td className="px-3 py-2 text-xs leading-relaxed text-[color:var(--text-secondary)]">{row.note || ""}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
 }
 
 export type FinancialsClientProps = {
@@ -69,31 +205,60 @@ export function FinancialsClient({
   const analysis = payload.analysis || {};
   const periods = Array.isArray(analysis.periods) ? (analysis.periods as FinancialPeriod[]) : [];
   const rows = Array.isArray(analysis.rows) ? (analysis.rows as FinancialRow[]) : [];
+  const currentMetrics = Array.isArray(analysis.current_metrics) ? (analysis.current_metrics as CurrentMetric[]) : [];
   const takeaways = asList(analysis.key_takeaways);
   const warnings = asList(analysis.warnings);
   const currency = String(analysis.currency || data.header?.original_financial_currency || data.header?.currency || "USD").toUpperCase();
   const unit = String(analysis.unit || "raw");
   const hasTable = status === "success" && periods.length > 0 && rows.length > 0;
 
+  const { snapshotMetrics, incomeRows, balanceRows, copyAllText } = useMemo(() => {
+    const snapshotFromRows: CurrentMetric[] = rows
+      .filter((row) => SNAPSHOT_METRICS.has(String(row.metric || "")))
+      .map((row) => {
+        const values = periods.map((period) => row.values?.[String(period.key || "")]).filter((value) => Number.isFinite(Number(value)));
+        const last = values.length ? Number(values[values.length - 1]) : null;
+        return { metric: row.metric, kind: row.kind, value: last, quality: row.quality, note: row.note };
+      });
+    const snapshot = currentMetrics.length ? currentMetrics : snapshotFromRows;
+    const filteredRows = rows.filter((row) => !SNAPSHOT_METRICS.has(String(row.metric || "")));
+    const balance = filteredRows.filter((row) => BALANCE_METRICS.has(String(row.metric || "")));
+    const income = filteredRows.filter((row) => !BALANCE_METRICS.has(String(row.metric || "")));
+    const copyBlocks = [
+      snapshot.length ? snapshotCopyText(snapshot) : "",
+      tableCopyText("Income and Cash Flow", periods, income),
+      tableCopyText("Balance Sheet", periods, balance),
+    ].filter(Boolean);
+    return {
+      snapshotMetrics: snapshot,
+      incomeRows: income,
+      balanceRows: balance,
+      copyAllText: copyBlocks.join("\n\n"),
+    };
+  }, [currentMetrics, periods, rows]);
+
   return (
     <div>
       <ReportChipRow ticker={upper} reports={reportsForTicker} currentReportId={resolvedReportId} />
 
-      <header className="mb-4 rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
+      <header className="mb-4 rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
-            <h1 className="inline-flex items-center gap-2 font-display text-2xl text-zinc-100">
-              <FileSpreadsheet size={18} className="text-emerald-300" />
+            <h1 className="inline-flex items-center gap-2 font-display text-2xl text-[color:var(--text-primary)]">
+              <FileSpreadsheet size={18} className="text-[color:var(--accent)]" />
               Financials
             </h1>
-            <p className="text-xs uppercase tracking-[0.18em] text-zinc-500">
-              {upper} · original reporting currency
+            <p className="text-xs uppercase tracking-[0.18em] text-[color:var(--text-muted)]">
+              {upper} - original reporting currency
             </p>
           </div>
-          <div className="rounded-xl border border-emerald-400/30 bg-emerald-500/10 px-3 py-2 text-right">
-            <p className="text-[10px] uppercase tracking-[0.16em] text-emerald-200">Currency</p>
-            <p className="font-mono text-lg font-semibold text-emerald-100">{currency}</p>
-            <p className="text-[11px] text-zinc-400">{unit}</p>
+          <div className="flex flex-wrap items-center gap-2">
+            {hasTable ? <SmallCopyButton text={copyAllText} label="Copy all financial tables" /> : null}
+            <div className="rounded-xl border border-[color:var(--border-strong)] bg-[color:var(--surface)] px-3 py-2 text-right">
+              <p className="text-[10px] uppercase tracking-[0.16em] text-[color:var(--text-muted)]">Currency</p>
+              <p className="font-mono text-lg font-semibold text-[color:var(--text-primary)]">{currency}</p>
+              <p className="text-[11px] text-[color:var(--text-muted)]">{unit}</p>
+            </div>
           </div>
         </div>
       </header>
@@ -109,84 +274,66 @@ export function FinancialsClient({
       ) : (
         <div className="space-y-5">
           {takeaways.length ? (
-            <section className="grid gap-3 lg:grid-cols-3">
-              {takeaways.slice(0, 6).map((item, idx) => (
-                <article key={`takeaway-${idx}`} className="rounded-xl border border-white/10 bg-zinc-950/70 p-3">
-                  <p className="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.14em] text-zinc-400">
-                    <BadgeDollarSign size={13} />
-                    Read {idx + 1}
-                  </p>
-                  <p className="mt-2 text-sm leading-relaxed text-zinc-100">{item}</p>
-                </article>
-              ))}
+            <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
+              <h2 className="inline-flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.16em] text-[color:var(--text-secondary)]">
+                <BadgeDollarSign size={14} />
+                What matters most
+              </h2>
+              <ol className="mt-3 grid gap-3 lg:grid-cols-2">
+                {takeaways.slice(0, 10).map((item, idx) => (
+                  <li key={`takeaway-${idx}`} className="flex gap-3 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-3">
+                    <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-[color:var(--border-strong)] font-mono text-xs text-[color:var(--text-secondary)]">
+                      {idx + 1}
+                    </span>
+                    <span className="text-sm leading-relaxed text-[color:var(--text-primary)]">{item}</span>
+                  </li>
+                ))}
+              </ol>
             </section>
           ) : null}
 
-          <section className="rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
-            <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
-              <div>
-                <h2 className="text-sm font-semibold uppercase tracking-[0.16em] text-zinc-300">
-                  {analysis.title || "Financial Statement Bridge"}
-                </h2>
-                {analysis.subtitle ? <p className="mt-1 text-sm text-zinc-400">{analysis.subtitle}</p> : null}
+          {snapshotMetrics.length ? (
+            <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
+              <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <h2 className="text-sm font-semibold uppercase tracking-[0.16em] text-[color:var(--text-secondary)]">Current Snapshot</h2>
+                  <p className="mt-1 text-sm text-[color:var(--text-muted)]">Latest market values, separate from historical statement periods.</p>
+                </div>
+                <SmallCopyButton text={snapshotCopyText(snapshotMetrics)} label="Copy current snapshot" />
               </div>
-              <p className="inline-flex items-center gap-1 text-xs text-zinc-400">
-                <Info size={13} />
-                Values stay in {currency}
-              </p>
-            </div>
-            <div className="overflow-auto rounded-xl border border-white/10 bg-black/25">
-              <table className="w-full min-w-[1180px] text-sm">
-                <thead className="border-b border-white/10 text-zinc-400">
-                  <tr>
-                    <th className="sticky left-0 z-10 bg-zinc-950 px-3 py-2 text-left font-medium">Metric</th>
-                    {periods.map((period) => (
-                      <th key={period.key} className="px-3 py-2 text-right font-medium">
-                        <span className="block text-zinc-200">{periodChip(period)}</span>
-                        <span className="block text-[10px] uppercase tracking-[0.12em] text-zinc-500">{period.date}</span>
-                      </th>
-                    ))}
-                    <th className="px-3 py-2 text-left font-medium">Quality</th>
-                    <th className="px-3 py-2 text-left font-medium">Note</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {rows.map((row, idx) => (
-                    <tr key={`${row.metric}-${idx}`} className="border-b border-white/5 last:border-b-0">
-                      <td className="sticky left-0 z-10 bg-zinc-950 px-3 py-2 font-medium text-zinc-100">
-                        {row.metric}
-                      </td>
-                      {periods.map((period) => (
-                        <td key={`${row.metric}-${period.key}`} className="px-3 py-2 text-right font-mono text-zinc-100">
-                          {fmtValue(row.values?.[String(period.key || "")], row.kind)}
-                        </td>
-                      ))}
-                      <td className="px-3 py-2">
-                        <span className={`rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-[0.12em] ${qualityClass(row.quality)}`}>
-                          {row.quality || "mixed"}
-                        </span>
-                      </td>
-                      <td className="max-w-[340px] px-3 py-2 text-xs leading-relaxed text-zinc-300">{row.note || ""}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </section>
+              <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                {snapshotMetrics.map((metric) => (
+                  <article key={metric.metric} className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-3">
+                    <p className="text-xs uppercase tracking-[0.14em] text-[color:var(--text-muted)]">{metric.metric}</p>
+                    <p className="mt-2 font-mono text-lg font-semibold text-[color:var(--text-primary)]">{fmtValue(metric.value, metric.kind)}</p>
+                    <p className="mt-2 text-xs leading-relaxed text-[color:var(--text-secondary)]">{metric.note || ""}</p>
+                  </article>
+                ))}
+              </div>
+            </section>
+          ) : null}
+
+          <FinancialTable title={analysis.title || "Income and Cash Flow"} subtitle={`Values stay in ${currency}`} periods={periods} rows={incomeRows} />
+          <FinancialTable title="Balance Sheet" subtitle="Assets, liabilities, equity, debt, and liquidity." periods={periods} rows={balanceRows} />
 
           {warnings.length ? (
-            <section className="rounded-2xl border border-amber-400/25 bg-amber-500/10 p-4">
-              <h2 className="text-xs font-semibold uppercase tracking-[0.16em] text-amber-100">Caveats</h2>
-              <ul className="mt-3 space-y-2 text-sm text-amber-50/90">
+            <section className="rounded-2xl border border-[color:var(--warning)] bg-[color:var(--surface-elevated)] p-4">
+              <h2 className="text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--warning)]">Caveats</h2>
+              <ul className="mt-3 space-y-2 text-sm text-[color:var(--text-secondary)]">
                 {warnings.map((item, idx) => (
                   <li key={`warning-${idx}`} className="flex gap-2">
-                    <span className="mt-1.5 inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-amber-200" />
+                    <span className="mt-1.5 inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-[color:var(--warning)]" />
                     <span>{item}</span>
                   </li>
                 ))}
               </ul>
             </section>
           ) : null}
+
+          <p className="inline-flex items-center gap-1 text-xs text-[color:var(--text-muted)]">
+            <Info size={13} />
+            Missing data is shown as "-"; a displayed 0 means the source value or formula is actually zero.
+          </p>
         </div>
       )}
     </div>

--- a/frontend/src/components/hedge-dashboard.tsx
+++ b/frontend/src/components/hedge-dashboard.tsx
@@ -419,6 +419,18 @@ function BulletList({ items, tone = "bull" }: { items: string[]; tone?: "bull" |
 
 type TabTone = "up" | "down" | "neutral";
 
+function tradingAgentsDecisionTone(text?: string): TabTone {
+  const src = String(text || "").toLowerCase();
+  const compact = src.replace(/[\s_-]+/g, "");
+  if (/\b(strong\s*buy|buy|overweight|overwhight|outperform|accumulate)\b/.test(src) || compact.includes("strongbuy")) {
+    return "up";
+  }
+  if (/\b(strong\s*sell|sell|underweight|underwhight|underperform|reduce)\b/.test(src) || compact.includes("strongsell")) {
+    return "down";
+  }
+  return "neutral";
+}
+
 function tabToneClass(tone: TabTone, active: boolean): string {
   if (tone === "up") {
     return active
@@ -660,6 +672,13 @@ function TradingAgentsPanel({ payload }: { payload?: DashboardPayload["trading_a
     if (!cleanText) return [];
     return splitMarkdownHeadingBlocks(title, cleanText);
   });
+  const decisionTone = tradingAgentsDecisionTone(payload.final_committee_view);
+  const decisionPanelClass =
+    decisionTone === "up"
+      ? "border-emerald-500/45 bg-emerald-500/10"
+      : decisionTone === "down"
+        ? "border-red-500/45 bg-red-500/10"
+        : "border-white/10 bg-black/30";
 
   return (
     <div className="mt-3 space-y-3">
@@ -681,8 +700,13 @@ function TradingAgentsPanel({ payload }: { payload?: DashboardPayload["trading_a
       </div>
 
       {renderedSections.map((section, index) => {
+        const isDecision = section.title.toLowerCase() === "final committee decision";
         return (
-          <details key={`${section.title}-${index}`} className="rounded-xl border border-white/10 bg-black/30 p-3" open={index === 0}>
+          <details
+            key={`${section.title}-${index}`}
+            className={`rounded-xl border p-3 ${isDecision ? decisionPanelClass : "border-white/10 bg-black/30"}`}
+            open={index === 0}
+          >
             <summary className="cursor-pointer text-sm font-semibold text-zinc-100">{section.title}</summary>
             <div className="mt-2 max-h-[24rem] overflow-auto break-words text-zinc-200">
               <MarkdownBlock text={section.text} />
@@ -1229,6 +1253,7 @@ export function HedgeDashboard({
   }, [methodTabs]);
   const activeMethod: DashboardMethodTab | null = methodTabs.find((m) => m.name === valuationTab) || null;
   const tradingAgentsPayload = data?.trading_agents;
+  const tradingAgentsTone = tradingAgentsDecisionTone(tradingAgentsPayload?.final_committee_view);
   const hasTradingAgents =
     !!tradingAgentsPayload &&
     (Object.keys(tradingAgentsPayload).length > 0 || String(tradingAgentsPayload.status || "").trim().length > 0);
@@ -1886,7 +1911,7 @@ export function HedgeDashboard({
                     />
                   ))}
                   {hasTradingAgents ? (
-                    <Tab active={valuationTab === "trading-agents"} onClick={() => setValuationTab("trading-agents")} label="TradingAgents" />
+                    <Tab active={valuationTab === "trading-agents"} onClick={() => setValuationTab("trading-agents")} label="TradingAgents" tone={tradingAgentsTone} />
                   ) : null}
                 </div>
                 {valuationTab === "overview" ? (
@@ -2188,38 +2213,40 @@ export function HedgeDashboard({
                     {showAssumptionsRangeMobile ? "Hide Min/Max" : "Show Min/Max"}
                   </button>
                 </div>
-                {showAssumptionsRangeMobile ? (
-                  <div className="space-y-2 sm:hidden">
-                    {assumptionsDisplayRows.map((entry) =>
-                      entry?.type === "spacer" ? (
-                        <div key={entry.key} className="h-2" />
-                      ) : entry?.type === "metric" ? (
-                        <article key={entry.key} className="rounded-xl border border-white/10 bg-white/5 p-3">
-                          <p className="text-sm font-semibold text-zinc-100">{entry.row.label}</p>
-                          <div className="mt-3 grid grid-cols-2 gap-2 text-xs">
-                            <div>
-                              <p className="uppercase tracking-[0.12em] text-zinc-500">Mean</p>
-                              <p className="mt-1 font-mono text-zinc-100">{formatAssumptionValue(entry.row.label, entry.row.mean, currencyContext)}</p>
-                            </div>
-                            <div>
-                              <p className="uppercase tracking-[0.12em] text-zinc-500">Current</p>
-                              <p className="mt-1 font-mono text-zinc-100">{formatAssumptionCurrentValue(entry.row.label, currentAssumptionValue(entry.row.label), currencyContext)}</p>
-                            </div>
-                            <div>
-                              <p className="uppercase tracking-[0.12em] text-zinc-500">Min</p>
-                              <p className="mt-1 font-mono text-zinc-100">{formatAssumptionValue(entry.row.label, entry.row.min, currencyContext)}</p>
-                            </div>
-                            <div>
-                              <p className="uppercase tracking-[0.12em] text-zinc-500">Max</p>
-                              <p className="mt-1 font-mono text-zinc-100">{formatAssumptionValue(entry.row.label, entry.row.max, currencyContext)}</p>
-                            </div>
+                <div className="space-y-2 sm:hidden">
+                  {assumptionsDisplayRows.map((entry) =>
+                    entry?.type === "spacer" ? (
+                      <div key={entry.key} className="h-2" />
+                    ) : entry?.type === "metric" ? (
+                      <article key={entry.key} className="rounded-xl border border-white/10 bg-white/5 p-3">
+                        <p className="text-sm font-semibold leading-snug text-zinc-100">{entry.row.label}</p>
+                        <div className="mt-3 grid grid-cols-2 gap-3 text-xs">
+                          <div>
+                            <p className="uppercase tracking-[0.12em] text-zinc-500">Mean</p>
+                            <p className="mt-1 break-words font-mono text-base text-zinc-100">{formatAssumptionValue(entry.row.label, entry.row.mean, currencyContext)}</p>
                           </div>
-                        </article>
-                      ) : null,
-                    )}
-                  </div>
-                ) : null}
-                <div className={`${showAssumptionsRangeMobile ? "hidden sm:block" : "block"} overflow-auto`}>
+                          <div>
+                            <p className="uppercase tracking-[0.12em] text-zinc-500">Current</p>
+                            <p className="mt-1 break-words font-mono text-base text-zinc-100">{formatAssumptionCurrentValue(entry.row.label, currentAssumptionValue(entry.row.label), currencyContext)}</p>
+                          </div>
+                          {showAssumptionsRangeMobile ? (
+                            <>
+                              <div>
+                                <p className="uppercase tracking-[0.12em] text-zinc-500">Min</p>
+                                <p className="mt-1 break-words font-mono text-zinc-100">{formatAssumptionValue(entry.row.label, entry.row.min, currencyContext)}</p>
+                              </div>
+                              <div>
+                                <p className="uppercase tracking-[0.12em] text-zinc-500">Max</p>
+                                <p className="mt-1 break-words font-mono text-zinc-100">{formatAssumptionValue(entry.row.label, entry.row.max, currencyContext)}</p>
+                              </div>
+                            </>
+                          ) : null}
+                        </div>
+                      </article>
+                    ) : null,
+                  )}
+                </div>
+                <div className="hidden overflow-auto sm:block">
                   <table className="hib-values-table w-full text-sm sm:min-w-[620px]">
                     <thead className="border-b border-white/10 text-zinc-500">
                       <tr>

--- a/frontend/src/lib/dashboard-types.ts
+++ b/frontend/src/lib/dashboard-types.ts
@@ -191,6 +191,13 @@ export type FinancialsPayload = {
       quality?: "reported" | "derived" | "unavailable" | "mixed" | string;
       note?: string;
     }>;
+    current_metrics?: Array<{
+      metric?: string;
+      kind?: "currency" | "percent" | "ratio" | "count" | string;
+      value?: number | null;
+      quality?: "reported" | "derived" | "unavailable" | "mixed" | string;
+      note?: string;
+    }>;
     added_rows?: string[];
     key_takeaways?: string[];
     warnings?: string[];

--- a/src/ai_hedge/financials_agent.py
+++ b/src/ai_hedge/financials_agent.py
@@ -19,10 +19,12 @@ REQUIRED_METRICS = [
     "Operating Margin",
     "Net Income (GAAP)",
     "Net Margin",
+    "Tax Rate",
     "Operating Cash Flow",
     "Free Cash Flow (FCF)",
     "FCF / Net Income",
     "(+) Stock-Based Compensation (SBC)",
+    "SBC / Revenue",
     "(+) Amortization of Intangible Assets",
     "(+/-) One-Time Expenses/Income, Net",
     "(+/-) Additional Adjustments, if any",
@@ -36,9 +38,13 @@ REQUIRED_METRICS = [
     "Total Debt: Short-Term and Long-Term",
     "Net Liquidity: Liquid Assets Less Debt",
     "Equity-to-Assets Ratio",
+]
+
+MARKET_SNAPSHOT_METRICS = [
     "Market Capitalization",
     "Enterprise Value (EV)",
     "Price-to-Book Ratio (P/B)",
+    "Price-to-Earnings Ratio (P/E)",
 ]
 
 
@@ -160,6 +166,7 @@ def build_raw_financials_payload(ticker: str, info_dict: Dict[str, Any]) -> Dict
 
 def build_financials_prompt(ticker: str, payload: Dict[str, Any]) -> str:
     required = "\n".join(f"- {metric}" for metric in REQUIRED_METRICS)
+    snapshot = "\n".join(f"- {metric}" for metric in MARKET_SNAPSHOT_METRICS)
     return f"""
 You are a forensic financial statement analyst building a dashboard table for equity research.
 
@@ -175,13 +182,16 @@ Use Deep Reasoning:
 - Never use industry averages, outside memory, estimates, assumptions, or generic financial knowledge to fill a table cell.
 - If an exact line is missing, derive only when defensible from nearby lines and mark confidence as "derived".
 - If unavailable, use null and explain the limitation in the row note. Do not hallucinate.
-- Sort columns chronologically from oldest to newest, mixing annual and quarterly periods intelligently by period end date. Preserve whether each period is annual or quarterly in column metadata.
+- Sort columns chronologically from oldest to newest, mixing annual and quarterly periods intelligently by period end date. Preserve whether each period is annual or quarterly in column metadata. If a fiscal year and its Q4 share the same period-end date, put Q4 before FY.
 - Keep values in the original financial currency. Ratios and margins should be decimals, not strings.
 - Keep currency/count numeric values as raw statement values. Do not rescale to thousands, millions, or billions; the dashboard will handle display formatting.
 - Make the table simple enough for a dashboard but deep enough to explain the economics.
 
 Mandatory rows, in this exact order:
 {required}
+
+Current market snapshot fields, outside the period table:
+{snapshot}
 
 Optional rows:
 - You may add up to 7 additional rows only if truly important for this company type.
@@ -199,13 +209,9 @@ Balance sheet and market-value logic:
 - Total Debt means short-term debt plus long-term debt. If only total debt is available from quote info, use it only where period-specific statement debt is missing and mark the row "derived" or "mixed".
 - Net Liquidity = Liquid Assets - Total Debt.
 - Equity-to-Assets Ratio = Total Shareholders' Equity / Total Assets. It is a ratio decimal, not a percent string.
-- Market Capitalization, Enterprise Value (EV), and Price-to-Book Ratio (P/B) are mandatory rows, but fill them only when defensible:
-  - If a period-specific market cap or EV is available in the provided data, use it.
-  - If shares outstanding and a period-end/current price are available, derive Market Cap = shares * price and explain the basis.
-  - EV = Market Cap + Total Debt - Liquid Assets when those pieces are available for the same period.
-  - P/B = Market Cap / Total Shareholders' Equity when both values are available.
-  - If only current quote info exists, you may populate the newest period and leave older periods null, with a note saying it is current quote data, not historical period-end pricing.
-  - Do not invent historical market caps, EV, or P/B when price/share data is not provided.
+- Tax Rate = tax provision / pretax income when both are available. If either line is missing, use null.
+- SBC / Revenue = Stock-Based Compensation / Revenue when both are available. If SBC is not disclosed separately, use null.
+- Market Capitalization, Enterprise Value (EV), Price-to-Book Ratio (P/B), and Price-to-Earnings Ratio (P/E) are current quote snapshot fields, not period-table rows. Put them in current_metrics only when available from quote info or defensible from quote info plus latest statements. Do not invent historical values for them.
 
 Return ONLY valid JSON with this exact shape:
 {{
@@ -231,8 +237,17 @@ Return ONLY valid JSON with this exact shape:
       "note": "short plain-English note"
     }}
   ],
+  "current_metrics": [
+    {{
+      "metric": "Market Capitalization",
+      "kind": "currency | ratio",
+      "value": null,
+      "quality": "reported | derived | unavailable | mixed",
+      "note": "short plain-English note"
+    }}
+  ],
   "added_rows": ["metric names you added beyond mandatory rows"],
-  "key_takeaways": ["3-6 concise bullets about growth, margins, cash conversion, and accounting adjustments"],
+  "key_takeaways": ["5-10 concise bullets sorted from most important to least important"],
   "warnings": ["short caveats, missing-data notes, or comparability warnings"]
 }}
 
@@ -243,6 +258,8 @@ Dashboard writing style:
 - Use null for missing values.
 - Use null for any number you cannot trace to the payload or to a transparent formula from payload numbers.
 - Do not invent placeholder numbers to make the table look complete.
+- Never output 0 for missing, unavailable, undisclosed, or not separately disclosed data. Output null instead. Only output 0 when the source statement actually reports zero or a formula from available values truly equals zero.
+- Key takeaways should be simple, smart, and useful for a user who wants to understand the table fast: what changed, what looks strong or weak, what is one-off, and what deserves attention.
 - Do not include markdown.
 
 Financial statement payload JSON:
@@ -260,6 +277,8 @@ def _default_kind_for_metric(metric: str) -> str:
     text = str(metric or "").lower()
     if "margin" in text or "growth" in text or "equity-to-assets" in text:
         return "percent"
+    if "tax rate" in text or "sbc / revenue" in text:
+        return "percent"
     if "ratio" in text or "p/b" in text or "fcf / net income" in text:
         return "ratio"
     return "currency"
@@ -267,6 +286,31 @@ def _default_kind_for_metric(metric: str) -> str:
 
 def _metric_key(metric: str) -> str:
     return re.sub(r"\s+", " ", str(metric or "").replace("’", "'").replace("`", "'").strip().lower())
+
+
+def _normalize_quality(value: Any) -> str:
+    quality = str(value or "mixed").strip().lower()
+    return quality if quality in {"reported", "derived", "unavailable", "mixed"} else "mixed"
+
+
+def _coerce_number(value: Any) -> Optional[float]:
+    try:
+        num = float(value)
+        return num if np.isfinite(num) else None
+    except Exception:
+        return None
+
+
+def _snapshot_value_from_rows(rows: List[Any], metric: str) -> Optional[float]:
+    for row in rows:
+        if not isinstance(row, dict) or _metric_key(row.get("metric", "")) != _metric_key(metric):
+            continue
+        values = row.get("values") if isinstance(row.get("values"), dict) else {}
+        for value in reversed(list(values.values())):
+            num = _coerce_number(value)
+            if num is not None and abs(num) > 1e-12:
+                return num
+    return None
 
 
 def normalize_financials_analysis(raw: Dict[str, Any], *, ticker: str, currency: str) -> Dict[str, Any]:
@@ -290,30 +334,31 @@ def normalize_financials_analysis(raw: Dict[str, Any], *, ticker: str, currency:
             "date": date,
             "period_type": "annual" if period_type == "annual" else "quarterly",
         })
-    periods.sort(key=lambda p: (p.get("date") or "", 0 if p.get("period_type") == "annual" else 1))
+    periods.sort(key=lambda p: (p.get("date") or "", 0 if p.get("period_type") == "quarterly" else 1))
 
     period_keys = {p["key"] for p in periods}
     rows = []
-    for row in _as_list(analysis.get("rows"), limit=len(REQUIRED_METRICS) + 7):
+    raw_rows = _as_list(analysis.get("rows"), limit=len(REQUIRED_METRICS) + len(MARKET_SNAPSHOT_METRICS) + 7)
+    market_keys = {_metric_key(metric) for metric in MARKET_SNAPSHOT_METRICS}
+    for row in raw_rows:
         if not isinstance(row, dict):
             continue
         metric = str(row.get("metric") or "").strip()
         if not metric:
             continue
+        if _metric_key(metric) in market_keys:
+            continue
         values_src = row.get("values") if isinstance(row.get("values"), dict) else {}
         values: Dict[str, Optional[float]] = {}
+        quality = _normalize_quality(row.get("quality"))
         for key in period_keys:
-            value = values_src.get(key)
-            try:
-                num = float(value)
-                values[key] = num if np.isfinite(num) else None
-            except Exception:
-                values[key] = None
+            num = _coerce_number(values_src.get(key))
+            values[key] = None if quality == "unavailable" and num == 0 else num
         rows.append({
             "metric": metric,
             "kind": str(row.get("kind") or "currency").strip().lower(),
             "values": values,
-            "quality": str(row.get("quality") or "mixed").strip().lower(),
+            "quality": quality,
             "note": str(row.get("note") or "").strip(),
         })
 
@@ -335,6 +380,39 @@ def normalize_financials_analysis(raw: Dict[str, Any], *, ticker: str, currency:
         }))
     ordered_rows.extend(list(by_metric.values())[:7])
 
+    current_by_key: Dict[str, Dict[str, Any]] = {}
+    for item in _as_list(analysis.get("current_metrics"), limit=12):
+        if not isinstance(item, dict):
+            continue
+        metric = str(item.get("metric") or "").strip()
+        if not metric:
+            continue
+        quality = _normalize_quality(item.get("quality"))
+        value = _coerce_number(item.get("value"))
+        current_by_key[_metric_key(metric)] = {
+            "metric": metric,
+            "kind": str(item.get("kind") or _default_kind_for_metric(metric)).strip().lower(),
+            "value": None if quality == "unavailable" and value == 0 else value,
+            "quality": quality,
+            "note": str(item.get("note") or "").strip(),
+        }
+
+    current_metrics = []
+    for metric in MARKET_SNAPSHOT_METRICS:
+        existing = current_by_key.get(_metric_key(metric))
+        if existing:
+            existing["metric"] = metric
+            current_metrics.append(existing)
+            continue
+        fallback_value = _snapshot_value_from_rows(raw_rows, metric)
+        current_metrics.append({
+            "metric": metric,
+            "kind": _default_kind_for_metric(metric),
+            "value": fallback_value,
+            "quality": "mixed" if fallback_value is not None else "unavailable",
+            "note": "Current quote snapshot; not a historical period-table value." if fallback_value is not None else "Not available in the provided quote data.",
+        })
+
     return {
         "ticker": str(analysis.get("ticker") or ticker).upper(),
         "currency": str(analysis.get("currency") or currency or "USD").upper(),
@@ -343,8 +421,9 @@ def normalize_financials_analysis(raw: Dict[str, Any], *, ticker: str, currency:
         "subtitle": str(analysis.get("subtitle") or "Original reporting currency").strip(),
         "periods": periods,
         "rows": ordered_rows,
+        "current_metrics": current_metrics,
         "added_rows": [str(x).strip() for x in _as_list(analysis.get("added_rows"), limit=7) if str(x).strip()],
-        "key_takeaways": [str(x).strip() for x in _as_list(analysis.get("key_takeaways"), limit=6) if str(x).strip()],
+        "key_takeaways": [str(x).strip() for x in _as_list(analysis.get("key_takeaways"), limit=10) if str(x).strip()],
         "warnings": [str(x).strip() for x in _as_list(analysis.get("warnings"), limit=8) if str(x).strip()],
     }
 
@@ -365,7 +444,7 @@ def financials_analysis_to_markdown(analysis: Dict[str, Any]) -> str:
     takeaways = analysis.get("key_takeaways") if isinstance(analysis.get("key_takeaways"), list) else []
     if takeaways:
         lines.append("### Key Takeaways")
-        for item in takeaways[:6]:
+        for item in takeaways[:10]:
             lines.append(f"- {item}")
         lines.append("")
     if periods and rows:
@@ -385,7 +464,7 @@ def financials_analysis_to_markdown(analysis: Dict[str, Any]) -> str:
                 elif str(row.get("kind") or "").lower() == "percent":
                     cells.append(f"{float(value) * 100:.1f}%")
                 elif str(row.get("kind") or "").lower() == "ratio":
-                    cells.append(f"{float(value):.2f}x")
+                    cells.append(f"{float(value):.2f}")
                 else:
                     cells.append(f"{float(value):,.0f}")
             cells.append(str(row.get("note") or ""))

--- a/tests/test_financials_agent.py
+++ b/tests/test_financials_agent.py
@@ -41,9 +41,11 @@ def test_normalize_financials_analysis_preserves_required_order_and_caps_added_r
     assert "Total Assets" in [row["metric"] for row in normalized["rows"]]
     assert "Net Liquidity: Liquid Assets Less Debt" in [row["metric"] for row in normalized["rows"]]
     equity_to_assets = next(row for row in normalized["rows"] if row["metric"] == "Equity-to-Assets Ratio")
-    pb = next(row for row in normalized["rows"] if row["metric"] == "Price-to-Book Ratio (P/B)")
+    tax_rate = next(row for row in normalized["rows"] if row["metric"] == "Tax Rate")
+    sbc_ratio = next(row for row in normalized["rows"] if row["metric"] == "SBC / Revenue")
     assert equity_to_assets["kind"] == "percent"
-    assert pb["kind"] == "ratio"
+    assert tax_rate["kind"] == "percent"
+    assert sbc_ratio["kind"] == "percent"
 
 
 def test_normalize_financials_analysis_canonicalizes_curly_shareholders_equity():
@@ -95,3 +97,40 @@ def test_financials_markdown_includes_currency_and_table():
     assert "## Financials" in markdown
     assert "- Currency: USD" in markdown
     assert "| Revenue | 1,000 | Reported. |" in markdown
+
+
+def test_normalize_financials_analysis_sorts_q4_before_fy_and_moves_market_snapshot():
+    normalized = normalize_financials_analysis(
+        {
+            "ticker": "TEST",
+            "periods": [
+                {"key": "2025-09-30_A", "label": "FY 2025", "date": "2025-09-30", "period_type": "annual"},
+                {"key": "2025-09-30_Q", "label": "Q4 2025", "date": "2025-09-30", "period_type": "quarterly"},
+            ],
+            "rows": [
+                {
+                    "metric": "Market Capitalization",
+                    "kind": "currency",
+                    "values": {"2025-09-30_A": 0, "2025-09-30_Q": 1000},
+                    "quality": "mixed",
+                    "note": "Current quote.",
+                },
+                {
+                    "metric": "(+) Amortization of Intangible Assets",
+                    "kind": "currency",
+                    "values": {"2025-09-30_A": 0, "2025-09-30_Q": 0},
+                    "quality": "unavailable",
+                    "note": "Not separately disclosed.",
+                },
+            ],
+        },
+        ticker="TEST",
+        currency="USD",
+    )
+
+    assert [p["key"] for p in normalized["periods"]] == ["2025-09-30_Q", "2025-09-30_A"]
+    assert "Market Capitalization" not in [row["metric"] for row in normalized["rows"]]
+    market_cap = next(metric for metric in normalized["current_metrics"] if metric["metric"] == "Market Capitalization")
+    assert market_cap["value"] == 1000
+    amortization = next(row for row in normalized["rows"] if row["metric"] == "(+) Amortization of Intangible Assets")
+    assert amortization["values"] == {"2025-09-30_Q": None, "2025-09-30_A": None}


### PR DESCRIPTION
## Summary

- Fix Financials tab missing-data handling so unavailable values render as "-" while real zero remains 0.
- Split current market snapshot values out of the historical table and separate balance-sheet rows into their own table.
- Improve financials insights, headers, light-mode contrast, ratio formatting, tax/SBC rows, spreadsheet-friendly copy actions, and mobile table behavior.
- Color the TradingAgents valuation sub-tab / final decision panel green or red when the final committee decision is bullish or bearish, and make valuation assumptions readable on mobile.

## Preview

URL: https://pr-105-hedge-in-a-box-site.fly.dev

## Test plan

- [x] `PYTHONPATH=src python -m pytest -q tests/test_financials_agent.py --basetemp .pytest-tmp-financials-tab`
- [x] `python -m py_compile src/ai_hedge/financials_agent.py`
- [x] `cd frontend && npm run build`
- [x] Local route smoke: `http://127.0.0.1:3000/api/health` -> 200 and `http://127.0.0.1:3000/dashboard/AAPL/financials` -> 200
- [x] Preview route smoke: `https://pr-105-hedge-in-a-box-site.fly.dev/api/health` -> 200, `/dashboard/AAPL/financials` -> 200, and `/dashboard/AAPL/valuation` -> 200

## Notes for reviewer

- The Financials agent prompt now asks for 5-10 user-friendly conclusions and puts Market Cap, EV, P/B, and P/E in `current_metrics` instead of period rows.
- The normalizer also cleans older/imperfect payloads by moving legacy market rows into the snapshot and treating unavailable `0` cells as missing.
- TradingAgents coloring is frontend-only and based on the stored final committee decision text; neutral/hold language keeps the existing regular tab style.
