### PR TITLE
Fix dashboard issue batch

### DIFF
--- a/frontend/src/app/(app)/dashboard/[ticker]/overview/overview-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/overview/overview-client.tsx
@@ -13,6 +13,7 @@ import {
   fmtMoneyCompact,
 } from "@/components/hedge-dashboard";
 import { INVESTORS_ORDERED, OVERVIEW_FEATURED_PERSONAS } from "@/components/dream-team/persona-themes";
+import { disagreementScoreForReport } from "@/lib/ticker-summary-aggregate";
 
 function fmtPct(v?: number | null): string {
   return typeof v === "number" && Number.isFinite(v) ? `${v >= 0 ? "+" : ""}${v.toFixed(2)}%` : "N/A";
@@ -84,21 +85,7 @@ export function OverviewClient({
     Number.isFinite(generatedDate.getTime())
       ? `${generatedDate.getFullYear()}-${String(generatedDate.getMonth() + 1).padStart(2, "0")}-${String(generatedDate.getDate()).padStart(2, "0")}`
       : "N/A";
-  const targetDisagreement =
-    typeof consensus?.cv === "number" && Number.isFinite(consensus.cv) ? Math.abs(Number(consensus.cv)) : null;
-  const investmentDisagreement =
-    Array.isArray(consensus?.lmil) && typeof consensus?.lmil?.[1] === "number" && Number.isFinite(consensus.lmil[1])
-      ? Math.abs(Number(consensus.lmil[1]))
-      : null;
-  const disagreementParts = [targetDisagreement, investmentDisagreement].filter(
-    (v): v is number => typeof v === "number" && Number.isFinite(v),
-  );
-  const disagreementScore =
-    typeof scoreCard?.overall_cv === "number" && Number.isFinite(scoreCard.overall_cv)
-      ? Math.abs(Number(scoreCard.overall_cv))
-      : disagreementParts.length > 0
-        ? disagreementParts.reduce((sum, v) => sum + v, 0) / disagreementParts.length
-        : null;
+  const disagreementScore = disagreementScoreForReport(data);
   const finalCombinedScore =
     typeof scoreCard?.combined_score === "number" && Number.isFinite(scoreCard.combined_score)
       ? Number(scoreCard.combined_score)

--- a/frontend/src/app/(app)/dashboard/[ticker]/scenarios/scenarios-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/scenarios/scenarios-client.tsx
@@ -28,6 +28,37 @@ type MainThesisDoc = {
   kpis?: WatchlistKpi[];
 };
 
+function fmtScenarioProbability(probability: number | null): string {
+  return typeof probability === "number"
+    ? `${(Math.max(0, Math.min(100, Math.abs(probability) <= 1 ? probability * 100 : probability))).toFixed(1)}%`
+    : "N/A";
+}
+
+function scenarioCopyText(title: string, probability: number | null, items: string[]): string {
+  return [
+    title,
+    `Probability: ${fmtScenarioProbability(probability)}`,
+    "",
+    ...items.map((reason, idx) => `${idx + 1}. ${String(reason || "").replace(/~~/g, "").trim()}`),
+  ].join("\n").trim();
+}
+
+function thesisCopyText(thesisLine: string, questionItems: string[], kpiItems: WatchlistKpi[]): string {
+  return [
+    thesisLine,
+    "",
+    "Questions",
+    ...questionItems.map((item, idx) => `${idx + 1}. ${item}`),
+    "",
+    "KPIs",
+    ...kpiItems.map((item, idx) => {
+      const name = item.name || "KPI";
+      const details = [item.why_it_matters, item.direction_to_watch].filter(Boolean).join(" ");
+      return `${idx + 1}. ${name}${details ? ` - ${details}` : ""}`;
+    }),
+  ].join("\n").trim();
+}
+
 function SwotAccordion({ swot }: { swot: SwotData }) {
   const [open, setOpen] = useState(false);
   const sections: Array<{ key: keyof SwotData; label: string; tone: string }> = [
@@ -95,13 +126,7 @@ function ScenarioColumn({
   const probClass = tone === "bull" ? "hib-bull-prob-label" : "hib-bear-prob-label";
   const probValueClass = tone === "bull" ? "hib-bull-prob-value" : "hib-bear-prob-value";
   const items = reasons.length ? reasons : doc?.reasons || [];
-  const copyText = [
-    typeof probability === "number"
-      ? `Probability: ${(Math.max(0, Math.min(100, Math.abs(probability) <= 1 ? probability * 100 : probability))).toFixed(1)}%`
-      : "Probability: N/A",
-    "",
-    ...items.map((reason, idx) => `${idx + 1}. ${String(reason || "").replace(/~~/g, "").trim()}`),
-  ].join("\n").trim();
+  const copyText = scenarioCopyText(title, probability, items);
 
   return (
     <section className={`rounded-2xl border p-4 ${borderCls}`}>
@@ -113,7 +138,7 @@ function ScenarioColumn({
             <div className="text-right">
               <p className={`text-[10px] uppercase tracking-[0.18em] ${probClass}`}>Probability</p>
               <p className={`text-xl font-bold ${probValueClass}`}>
-                {(Math.max(0, Math.min(100, Math.abs(probability) <= 1 ? probability * 100 : probability))).toFixed(1)}%
+                {fmtScenarioProbability(probability)}
               </p>
             </div>
           ) : null}
@@ -153,19 +178,7 @@ function MainThesisPanel({
   const kpiItems = kpis.length ? kpis : doc?.kpis || [];
   if (!thesisLine && !questionItems.length && !kpiItems.length) return null;
 
-  const copyText = [
-    thesisLine,
-    "",
-    "Main questions",
-    ...questionItems.map((item, idx) => `${idx + 1}. ${item}`),
-    "",
-    "KPIs to watch",
-    ...kpiItems.map((item, idx) => {
-      const name = item.name || "KPI";
-      const details = [item.why_it_matters, item.direction_to_watch].filter(Boolean).join(" ");
-      return `${idx + 1}. ${name}${details ? ` - ${details}` : ""}`;
-    }),
-  ].join("\n").trim();
+  const copyText = thesisCopyText(thesisLine, questionItems, kpiItems);
 
   return (
     <section className="mt-4 rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
@@ -241,13 +254,30 @@ export function ScenariosClient({
   }
   const bullProb = probFor("Bull Probability") ?? probFor("Bull 0");
   const bearProb = probFor("Bear Probability") ?? probFor("Bear 0");
+  const bullItems = bullReasons.length ? bullReasons : matrix.documents?.bull_case?.reasons || [];
+  const bearItems = bearReasons.length ? bearReasons : matrix.documents?.bear_case?.reasons || [];
+  const thesisLine = mainThesisDoc?.valuation_revolves_around || "";
+  const questionItems = mainQuestions.length ? mainQuestions : mainThesisDoc?.main_questions || [];
+  const kpiItems = watchlistKpis.length ? watchlistKpis : mainThesisDoc?.kpis || [];
+  const copyAllText = [
+    `Bull vs Bear - ${upper}`,
+    "",
+    scenarioCopyText("Bull Case", bullProb, bullItems),
+    "",
+    scenarioCopyText("Bear Case", bearProb, bearItems),
+    "",
+    thesisCopyText(thesisLine, questionItems, kpiItems),
+  ].join("\n\n").trim();
 
   return (
     <div>
       <ReportChipRow ticker={upper} reports={reportsForTicker} currentReportId={resolvedReportId} />
-      <header className="mb-4">
-        <h1 className="font-display text-2xl text-zinc-100">Bull vs Bear</h1>
+      <header className="mb-4 flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h1 className="font-display text-2xl text-zinc-100">Bull vs Bear</h1>
         <p className="text-xs uppercase tracking-[0.18em] text-zinc-500">{upper} — scenario comparison</p>
+        </div>
+        <SmallCopyButton text={copyAllText} label="Copy Bull vs Bear tab" />
       </header>
       <SwotAccordion
         swot={

--- a/frontend/src/app/(app)/dashboard/[ticker]/wall-st/wall-st-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/wall-st/wall-st-client.tsx
@@ -152,13 +152,64 @@ type StreetMarker = {
   labelClass: string;
 };
 
+const STREET_MARKER_LABEL_ORDER = ["Current", "Low", "Median", "Mean", "High"] as const;
+
 type PlacedStreetMarker = StreetMarker & {
   lane: "top" | "bottom";
   row: number;
 };
 
+function streetMarkerLabelRank(label: string): number {
+  const idx = STREET_MARKER_LABEL_ORDER.indexOf(label as (typeof STREET_MARKER_LABEL_ORDER)[number]);
+  return idx >= 0 ? idx : STREET_MARKER_LABEL_ORDER.length;
+}
+
+function mergeOverlappingStreetMarkers(markers: StreetMarker[]): StreetMarker[] {
+  const sorted = markers
+    .filter((marker) => marker.value !== null)
+    .slice()
+    .sort((a, b) => a.pct - b.pct || streetMarkerLabelRank(a.label) - streetMarkerLabelRank(b.label));
+  const groups: StreetMarker[][] = [];
+  const mergeGapPct = 1.5;
+
+  for (const marker of sorted) {
+    const group = groups[groups.length - 1];
+    const groupPct = group ? group.reduce((sum, item) => sum + item.pct, 0) / group.length : null;
+    if (group && groupPct !== null && Math.abs(marker.pct - groupPct) <= mergeGapPct) {
+      group.push(marker);
+    } else {
+      groups.push([marker]);
+    }
+  }
+
+  return groups.map((group) => {
+    if (group.length === 1) return group[0];
+    const orderedLabels = group
+      .map((marker) => marker.label)
+      .sort((a, b) => streetMarkerLabelRank(a) - streetMarkerLabelRank(b));
+    const primary = group.find((marker) => marker.label === "Current") || group[0];
+    const valueMarker = group.find((marker) => marker.value !== null) || primary;
+    const changeMarker = group.find((marker) => marker.change !== null && marker.change !== undefined) || primary;
+    const pct = group.reduce((sum, marker) => sum + marker.pct, 0) / group.length;
+    const preferredLane = group.some((marker) => marker.preferredLane === "top") ? "top" : primary.preferredLane;
+    const hasCurrent = group.some((marker) => marker.label === "Current");
+
+    return {
+      ...primary,
+      label: orderedLabels.join(", "),
+      value: valueMarker.value,
+      change: changeMarker.change,
+      pct,
+      preferredLane,
+      translateClass: pct > 90 ? "-translate-x-full" : pct < 10 ? "translate-x-0" : "-translate-x-1/2",
+      dotClass: hasCurrent ? "bg-[color:var(--warning)]" : primary.dotClass,
+      labelClass: hasCurrent ? "text-[color:var(--warning)]" : primary.labelClass,
+    };
+  });
+}
+
 function placeStreetMarkers(markers: StreetMarker[]): PlacedStreetMarker[] {
-  const sorted = markers.slice().sort((a, b) => a.pct - b.pct || a.label.localeCompare(b.label));
+  const sorted = mergeOverlappingStreetMarkers(markers).sort((a, b) => a.pct - b.pct || a.label.localeCompare(b.label));
   const lastByLane: Record<"top" | "bottom", number[]> = { top: [], bottom: [] };
   const minGapPct = 13;
 

--- a/frontend/src/app/(app)/dashboard/[ticker]/wall-st/wall-st-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/wall-st/wall-st-client.tsx
@@ -141,6 +141,49 @@ function clampPct(value: number, low: number, high: number): number {
   return Math.max(0, Math.min(100, ((value - low) / (high - low)) * 100));
 }
 
+type StreetMarker = {
+  label: string;
+  value: number | null;
+  change: number | null | undefined;
+  pct: number;
+  preferredLane: "top" | "bottom";
+  translateClass: string;
+  dotClass: string;
+  labelClass: string;
+};
+
+type PlacedStreetMarker = StreetMarker & {
+  lane: "top" | "bottom";
+  row: number;
+};
+
+function placeStreetMarkers(markers: StreetMarker[]): PlacedStreetMarker[] {
+  const sorted = markers.slice().sort((a, b) => a.pct - b.pct || a.label.localeCompare(b.label));
+  const lastByLane: Record<"top" | "bottom", number[]> = { top: [], bottom: [] };
+  const minGapPct = 13;
+
+  return sorted.map((marker) => {
+    const laneOrder: Array<"top" | "bottom"> =
+      marker.preferredLane === "top" ? ["top", "bottom"] : ["bottom", "top"];
+    for (const lane of laneOrder) {
+      for (let row = 0; row < 3; row += 1) {
+        const lastPct = lastByLane[lane][row];
+        if (lastPct === undefined || Math.abs(marker.pct - lastPct) >= minGapPct) {
+          lastByLane[lane][row] = marker.pct;
+          return { ...marker, lane, row };
+        }
+      }
+    }
+
+    const fallbackLane = marker.preferredLane;
+    const bestRow = lastByLane[fallbackLane]
+      .map((lastPct, row) => ({ row, distance: Math.abs(marker.pct - lastPct) }))
+      .sort((a, b) => b.distance - a.distance)[0]?.row ?? 0;
+    lastByLane[fallbackLane][bestRow] = marker.pct;
+    return { ...marker, lane: fallbackLane, row: bestRow };
+  });
+}
+
 function recommendationCounts(metrics: NonNullable<WallStPayload["metrics"]>["recommendations"]) {
   const latest = metrics?.latest || {};
   const keys = [
@@ -257,13 +300,15 @@ function StreetRange({ targets, currency }: { targets: NonNullable<WallStPayload
   const railPct = (pct: number) => 3 + (pct * 94) / 100;
   const analystDotClass = "bg-[color:var(--text-primary)]";
   const analystLabelClass = "text-[color:var(--text-primary)]";
-  const markers = [
-    { label: "Low", value: low, change: lowChangePct, pct: railPct(lowPct), lane: "top", translateClass: "-translate-x-1/2", dotClass: analystDotClass, labelClass: analystLabelClass },
-    { label: "Current", value: current, change: null, pct: railPct(currentPct), lane: "bottom", translateClass: "-translate-x-1/2", dotClass: "bg-[color:var(--warning)]", labelClass: "text-[color:var(--warning)]" },
-    { label: "Median", value: median, change: medianChangePct, pct: railPct(medianPct), lane: "top", translateClass: "-translate-x-1/2", dotClass: analystDotClass, labelClass: analystLabelClass },
-    { label: "Mean", value: mean, change: targets?.upside_pct, pct: railPct(meanPct), lane: "bottom", translateClass: "-translate-x-1/2", dotClass: analystDotClass, labelClass: analystLabelClass },
-    { label: "High", value: high, change: highChangePct, pct: railPct(highPct), lane: "top", translateClass: "-translate-x-full", dotClass: analystDotClass, labelClass: analystLabelClass },
-  ];
+  const markers = placeStreetMarkers([
+    { label: "Low", value: low, change: lowChangePct, pct: railPct(lowPct), preferredLane: "top", translateClass: "-translate-x-1/2", dotClass: analystDotClass, labelClass: analystLabelClass },
+    { label: "Current", value: current, change: null, pct: railPct(currentPct), preferredLane: "bottom", translateClass: "-translate-x-1/2", dotClass: "bg-[color:var(--warning)]", labelClass: "text-[color:var(--warning)]" },
+    { label: "Median", value: median, change: medianChangePct, pct: railPct(medianPct), preferredLane: "top", translateClass: "-translate-x-1/2", dotClass: analystDotClass, labelClass: analystLabelClass },
+    { label: "Mean", value: mean, change: targets?.upside_pct, pct: railPct(meanPct), preferredLane: "bottom", translateClass: "-translate-x-1/2", dotClass: analystDotClass, labelClass: analystLabelClass },
+    { label: "High", value: high, change: highChangePct, pct: railPct(highPct), preferredLane: "top", translateClass: "-translate-x-full", dotClass: analystDotClass, labelClass: analystLabelClass },
+  ]);
+  const labelTopClass = (row: number) => ["top-0", "top-10", "top-20"][row] || "top-0";
+  const labelBottomClass = (row: number) => ["top-24", "top-32", "top-40"][row] || "top-24";
 
   return (
     <section className="min-w-0 rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
@@ -280,7 +325,7 @@ function StreetRange({ targets, currency }: { targets: NonNullable<WallStPayload
         <p className="text-sm text-[color:var(--text-secondary)]">No usable low/high analyst target range was returned.</p>
       ) : (
         <div className="px-2 py-5">
-          <div className="relative h-36">
+          <div className="relative h-56">
             <div className="hib-wallst-range-rail absolute left-[3%] right-[3%] top-16 h-2 rounded-full" aria-label="Current price and analyst target range" />
             {markers.map((marker) => (
               <div
@@ -290,7 +335,7 @@ function StreetRange({ targets, currency }: { targets: NonNullable<WallStPayload
                 title={`${marker.label}: ${fmtNum(marker.value)}${marker.change !== null ? ` (${fmtPct(marker.change)})` : ""}`}
               >
                 {marker.lane === "top" ? (
-                  <div className="absolute top-0 flex flex-col gap-0.5">
+                  <div className={`absolute ${labelTopClass(marker.row)} flex flex-col gap-0.5`}>
                     <span className={`whitespace-nowrap text-xs font-semibold ${marker.labelClass}`}>{marker.label}</span>
                     <span className="whitespace-nowrap font-mono text-[11px] text-[color:var(--text-secondary)]">{fmtNum(marker.value)}</span>
                     {marker.change !== null ? (
@@ -301,7 +346,7 @@ function StreetRange({ targets, currency }: { targets: NonNullable<WallStPayload
                 <span className={`absolute left-1/2 h-7 w-px -translate-x-1/2 ${marker.lane === "top" ? "top-9" : "top-16"} ${marker.dotClass}`} />
                 <span className={`absolute left-1/2 top-[3.625rem] h-3 w-3 -translate-x-1/2 rounded-full ring-2 ring-[color:var(--surface)] ${marker.dotClass}`} />
                 {marker.lane === "bottom" ? (
-                  <div className="absolute top-24 flex flex-col gap-0.5">
+                  <div className={`absolute ${labelBottomClass(marker.row)} flex flex-col gap-0.5`}>
                     <span className={`whitespace-nowrap text-xs font-semibold ${marker.labelClass}`}>{marker.label}</span>
                     <span className="whitespace-nowrap font-mono text-[11px] text-[color:var(--text-secondary)]">{fmtNum(marker.value)}</span>
                     {marker.change !== null ? (

--- a/frontend/src/app/api/discovery/route.ts
+++ b/frontend/src/app/api/discovery/route.ts
@@ -6,6 +6,7 @@ import { DashboardPayload, DiscoveryRow } from "@/lib/dashboard-types";
 import { getLiveCurrentPricesBatch } from "@/lib/dashboard-server";
 import { isDbEnabled } from "@/lib/db";
 import { getDeletedReportFilter, siteRunIdFromPathLike } from "@/lib/deleted-reports";
+import { isExcludedTicker } from "@/lib/excluded-tickers";
 import { listAllDashboardsForHitRate } from "@/lib/reports-db";
 import { listDashboardReports, readJson } from "@/lib/server-outputs";
 import {
@@ -153,6 +154,7 @@ async function loadDashboards(): Promise<
         updatedAt: new Date(r.generated_at).toISOString(),
         sourceLabel: r.ticker,
       };
+      if (isExcludedTicker(row.ticker)) continue;
       const runId = String(r.source_run_id || "").trim();
       const key = runId ? `run:${row.ticker}:${runId}` : `db:${row.ticker}:${row.updatedAt}`;
       merged.set(key, row);
@@ -170,7 +172,7 @@ async function loadDashboards(): Promise<
     const payload = readJson<DashboardPayload>(entry.path);
     if (!payload) continue;
     const ticker = String(payload.ticker || entry.ticker || "").toUpperCase();
-    if (!ticker) continue;
+    if (!ticker || isExcludedTicker(ticker)) continue;
     const updatedAt =
       typeof payload.generated_at === "string" && payload.generated_at.trim()
         ? payload.generated_at
@@ -203,7 +205,7 @@ export async function GET(request: Request) {
   const byTicker = new Map<string, SummarySourceReport[]>();
   for (const item of items) {
     const ticker = String(item.ticker || "").toUpperCase();
-    if (!ticker) continue;
+    if (!ticker || isExcludedTicker(ticker)) continue;
     if (!byTicker.has(ticker)) {
       byTicker.set(ticker, []);
     }

--- a/frontend/src/app/api/ticker-search/route.ts
+++ b/frontend/src/app/api/ticker-search/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 
+import { filterExcludedTickers } from "@/lib/excluded-tickers";
 import { yahooSearch } from "@/lib/yahoo-lookup";
 
 export const runtime = "nodejs";
@@ -13,6 +14,6 @@ export async function GET(req: Request) {
   const limitRaw = Number(url.searchParams.get("limit") || "8");
   const limit = Math.max(1, Math.min(20, Number.isFinite(limitRaw) ? limitRaw : 8));
 
-  const results = await yahooSearch(q, limit);
+  const results = filterExcludedTickers(await yahooSearch(q, limit), (row) => row.s);
   return NextResponse.json({ results });
 }

--- a/frontend/src/app/api/tickers/route.ts
+++ b/frontend/src/app/api/tickers/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 
+import { filterExcludedTickers } from "@/lib/excluded-tickers";
 import { listAllTickerSymbols } from "@/lib/reports-db";
 import { listTickersFromOutputs } from "@/lib/server-outputs";
 
@@ -7,11 +8,11 @@ export async function GET() {
   try {
     const dbTickers = await listAllTickerSymbols();
     if (dbTickers.length) {
-      return NextResponse.json({ tickers: dbTickers });
+      return NextResponse.json({ tickers: filterExcludedTickers(dbTickers) });
     }
   } catch (err) {
     console.warn("[tickers] DB read failed:", err);
   }
-  const tickers = listTickersFromOutputs();
+  const tickers = filterExcludedTickers(listTickersFromOutputs());
   return NextResponse.json({ tickers });
 }

--- a/frontend/src/lib/excluded-tickers.ts
+++ b/frontend/src/lib/excluded-tickers.ts
@@ -1,0 +1,17 @@
+const EXCLUDED_TICKERS = new Set(["HSBK.IL"]);
+
+export function normalizeTicker(value: unknown): string {
+  return String(value || "").trim().toUpperCase();
+}
+
+export function isExcludedTicker(value: unknown): boolean {
+  const ticker = normalizeTicker(value);
+  return Boolean(ticker && EXCLUDED_TICKERS.has(ticker));
+}
+
+export function filterExcludedTickers<T>(
+  rows: T[],
+  getTicker: (row: T) => unknown = (row) => row,
+): T[] {
+  return rows.filter((row) => !isExcludedTicker(getTicker(row)));
+}

--- a/frontend/src/lib/reports-db.ts
+++ b/frontend/src/lib/reports-db.ts
@@ -1,5 +1,6 @@
 import { getSql } from "@/lib/db";
 import type { DashboardPayload } from "@/lib/dashboard-types";
+import { filterExcludedTickers, isExcludedTicker } from "@/lib/excluded-tickers";
 import { listDashboardReports, readJson } from "@/lib/server-outputs";
 
 export type ReportVisibility = "public" | "private" | "unlisted";
@@ -46,6 +47,7 @@ export interface DeletedReportRef {
 }
 
 export async function fetchLatestReport(ticker: string): Promise<DbReportFull | null> {
+  if (isExcludedTicker(ticker)) return null;
   const sql = getSql();
   if (!sql) return null;
   const rows = (await sql`
@@ -123,7 +125,8 @@ export async function fetchReportById(id: string): Promise<DbReportFull | null> 
        AND r.deleted_at IS NULL
      LIMIT 1
   `) as unknown as DbReportFull[];
-  return rows[0] || null;
+  const row = rows[0] || null;
+  return row && !isExcludedTicker(row.ticker) ? row : null;
 }
 
 export async function listAllTickerSymbols(): Promise<string[]> {
@@ -132,7 +135,7 @@ export async function listAllTickerSymbols(): Promise<string[]> {
   const rows = (await sql`
     SELECT symbol FROM tickers ORDER BY symbol;
   `) as unknown as { symbol: string }[];
-  return rows.map((r) => r.symbol);
+  return filterExcludedTickers(rows.map((r) => r.symbol));
 }
 
 export async function listTickers(): Promise<DbTickerRow[]> {
@@ -144,7 +147,7 @@ export async function listTickers(): Promise<DbTickerRow[]> {
       FROM tickers
      ORDER BY report_count DESC, symbol;
   `) as unknown as DbTickerRow[];
-  return rows;
+  return filterExcludedTickers(rows, (row) => row.symbol);
 }
 
 /**
@@ -180,7 +183,7 @@ export async function listLatestReportsPerTicker(): Promise<DbReportSummary[]> {
      WHERE r.deleted_at IS NULL
      ORDER BY r.ticker, r.generated_at DESC;
   `) as unknown as DbReportSummary[];
-  return rows;
+  return filterExcludedTickers(rows, (row) => row.ticker);
 }
 
 export async function attributeReportToUser(opts: {
@@ -291,7 +294,7 @@ function fallbackCommunityReportsFromOutputs(query?: string, isDeleted: DeletedR
     });
   }
   rows.sort((a, b) => Date.parse(String(b.generated_at || "")) - Date.parse(String(a.generated_at || "")));
-  return rows;
+  return filterExcludedTickers(rows, (row) => row.ticker);
 }
 
 export async function findReportIdBySourceRunId(opts: {
@@ -303,6 +306,7 @@ export async function findReportIdBySourceRunId(opts: {
   if (!sql) return null;
   const source = String(opts.source || "site");
   const ticker = String(opts.ticker || "").trim().toUpperCase();
+  if (isExcludedTicker(ticker)) return null;
   const rows = ticker
     ? ((await sql`
         SELECT id::text AS id
@@ -355,7 +359,7 @@ export async function listAllReports(): Promise<DbReportSummary[]> {
      WHERE r.deleted_at IS NULL
      ORDER BY r.generated_at DESC;
   `) as unknown as DbReportSummary[];
-  return rows;
+  return filterExcludedTickers(rows, (row) => row.ticker);
 }
 
 /** Reports owned by a specific user, regardless of visibility. */
@@ -388,7 +392,7 @@ export async function listUserReports(userId: string): Promise<DbReportSummary[]
        AND r.deleted_at IS NULL
      ORDER BY r.generated_at DESC;
   `) as unknown as DbReportSummary[];
-  return rows;
+  return filterExcludedTickers(rows, (row) => row.ticker);
 }
 
 /** Public reports authored by anyone. */
@@ -422,7 +426,7 @@ export async function listCommunityReports(): Promise<DbReportSummary[]> {
            AND r.deleted_at IS NULL
          ORDER BY r.generated_at DESC;
       `) as unknown as DbReportSummary[]);
-    return rows;
+    return filterExcludedTickers(rows, (row) => row.ticker);
   } catch {
     return fallbackCommunityReportsFromOutputs(undefined, await deletedReportPredicate());
   }
@@ -488,8 +492,9 @@ export async function listCommunityReportsPaged(opts: {
         OFFSET ${offset};
       `) as unknown as DbReportSummary[]);
 
-    const hasMore = rows.length > limit;
-    return { rows: hasMore ? rows.slice(0, limit) : rows, hasMore };
+    const filteredRows = filterExcludedTickers(rows, (row) => row.ticker);
+    const hasMore = filteredRows.length > limit;
+    return { rows: hasMore ? filteredRows.slice(0, limit) : filteredRows, hasMore };
   } catch {
     const all = fallbackCommunityReportsFromOutputs(opts.query, await deletedReportPredicate());
     const pageRows = all.slice(offset, offset + limit + 1);
@@ -545,7 +550,7 @@ export async function listDeletedReportRefs(): Promise<DeletedReportRef[]> {
       FROM reports
      WHERE deleted_at IS NOT NULL;
   `) as unknown as DeletedReportRef[];
-  return rows;
+  return filterExcludedTickers(rows, (row) => row.ticker);
 }
 
 export async function listDeletedReportRefsForTicker(ticker: string): Promise<DeletedReportRef[]> {
@@ -559,7 +564,7 @@ export async function listDeletedReportRefsForTicker(ticker: string): Promise<De
      WHERE deleted_at IS NOT NULL
        AND ticker = ${String(ticker || "").toUpperCase()};
   `) as unknown as DeletedReportRef[];
-  return rows;
+  return filterExcludedTickers(rows, (row) => row.ticker);
 }
 
 /**
@@ -580,7 +585,7 @@ export async function listDashboardsForDiscovery(): Promise<
      WHERE r.deleted_at IS NULL
      ORDER BY r.ticker, r.generated_at DESC;
   `) as unknown as { ticker: string; generated_at: string; dashboard: unknown }[];
-  return rows;
+  return filterExcludedTickers(rows, (row) => row.ticker);
 }
 
 /**
@@ -599,7 +604,7 @@ export async function listAllDashboardsForHitRate(): Promise<
      WHERE r.deleted_at IS NULL
      ORDER BY r.generated_at DESC;
   `) as unknown as { ticker: string; generated_at: string; dashboard: unknown; source_run_id: string | null }[];
-  return rows;
+  return filterExcludedTickers(rows, (row) => row.ticker);
 }
 
 export async function listDashboardsForTicker(ticker: string): Promise<
@@ -615,5 +620,5 @@ export async function listDashboardsForTicker(ticker: string): Promise<
        AND r.ticker = ${String(ticker || "").toUpperCase()}
      ORDER BY r.generated_at DESC;
   `) as unknown as { ticker: string; generated_at: string; dashboard: unknown; source_run_id: string | null }[];
-  return rows;
+  return filterExcludedTickers(rows, (row) => row.ticker);
 }

--- a/frontend/src/lib/server-outputs.ts
+++ b/frontend/src/lib/server-outputs.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
 
+import { isExcludedTicker } from "@/lib/excluded-tickers";
+
 const MAX_SCAN_DEPTH = 4;
 
 export type FoundFile = {
@@ -111,7 +113,7 @@ export function listTickersFromOutputs(): string[] {
       continue;
     }
     const ticker = String(match[1] || "").toUpperCase().trim();
-    if (ticker) {
+    if (ticker && !isExcludedTicker(ticker)) {
       tickers.add(ticker);
     }
   }
@@ -168,7 +170,7 @@ export function listDashboardReports(): DashboardReportEntry[] {
     .map((item) => {
       const base = path.basename(item.path);
       const ticker = String(base.split("_")[0] || "").toUpperCase();
-      if (!ticker) {
+      if (!ticker || isExcludedTicker(ticker)) {
         return null;
       }
       const rel = path.relative(outputsRoot(), item.path).replace(/\\/g, "/");

--- a/frontend/src/lib/ticker-catalog.ts
+++ b/frontend/src/lib/ticker-catalog.ts
@@ -2,6 +2,8 @@
 
 import Fuse from "fuse.js";
 
+import { filterExcludedTickers, isExcludedTicker } from "@/lib/excluded-tickers";
+
 export type TickerEntry = {
   s: string; // symbol
   n: string; // name
@@ -20,6 +22,7 @@ export function loadTickerCatalog(): Promise<TickerEntry[]> {
       if (!res.ok) throw new Error(`tickers.json HTTP ${res.status}`);
       return res.json() as Promise<TickerEntry[]>;
     })
+    .then((rows) => filterExcludedTickers(rows, (row) => row.s))
     .catch((err) => {
       console.warn("[ticker-catalog] failed to load", err);
       catalogPromise = null;
@@ -57,6 +60,7 @@ export function searchCatalog(catalog: TickerEntry[], query: string, limit = 8):
   if (!q) return [];
   const qUp = q.toUpperCase();
   const qLow = q.toLowerCase();
+  if (isExcludedTicker(qUp)) return [];
 
   const out: TickerEntry[] = [];
   const seen = new Set<string>();
@@ -74,6 +78,7 @@ export function searchCatalog(catalog: TickerEntry[], query: string, limit = 8):
   for (const e of catalog) {
     if (out.length + exact.length + symbolPrefix.length + nameWordPrefix.length + symbolContains.length > limit * 6) break;
     const sym = e.s;
+    if (isExcludedTicker(sym)) continue;
     if (sym === qUp) {
       exact.push(e);
       continue;

--- a/frontend/src/lib/ticker-summary-aggregate.ts
+++ b/frontend/src/lib/ticker-summary-aggregate.ts
@@ -176,7 +176,7 @@ function compareMeanRows(a: SummaryMeanRow, b: SummaryMeanRow): number {
   return a.label.localeCompare(b.label);
 }
 
-function disagreementScoreForReport(payload: DashboardPayload): number | null {
+export function disagreementScoreForReport(payload: DashboardPayload): number | null {
   const scoreCard = payload.score_card || payload.decision_card;
   const scoreCv = toNumOrNull(scoreCard?.overall_cv);
   if (typeof scoreCv === "number" && Number.isFinite(scoreCv)) {

--- a/src/ai_hedge/legacy_port.py
+++ b/src/ai_hedge/legacy_port.py
@@ -6147,10 +6147,55 @@ def pdf_downloader(ticker):
 
   ul {{
       padding-left: 20px;
+      break-inside: avoid-page;
+      page-break-inside: avoid;
   }}
 
   li {{
       margin-bottom: 4px;
+      break-inside: avoid-page;
+      page-break-inside: avoid;
+  }}
+
+  h1, h2, h3 {{
+      break-after: avoid-page;
+      page-break-after: avoid;
+  }}
+
+  table {{
+      width: 100%;
+      border-collapse: collapse;
+      margin: 14px 0 20px;
+      font-size: 9.5pt;
+      break-inside: auto;
+      page-break-inside: auto;
+  }}
+
+  th, td {{
+      border: 1px solid #d0d7de;
+      padding: 6px 8px;
+      vertical-align: top;
+      overflow-wrap: anywhere;
+  }}
+
+  th {{
+      background: #f6f8fa;
+      font-weight: 700;
+      text-align: left;
+  }}
+
+  thead {{
+      display: table-header-group;
+  }}
+
+  tr {{
+      break-inside: avoid-page;
+      page-break-inside: avoid;
+  }}
+
+  pre, blockquote {{
+      break-inside: avoid-page;
+      page-break-inside: avoid;
   }}
   </style>
   </head>

--- a/src/ai_hedge/text_to_pdf_check.py
+++ b/src/ai_hedge/text_to_pdf_check.py
@@ -58,6 +58,35 @@ th {{
 td {{
     word-break: normal;
 }}
+
+h1, h2, h3 {{
+    break-after: avoid-page;
+    page-break-after: avoid;
+}}
+
+ul, ol {{
+    break-inside: avoid-page;
+    page-break-inside: avoid;
+}}
+
+table {{
+    break-inside: auto;
+    page-break-inside: auto;
+}}
+
+thead {{
+    display: table-header-group;
+}}
+
+tr {{
+    break-inside: avoid-page;
+    page-break-inside: avoid;
+}}
+
+pre, blockquote {{
+    break-inside: avoid-page;
+    page-break-inside: avoid;
+}}
 </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary

- Improves new PDF generation so financials headings/lists/tables avoid awkward page breaks and tables repeat headers cleanly across pages.
- Fixes dashboard consistency issues: Wall St range labels are staggered when targets overlap, Overview uses the same total disagreement value as Summary/Discovery, and Bull vs Bear has one copy-all button for bull, bear, questions, and KPIs.
- Removes HSBK.IL from live DB rows and adds a shared excluded-ticker guard across ticker lists, Discovery, reports, local outputs, catalog search, and Yahoo autocomplete fallback.

## Preview

URL: pending preview workflow

## Test plan

- [x] `python -m py_compile src\ai_hedge\legacy_port.py src\ai_hedge\text_to_pdf_check.py`
- [x] `cd frontend && npm run build`
- [x] `cd frontend && npx eslint src/app/(app)/dashboard/[ticker]/overview/overview-client.tsx src/app/(app)/dashboard/[ticker]/scenarios/scenarios-client.tsx src/app/(app)/dashboard/[ticker]/wall-st/wall-st-client.tsx src/app/api/discovery/route.ts src/app/api/ticker-search/route.ts src/app/api/tickers/route.ts src/lib/excluded-tickers.ts src/lib/reports-db.ts src/lib/server-outputs.ts src/lib/ticker-catalog.ts src/lib/ticker-summary-aggregate.ts`
- [x] Local HTTP: `/api/tickers` excludes `HSBK.IL`; `/api/ticker-search?q=HSBK.IL` returns no results; `/api/discovery` returns `HasHSBK=false` across result sections.
- [x] Local HTTP: `/dashboard/AAPL/scenarios` returns 200 and includes `Copy Bull vs Bear tab`; `/dashboard/AAPL/overview` returns 200 and includes `Disagreement Score`.

## Notes for reviewer

- Hard-deleted live DB rows for `HSBK.IL`: 4 reports and 1 ticker row removed, with 0 remaining after deletion.
- The in-app Browser surface was unavailable in this session, so UI verification used local build, targeted lint, and HTTP/HTML checks. A Wall St report with populated `wall_st` data was not present in local outputs, so the Wall St chart change is covered by TypeScript/build rather than a data-backed local visual route.
- `npm run build` passes with the pre-existing Turbopack warning about `next.config.ts` being traced through the Dream Team chat route.