### PR TITLE
Fix financials tab metrics and period columns

### DIFF
--- a/frontend/src/app/(app)/dashboard/[ticker]/financials/financials-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/financials/financials-client.tsx
@@ -30,6 +30,10 @@ type CurrentMetric = {
   note?: string;
 };
 
+const EMPTY_PERIODS: FinancialPeriod[] = [];
+const EMPTY_ROWS: FinancialRow[] = [];
+const EMPTY_CURRENT_METRICS: CurrentMetric[] = [];
+
 const BALANCE_METRICS = new Set([
   "Total Assets",
   "Customers / Accounts Receivable",
@@ -79,6 +83,10 @@ function periodChip(period: FinancialPeriod): string {
   const raw = String(period.label || period.date || period.key || "").trim();
   const prefix = String(period.period_type || "").toLowerCase() === "annual" ? "FY" : "Q";
   return `${prefix} ${raw}`.replace(/^FY FY\s+/i, "FY ").replace(/^Q Q/i, "Q");
+}
+
+function isAnnualPeriod(period: FinancialPeriod): boolean {
+  return String(period.period_type || "").toLowerCase() === "annual";
 }
 
 function dateParts(date?: string): string[] {
@@ -145,8 +153,15 @@ function FinancialTable({
             <tr>
               <th className="bg-[color:var(--surface-elevated)] px-3 py-3 text-left font-medium sm:sticky sm:left-0 sm:z-10">Metric</th>
               {periods.map((period) => (
-                <th key={period.key} className="px-3 py-3 text-right align-bottom font-medium">
-                  <span className="block text-base leading-5 text-[color:var(--text-primary)]">{periodChip(period).replace(/\s+/g, " ")}</span>
+                <th
+                  key={period.key}
+                  className={`px-3 py-3 text-right align-bottom font-medium ${
+                    isAnnualPeriod(period) ? "border-x border-[color:var(--border-strong)] bg-[color:var(--surface-elevated)]" : ""
+                  }`}
+                >
+                  <span className={`block text-base leading-5 text-[color:var(--text-primary)] ${isAnnualPeriod(period) ? "font-semibold" : ""}`}>
+                    {periodChip(period).replace(/\s+/g, " ")}
+                  </span>
                   <span className="mt-1 block font-mono text-[11px] leading-4 text-[color:var(--text-muted)]">
                     {dateParts(period.date).map((part) => (
                       <span key={`${period.key}-${part}`} className="block">
@@ -167,7 +182,12 @@ function FinancialTable({
                   {row.metric}
                 </td>
                 {periods.map((period) => (
-                  <td key={`${row.metric}-${period.key}`} className="px-3 py-2 text-right font-mono text-[color:var(--text-primary)]">
+                  <td
+                    key={`${row.metric}-${period.key}`}
+                    className={`px-3 py-2 text-right font-mono text-[color:var(--text-primary)] ${
+                      isAnnualPeriod(period) ? "border-x border-[color:var(--border-strong)] bg-[color:var(--surface-elevated)] font-semibold" : ""
+                    }`}
+                  >
                     {fmtValue(row.values?.[String(period.key || "")], row.kind)}
                   </td>
                 ))}
@@ -203,9 +223,9 @@ export function FinancialsClient({
   const payload = data.financials || {};
   const status = String(payload.status || "").toLowerCase();
   const analysis = payload.analysis || {};
-  const periods = Array.isArray(analysis.periods) ? (analysis.periods as FinancialPeriod[]) : [];
-  const rows = Array.isArray(analysis.rows) ? (analysis.rows as FinancialRow[]) : [];
-  const currentMetrics = Array.isArray(analysis.current_metrics) ? (analysis.current_metrics as CurrentMetric[]) : [];
+  const periods = Array.isArray(analysis.periods) ? (analysis.periods as FinancialPeriod[]) : EMPTY_PERIODS;
+  const rows = Array.isArray(analysis.rows) ? (analysis.rows as FinancialRow[]) : EMPTY_ROWS;
+  const currentMetrics = Array.isArray(analysis.current_metrics) ? (analysis.current_metrics as CurrentMetric[]) : EMPTY_CURRENT_METRICS;
   const takeaways = asList(analysis.key_takeaways);
   const warnings = asList(analysis.warnings);
   const currency = String(analysis.currency || data.header?.original_financial_currency || data.header?.currency || "USD").toUpperCase();
@@ -332,7 +352,7 @@ export function FinancialsClient({
 
           <p className="inline-flex items-center gap-1 text-xs text-[color:var(--text-muted)]">
             <Info size={13} />
-            Missing data is shown as "-"; a displayed 0 means the source value or formula is actually zero.
+            Missing data is shown as a dash; a displayed 0 means the source value or formula is actually zero.
           </p>
         </div>
       )}

--- a/src/ai_hedge/financials_agent.py
+++ b/src/ai_hedge/financials_agent.py
@@ -21,6 +21,8 @@ REQUIRED_METRICS = [
     "Net Margin",
     "Tax Rate",
     "Operating Cash Flow",
+    "Capital Expenditures (Capex)",
+    "Capex / Revenue",
     "Free Cash Flow (FCF)",
     "FCF / Net Income",
     "(+) Stock-Based Compensation (SBC)",
@@ -195,7 +197,7 @@ Current market snapshot fields, outside the period table:
 
 Optional rows:
 - You may add up to 7 additional rows only if truly important for this company type.
-- Examples: ARR/RPO for SaaS, deposits/NII for banks, same-store sales for retailers, inventory turns, R&D intensity, capex, deferred revenue, net debt, customer deposits, asset turnover.
+- Examples: ARR/RPO for SaaS, deposits/NII for banks, same-store sales for retailers, inventory turns, R&D intensity, deferred revenue, net debt, customer deposits, asset turnover.
 - Do not add optional rows just to look comprehensive.
 
 Non-GAAP logic:
@@ -210,6 +212,8 @@ Balance sheet and market-value logic:
 - Net Liquidity = Liquid Assets - Total Debt.
 - Equity-to-Assets Ratio = Total Shareholders' Equity / Total Assets. It is a ratio decimal, not a percent string.
 - Tax Rate = tax provision / pretax income when both are available. If either line is missing, use null.
+- Capital Expenditures (Capex) should come from the cash flow statement when available. Use the absolute cash outflow amount as a positive currency value even if the statement reports capex as negative.
+- Capex / Revenue = Capital Expenditures (Capex) / Revenue when both are available. It is a ratio decimal, not a percent string.
 - SBC / Revenue = Stock-Based Compensation / Revenue when both are available. If SBC is not disclosed separately, use null.
 - Market Capitalization, Enterprise Value (EV), Price-to-Book Ratio (P/B), and Price-to-Earnings Ratio (P/E) are current quote snapshot fields, not period-table rows. Put them in current_metrics only when available from quote info or defensible from quote info plus latest statements. Do not invent historical values for them.
 
@@ -277,7 +281,7 @@ def _default_kind_for_metric(metric: str) -> str:
     text = str(metric or "").lower()
     if "margin" in text or "growth" in text or "equity-to-assets" in text:
         return "percent"
-    if "tax rate" in text or "sbc / revenue" in text:
+    if "tax rate" in text or "sbc / revenue" in text or "capex / revenue" in text:
         return "percent"
     if "ratio" in text or "p/b" in text or "fcf / net income" in text:
         return "ratio"

--- a/tests/test_financials_agent.py
+++ b/tests/test_financials_agent.py
@@ -42,9 +42,13 @@ def test_normalize_financials_analysis_preserves_required_order_and_caps_added_r
     assert "Net Liquidity: Liquid Assets Less Debt" in [row["metric"] for row in normalized["rows"]]
     equity_to_assets = next(row for row in normalized["rows"] if row["metric"] == "Equity-to-Assets Ratio")
     tax_rate = next(row for row in normalized["rows"] if row["metric"] == "Tax Rate")
+    capex = next(row for row in normalized["rows"] if row["metric"] == "Capital Expenditures (Capex)")
+    capex_ratio = next(row for row in normalized["rows"] if row["metric"] == "Capex / Revenue")
     sbc_ratio = next(row for row in normalized["rows"] if row["metric"] == "SBC / Revenue")
     assert equity_to_assets["kind"] == "percent"
     assert tax_rate["kind"] == "percent"
+    assert capex["kind"] == "currency"
+    assert capex_ratio["kind"] == "percent"
     assert sbc_ratio["kind"] == "percent"
 
 


### PR DESCRIPTION
﻿## Summary

- Add Capital Expenditures (Capex) and Capex / Revenue as mandatory financials table rows in the extraction prompt and normalizer order.
- Distinguish annual/FY columns from quarterly columns in the Financials tab with stronger borders, subtle token-backed column background, and bolder annual values.
- Add focused coverage for CAPEX row kind normalization.

## Preview

URL: pending - site preview workflow should publish `pr-<N>-hedge-in-a-box-site.fly.dev` because this touches `frontend/**`.

## Test plan

- [x] `PYTHONPATH=src pytest tests/test_financials_agent.py`
- [x] `cd frontend; npx eslint "src/app/(app)/dashboard/[ticker]/financials/financials-client.tsx"`
- [x] `cd frontend; npm run build`
- [x] Local route check: `http://127.0.0.1:3000/dashboard/AAPL/financials` returned 200 and rendered the updated Financials tab HTML/classes.
- [ ] Preview URL verification after workflow deploys.

## Notes for reviewer

- `npm run build` passes with an existing Next/Turbopack warning about the deprecated `middleware` convention / NFT tracing from `next.config.ts`; no new build failure.
- The in-app Browser was unavailable in this session, so local verification used HTTP/HTML inspection instead of a screenshot.
