### PR TITLE
Add yahooquery info and multiples integration

### DIFF
--- a/frontend/src/app/(app)/dashboard/[ticker]/info/info-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/info/info-client.tsx
@@ -1,0 +1,319 @@
+"use client";
+
+import { Activity, BadgeDollarSign, BarChart3, CalendarDays, Database, Landmark, LineChart, RefreshCw, ShieldCheck } from "lucide-react";
+
+import { ReportChipRow } from "@/components/dashboard-chrome";
+import type { ReportListItem } from "@/lib/dashboard-types";
+import type { YahooqueryInfo } from "@/lib/dashboard-server";
+
+type ReturnsMap = {
+  "1D"?: number | null;
+  "1W"?: number | null;
+  "1M"?: number | null;
+  "3M"?: number | null;
+  "6M"?: number | null;
+  "1Y"?: number | null;
+  "3Y"?: number | null;
+  "5Y"?: number | null;
+};
+
+type MetricCard = {
+  label: string;
+  value: unknown;
+  kind?: "currency" | "ratio" | "percent" | "plain";
+  note?: string;
+};
+
+const RETURN_COLUMNS = ["1D", "1W", "1M", "3M", "6M", "1Y", "3Y", "5Y"] as const;
+
+const MULTIPLE_MAP: Array<{ key: string; label: string; kind: "currency" | "ratio" }> = [
+  { key: "MarketCap", label: "Market Cap", kind: "currency" },
+  { key: "EnterpriseValue", label: "Enterprise Value", kind: "currency" },
+  { key: "PeRatio", label: "P/E", kind: "ratio" },
+  { key: "ForwardPeRatio", label: "Forward P/E", kind: "ratio" },
+  { key: "PegRatio", label: "PEG", kind: "ratio" },
+  { key: "PbRatio", label: "P/B", kind: "ratio" },
+  { key: "PsRatio", label: "P/S", kind: "ratio" },
+  { key: "EnterprisesValueRevenueRatio", label: "EV/Revenue", kind: "ratio" },
+  { key: "EnterprisesValueEBITDARatio", label: "EV/EBITDA", kind: "ratio" },
+];
+
+const FINANCIAL_CARD_MAP: MetricCard[] = [
+  { label: "Current Price", value: "currentPrice", kind: "currency" },
+  { label: "Target Mean", value: "targetMeanPrice", kind: "currency" },
+  { label: "Target Median", value: "targetMedianPrice", kind: "currency" },
+  { label: "Analysts", value: "numberOfAnalystOpinions", kind: "plain" },
+  { label: "Revenue Growth", value: "revenueGrowth", kind: "percent" },
+  { label: "Earnings Growth", value: "earningsGrowth", kind: "percent" },
+  { label: "Gross Margin", value: "grossMargins", kind: "percent" },
+  { label: "EBITDA Margin", value: "ebitdaMargins", kind: "percent" },
+  { label: "Operating Margin", value: "operatingMargins", kind: "percent" },
+  { label: "Profit Margin", value: "profitMargins", kind: "percent" },
+  { label: "ROA", value: "returnOnAssets", kind: "percent" },
+  { label: "ROE", value: "returnOnEquity", kind: "percent" },
+  { label: "Cash", value: "totalCash", kind: "currency" },
+  { label: "Debt", value: "totalDebt", kind: "currency" },
+  { label: "Current Ratio", value: "currentRatio", kind: "ratio" },
+  { label: "Debt / Equity", value: "debtToEquity", kind: "ratio" },
+];
+
+function num(value: unknown): number | null {
+  if (value === null || value === undefined || value === "") return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function pct(value: unknown): string {
+  const n = num(value);
+  if (n === null) return "N/A";
+  return `${n >= 0 ? "+" : ""}${n.toFixed(2)}%`;
+}
+
+function fmtValue(value: unknown, kind: MetricCard["kind"] = "plain", currency = "USD"): string {
+  const n = num(value);
+  if (n === null) {
+    const text = String(value ?? "").trim();
+    return text || "N/A";
+  }
+  if (kind === "percent") return `${(n * 100).toFixed(1)}%`;
+  if (kind === "ratio") return n.toFixed(Math.abs(n) >= 100 ? 1 : 2);
+  if (kind === "currency") {
+    if (Math.abs(n) >= 1_000_000_000_000) return `${currency} ${(n / 1_000_000_000_000).toFixed(2)}T`;
+    if (Math.abs(n) >= 1_000_000_000) return `${currency} ${(n / 1_000_000_000).toFixed(2)}B`;
+    if (Math.abs(n) >= 1_000_000) return `${currency} ${(n / 1_000_000).toFixed(2)}M`;
+    return `${currency} ${n.toLocaleString(undefined, { maximumFractionDigits: 2 })}`;
+  }
+  return n.toLocaleString(undefined, { maximumFractionDigits: 2 });
+}
+
+function toneClass(value: unknown): string {
+  const n = num(value);
+  if (n === null || Math.abs(n) <= 1e-9) return "text-[color:var(--text-primary)]";
+  return n > 0 ? "text-[color:var(--success)]" : "text-[color:var(--danger)]";
+}
+
+function dateLabel(value: unknown): string {
+  const raw = String(value || "").trim();
+  if (!raw) return "N/A";
+  return raw.slice(0, 10);
+}
+
+function rowsFromInfo(info: YahooqueryInfo): Array<Record<string, unknown>> {
+  const rows = info.valuation_measures?.rows;
+  return Array.isArray(rows) ? rows : [];
+}
+
+function latestMultiple(info: YahooqueryInfo): Record<string, unknown> {
+  return info.valuation_measures?.latest || {};
+}
+
+function financialData(info: YahooqueryInfo): Record<string, unknown> {
+  return info.financial_data || {};
+}
+
+function MetricTile({ card, currency }: { card: MetricCard; currency: string }) {
+  return (
+    <article className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-3">
+      <p className="text-[10px] uppercase tracking-[0.14em] text-[color:var(--text-muted)]">{card.label}</p>
+      <p className="mt-2 font-mono text-lg font-semibold text-[color:var(--text-primary)]">
+        {fmtValue(card.value, card.kind, currency)}
+      </p>
+      {card.note ? <p className="mt-2 text-xs leading-relaxed text-[color:var(--text-secondary)]">{card.note}</p> : null}
+    </article>
+  );
+}
+
+function PricePerformance({ rows }: { rows: ReturnsMap }) {
+  return (
+    <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
+      <h2 className="inline-flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.16em] text-[color:var(--text-secondary)]">
+        <LineChart size={15} />
+        Price Performance
+      </h2>
+      <div className="mt-3 grid grid-cols-2 gap-2 text-xs md:grid-cols-4 xl:grid-cols-8">
+        {RETURN_COLUMNS.map((key) => {
+          const value = rows?.[key];
+          return (
+            <div key={key} className="hib-perf-cell rounded-md bg-[color:var(--surface)] px-2 py-1.5">
+              <span className="block text-[10px] uppercase tracking-[0.12em] text-[color:var(--text-muted)]">{key}</span>
+              <span className={`mt-1 block text-sm font-semibold ${toneClass(value)}`}>
+                {typeof value === "number" && Number.isFinite(value) ? pct(value) : "N/A"}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+export type InfoClientProps = {
+  ticker: string;
+  info: YahooqueryInfo;
+  returnsPct: ReturnsMap;
+  liveCurrentPrice: number | null;
+  reportsForTicker: ReportListItem[];
+  resolvedReportId: string;
+};
+
+export function InfoClient({
+  ticker,
+  info,
+  returnsPct,
+  liveCurrentPrice,
+  reportsForTicker,
+  resolvedReportId,
+}: InfoClientProps) {
+  const rows = rowsFromInfo(info);
+  const latest = latestMultiple(info);
+  const finance = financialData(info);
+  const currency = String(finance.financialCurrency || (ticker.endsWith(".TA") ? "ILS" : "USD")).toUpperCase();
+  const recommendation = String(finance.recommendationKey || "none").replace(/_/g, " ");
+  const status = String(info.status || "").toLowerCase();
+  const multipleCards = MULTIPLE_MAP.map((item) => ({
+    label: item.label,
+    value: latest[item.key],
+    kind: item.kind,
+    note: item.key in (info.valuation_measures?.recent_average || {})
+      ? `Recent avg ${fmtValue(info.valuation_measures?.recent_average?.[item.key], item.kind, currency)}`
+      : undefined,
+  }));
+  const financeCards = FINANCIAL_CARD_MAP.map((item) => ({
+    label: item.label,
+    value: finance[String(item.value)],
+    kind: item.kind,
+  }));
+
+  return (
+    <div className="space-y-5">
+      <ReportChipRow ticker={ticker} reports={reportsForTicker} currentReportId={resolvedReportId} />
+
+      <header className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <h1 className="inline-flex items-center gap-2 font-display text-2xl text-[color:var(--text-primary)]">
+              <Database size={19} className="text-[color:var(--accent)]" />
+              Info
+            </h1>
+            <p className="text-xs uppercase tracking-[0.18em] text-[color:var(--text-muted)]">
+              {ticker} - live yahooquery profile, multiples, and market context
+            </p>
+          </div>
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+            <MetricTile card={{ label: "Live Price", value: liveCurrentPrice ?? finance.currentPrice, kind: "currency" }} currency={currency} />
+            <MetricTile card={{ label: "Currency", value: currency, kind: "plain" }} currency={currency} />
+            <MetricTile card={{ label: "Recommendation", value: recommendation, kind: "plain" }} currency={currency} />
+            <MetricTile card={{ label: "Data Rows", value: rows.length, kind: "plain" }} currency={currency} />
+          </div>
+        </div>
+        {status !== "success" ? (
+          <p className="mt-4 rounded-xl border border-[color:var(--warning)] bg-[color:var(--surface)] p-3 text-sm text-[color:var(--warning)]">
+            {info.error || "Yahooquery data is not available right now."}
+          </p>
+        ) : null}
+      </header>
+
+      <PricePerformance rows={returnsPct} />
+
+      <section className="grid gap-4 xl:grid-cols-[1.2fr_0.8fr]">
+        <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
+          <div className="mb-3 flex items-center justify-between gap-3">
+            <div>
+              <h2 className="inline-flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.16em] text-[color:var(--text-secondary)]">
+                <BadgeDollarSign size={15} />
+                Valuation Multiples
+              </h2>
+              <p className="mt-1 text-sm text-[color:var(--text-muted)]">
+                Latest preferred row: {dateLabel(latest.asOfDate)} / {String(latest.periodType || "N/A")}
+              </p>
+            </div>
+            <RefreshCw size={15} className="text-[color:var(--text-muted)]" />
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+            {multipleCards.map((card) => (
+              <MetricTile key={card.label} card={card} currency={currency} />
+            ))}
+          </div>
+        </div>
+
+        <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
+          <h2 className="inline-flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.16em] text-[color:var(--text-secondary)]">
+            <ShieldCheck size={15} />
+            Quality Snapshot
+          </h2>
+          <div className="mt-3 grid gap-3 sm:grid-cols-2">
+            {financeCards.slice(4, 12).map((card) => (
+              <MetricTile key={card.label} card={card} currency={currency} />
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
+        <h2 className="inline-flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.16em] text-[color:var(--text-secondary)]">
+          <Landmark size={15} />
+          Financial Data
+        </h2>
+        <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          {financeCards.map((card) => (
+            <MetricTile key={card.label} card={card} currency={currency} />
+          ))}
+        </div>
+      </section>
+
+      <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h2 className="inline-flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.16em] text-[color:var(--text-secondary)]">
+              <BarChart3 size={15} />
+              Multiple History
+            </h2>
+            <p className="mt-1 text-sm text-[color:var(--text-muted)]">Historical yahooquery valuation rows, newest first.</p>
+          </div>
+          <p className="inline-flex items-center gap-1 text-xs text-[color:var(--text-muted)]">
+            <CalendarDays size={13} />
+            {info.generated_at ? `Updated ${dateLabel(info.generated_at)}` : "Live fetch"}
+          </p>
+        </div>
+        <div className="overflow-auto rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)]">
+          <table className="w-full min-w-[980px] text-sm">
+            <thead className="border-b border-[color:var(--border-subtle)] text-[color:var(--text-muted)]">
+              <tr>
+                <th className="px-3 py-2 text-left font-medium">Date</th>
+                <th className="px-3 py-2 text-left font-medium">Period</th>
+                {MULTIPLE_MAP.slice(2).map((metric) => (
+                  <th key={metric.key} className="px-3 py-2 text-right font-medium">{metric.label}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.slice().reverse().slice(0, 14).map((row, idx) => (
+                <tr key={`${row.asOfDate}-${row.periodType}-${idx}`} className="border-b border-[color:var(--border-subtle)] last:border-b-0">
+                  <td className="px-3 py-2 font-mono text-[color:var(--text-primary)]">{dateLabel(row.asOfDate)}</td>
+                  <td className="px-3 py-2 text-[color:var(--text-secondary)]">{String(row.periodType || "N/A")}</td>
+                  {MULTIPLE_MAP.slice(2).map((metric) => (
+                    <td key={`${idx}-${metric.key}`} className="px-3 py-2 text-right font-mono text-[color:var(--text-primary)]">
+                      {fmtValue(row[metric.key], metric.kind, currency)}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+              {!rows.length ? (
+                <tr>
+                  <td colSpan={MULTIPLE_MAP.length} className="px-3 py-4 text-[color:var(--text-muted)]">
+                    No valuation-measure rows returned.
+                  </td>
+                </tr>
+              ) : null}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <p className="inline-flex items-center gap-1 text-xs text-[color:var(--text-muted)]">
+        <Activity size={13} />
+        This tab is deterministic live yahooquery data. No LLM is used here.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/app/(app)/dashboard/[ticker]/info/page.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/info/page.tsx
@@ -1,0 +1,42 @@
+import { DashboardError } from "@/components/dashboard-chrome";
+import { getLivePerformance, getLiveYahooqueryInfo, loadTickerData } from "@/lib/dashboard-server";
+
+import { InfoClient } from "./info-client";
+
+export default async function DashboardInfoPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ ticker: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const { ticker } = await params;
+  const search = (await searchParams) ?? {};
+  const reportId = typeof search.report === "string" ? search.report : undefined;
+
+  let resolved;
+  try {
+    resolved = await loadTickerData(ticker, reportId);
+  } catch (err) {
+    const upper = decodeURIComponent(String(ticker || "")).toUpperCase();
+    return <DashboardError error={(err as Error)?.message || "Failed to load dashboard"} ticker={upper} />;
+  }
+
+  const { ticker: upper, reportsForTicker, resolvedReportId } = resolved;
+  const [info, performance] = await Promise.all([
+    getLiveYahooqueryInfo(upper),
+    getLivePerformance(upper).catch(() => null),
+  ]);
+
+  return (
+    <InfoClient
+      ticker={upper}
+      info={info}
+      returnsPct={performance?.returns_pct || {}}
+      liveCurrentPrice={typeof performance?.current_price === "number" ? performance.current_price : null}
+      reportsForTicker={reportsForTicker}
+      resolvedReportId={resolvedReportId}
+    />
+  );
+}
+

--- a/frontend/src/components/shell/topbar.tsx
+++ b/frontend/src/components/shell/topbar.tsx
@@ -3,7 +3,7 @@
 import { Suspense, useEffect, useState } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
-import { BarChart3, Calculator, CandlestickChart, Download, FileQuestion, FileText, Landmark, Menu, Scale, Store, Users } from "lucide-react";
+import { BarChart3, Calculator, CandlestickChart, Database, Download, FileQuestion, FileText, Landmark, Menu, Scale, Store, Users } from "lucide-react";
 import type { ComponentType } from "react";
 
 import { AuthMenu } from "@/components/shell/auth-menu";
@@ -13,6 +13,7 @@ import type { ReportListItem } from "@/lib/dashboard-types";
 type SectionItem = { slug: string; label: string; icon: ComponentType<{ size?: number }> };
 
 const SECTIONS: SectionItem[] = [
+  { slug: "info", label: "Info", icon: Database },
   { slug: "overview", label: "Overview", icon: FileText },
   { slug: "valuation", label: "Valuation", icon: BarChart3 },
   { slug: "financials", label: "Financials", icon: Calculator },

--- a/frontend/src/lib/dashboard-server.ts
+++ b/frontend/src/lib/dashboard-server.ts
@@ -51,6 +51,21 @@ export type LiveFundamentals = {
   assumption_current_values?: Record<string, number | null>;
 };
 
+export type YahooqueryInfo = {
+  status?: "success" | "error" | "unavailable" | string;
+  ticker: string;
+  generated_at?: string;
+  error?: string;
+  valuation_measures?: {
+    rows?: Array<Record<string, unknown>>;
+    columns?: string[];
+    latest?: Record<string, unknown>;
+    latest_by_period?: Record<string, Record<string, unknown>>;
+    recent_average?: Record<string, number | null>;
+  };
+  financial_data?: Record<string, unknown>;
+};
+
 async function loadReportsList(): Promise<ReportListItem[]> {
   const merged = new Map<string, ReportListItem>();
   const deletedFilter = await getDeletedReportFilter();
@@ -378,6 +393,51 @@ function runLiveFundamentalsScript(ticker: string): Promise<LiveFundamentals> {
   });
 }
 
+function runLiveYahooqueryInfoScript(ticker: string): Promise<YahooqueryInfo> {
+  return new Promise((resolve, reject) => {
+    const root = repoRoot();
+    const scriptPath = path.resolve(root, "scripts", "live_yahooquery_info.py");
+    const pythonExe = process.env.PYTHON_EXECUTABLE || "python";
+
+    const child = spawn(pythonExe, [scriptPath, "--ticker", ticker], {
+      cwd: root,
+      env: {
+        ...process.env,
+        PYTHONUNBUFFERED: "1",
+        PYTHONPATH: path.resolve(root, "src"),
+      },
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on("error", (err) => {
+      reject(err);
+    });
+    child.on("close", (code) => {
+      try {
+        const parsed = JSON.parse(stdout) as YahooqueryInfo;
+        if (code !== 0 && !parsed?.status) {
+          reject(new Error(stderr.trim() || `live_yahooquery_info.py exited with ${code}`));
+          return;
+        }
+        resolve(parsed);
+      } catch (err) {
+        if (code !== 0) {
+          reject(new Error(stderr.trim() || `live_yahooquery_info.py exited with ${code}`));
+          return;
+        }
+        reject(err);
+      }
+    });
+  });
+}
+
 export const getLivePerformance = unstable_cache(
   async (ticker: string): Promise<LivePerformance> => {
     const tk = ticker.toUpperCase();
@@ -415,6 +475,27 @@ export const getLiveFundamentals = unstable_cache(
   },
   ["live-fundamentals-v1"],
   { revalidate: 300 },
+);
+
+export const getLiveYahooqueryInfo = unstable_cache(
+  async (ticker: string): Promise<YahooqueryInfo> => {
+    const tk = ticker.toUpperCase();
+    try {
+      const result = await runLiveYahooqueryInfoScript(tk);
+      return {
+        ...result,
+        ticker: String(result?.ticker || tk).toUpperCase(),
+      };
+    } catch (err) {
+      return {
+        status: "error",
+        ticker: tk,
+        error: (err as Error)?.message || "Failed to fetch yahooquery data.",
+      };
+    }
+  },
+  ["live-yahooquery-info-v1"],
+  { revalidate: 180 },
 );
 
 export async function getLiveCurrentPricesBatch(tickers: string[]): Promise<Record<string, number | null>> {

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ numpy>=1.25
 matplotlib>=3.8
 requests>=2.31
 yfinance>=0.2.40
+yahooquery>=2.4.1
 html2text>=2024.2.26
 Markdown>=3.6
 weasyprint>=62.0

--- a/scripts/live_yahooquery_info.py
+++ b/scripts/live_yahooquery_info.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Fetch live yahooquery valuation and financial data.")
+    parser.add_argument("--ticker", required=True)
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[1]
+    src = repo_root / "src"
+    if str(src) not in sys.path:
+        sys.path.insert(0, str(src))
+
+    from ai_hedge.yahooquery_data import fetch_yahooquery_snapshot
+
+    ticker = str(args.ticker or "").strip().upper()
+    payload = fetch_yahooquery_snapshot(ticker)
+    print(json.dumps(payload, ensure_ascii=False, allow_nan=False))
+    return 0 if payload.get("status") == "success" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/src/ai_hedge/dashboard.py
+++ b/src/ai_hedge/dashboard.py
@@ -1704,6 +1704,17 @@ def _table_payload_rows(value: Any, *, max_rows: Optional[int] = None) -> List[D
     return rows
 
 
+def _record_payload_rows(value: Any, *, max_rows: Optional[int] = None) -> List[Dict[str, Any]]:
+    if isinstance(value, dict) and isinstance(value.get("rows"), list):
+        rows = [row for row in value.get("rows", []) if isinstance(row, dict)]
+    elif isinstance(value, list):
+        rows = [row for row in value if isinstance(row, dict)]
+    else:
+        rows = []
+    rows = rows if max_rows is None else rows[:max_rows]
+    return [_json_safe(row) for row in rows]
+
+
 def _latest_recommendation_mix(recommendations: Any) -> Dict[str, Any]:
     rows = _table_payload_rows(recommendations)
     if not rows:
@@ -1810,6 +1821,10 @@ def build_wall_st_payload(
     down_upgrades = raw.get("down_upgrades", info_dict.get("down_upgrades") if isinstance(info_dict, dict) else None)
     earnings_estimate = raw.get("earnings_estimate", info_dict.get("earnings_estimate") if isinstance(info_dict, dict) else None)
     revenue_estimate = raw.get("revenue_estimate", info_dict.get("revenue_estimate") if isinstance(info_dict, dict) else None)
+    earnings_surprise = raw.get("earnings_surprise")
+    if earnings_surprise is None and isinstance(info_dict, dict):
+        yq = info_dict.get("yahooquery") if isinstance(info_dict.get("yahooquery"), dict) else {}
+        earnings_surprise = yq.get("earnings_surprise")
     rec_metrics = _latest_recommendation_mix(recommendations)
     errors_out = [str(e) for e in (errors or []) if str(e or "").strip()]
     table_count = sum(
@@ -1827,6 +1842,7 @@ def build_wall_st_payload(
             "down_upgrades": _json_safe(down_upgrades),
             "earnings_estimate": _json_safe(earnings_estimate),
             "revenue_estimate": _json_safe(revenue_estimate),
+            "earnings_surprise": _json_safe(earnings_surprise),
             "num_of_analysts": int(_safe_float(raw.get("num_of_analysts", info_dict.get("num_of_analysts", 0) if isinstance(info_dict, dict) else 0)) or 0),
             "currency": currency_context,
         },
@@ -1836,6 +1852,7 @@ def build_wall_st_payload(
             "recent_actions": _table_payload_rows(down_upgrades, max_rows=80),
             "earnings_rows": _table_payload_rows(earnings_estimate),
             "revenue_rows": _table_payload_rows(revenue_estimate),
+            "earnings_surprise_rows": _record_payload_rows(earnings_surprise),
         },
         "synthesis": synthesis if isinstance(synthesis, dict) else {"status": "unavailable", "bullets": []},
         "errors": errors_out,
@@ -1858,6 +1875,7 @@ def generate_wall_st_synthesis(*, ticker: str, wall_st_payload: Dict[str, Any]) 
         "recent_actions": ((wall_st_payload.get("metrics") or {}).get("recent_actions") or [])[:20],
         "earnings_rows": ((wall_st_payload.get("metrics") or {}).get("earnings_rows") or []),
         "revenue_rows": ((wall_st_payload.get("metrics") or {}).get("revenue_rows") or []),
+        "earnings_surprise_rows": ((wall_st_payload.get("metrics") or {}).get("earnings_surprise_rows") or [])[:8],
     }
     prompt = f"""
 You are writing a dashboard-only Wall Street analyst read for {ticker}.
@@ -1878,6 +1896,7 @@ Focus on:
 - whether conviction is strong, split, or hold-heavy
 - whether analyst actions/revisions look improving or deteriorating
 - what revenue and EPS estimates imply
+- whether recent actual-vs-estimate earnings history makes the estimates look reliable, conservative, or risky
 - any contradiction, such as bullish ratings with weak growth or target cuts
 
 Return JSON only:

--- a/src/ai_hedge/financials_agent.py
+++ b/src/ai_hedge/financials_agent.py
@@ -47,6 +47,11 @@ MARKET_SNAPSHOT_METRICS = [
     "Enterprise Value (EV)",
     "Price-to-Book Ratio (P/B)",
     "Price-to-Earnings Ratio (P/E)",
+    "Forward Price-to-Earnings Ratio (Forward P/E)",
+    "Price-to-Sales Ratio (P/S)",
+    "Enterprise Value-to-Revenue Ratio (EV/Revenue)",
+    "Enterprise Value-to-EBITDA Ratio (EV/EBITDA)",
+    "PEG Ratio",
 ]
 
 
@@ -150,11 +155,15 @@ def build_raw_financials_payload(ticker: str, info_dict: Dict[str, Any]) -> Dict
         "total_debt": info.get("totalDebt"),
         "total_cash": info.get("totalCash"),
     }
+    yahooquery = info_dict.get("yahooquery") if isinstance(info_dict, dict) else {}
+    if not isinstance(yahooquery, dict):
+        yahooquery = {}
     return {
         "ticker": str(ticker).upper(),
         "created_at": datetime.now(timezone.utc).isoformat(),
         "currency": str(financial_currency or "USD").upper(),
         "info": _json_safe(raw_info),
+        "yahooquery": _json_safe(yahooquery),
         "statements": [
             _table_payload(ticker_obj.financials, "Annual Income Statement", "income_statement", "annual"),
             _table_payload(ticker_obj.quarterly_financials, "Quarterly Income Statement", "income_statement", "quarterly"),
@@ -192,7 +201,7 @@ Use Deep Reasoning:
 Mandatory rows, in this exact order:
 {required}
 
-Current market snapshot fields, outside the period table:
+Current market snapshot fields, outside the period table. Use the yahooquery valuation_measures and financial_data payload as the preferred source for these current multiple boxes, especially P/S, EV/Revenue, EV/EBITDA, PEG, and Forward P/E. If multiple period rows exist, prefer the latest TTM row; if TTM is missing, use the latest available row and state that in the note. The recent_average object may be used as context in the note, not as a replacement for the current latest value unless the latest value is missing:
 {snapshot}
 
 Optional rows:
@@ -215,7 +224,7 @@ Balance sheet and market-value logic:
 - Capital Expenditures (Capex) should come from the cash flow statement when available. Use the absolute cash outflow amount as a positive currency value even if the statement reports capex as negative.
 - Capex / Revenue = Capital Expenditures (Capex) / Revenue when both are available. It is a ratio decimal, not a percent string.
 - SBC / Revenue = Stock-Based Compensation / Revenue when both are available. If SBC is not disclosed separately, use null.
-- Market Capitalization, Enterprise Value (EV), Price-to-Book Ratio (P/B), and Price-to-Earnings Ratio (P/E) are current quote snapshot fields, not period-table rows. Put them in current_metrics only when available from quote info or defensible from quote info plus latest statements. Do not invent historical values for them.
+- Market Capitalization, Enterprise Value (EV), Price-to-Book Ratio (P/B), Price-to-Earnings Ratio (P/E), Forward P/E, Price-to-Sales, EV/Revenue, EV/EBITDA, and PEG are current quote/multiple snapshot fields, not period-table rows. Put them in current_metrics only when available from quote info, yahooquery valuation_measures, yahooquery financial_data, or defensible from quote info plus latest statements. Do not invent historical values for them.
 
 Return ONLY valid JSON with this exact shape:
 {{

--- a/src/ai_hedge/legacy_port.py
+++ b/src/ai_hedge/legacy_port.py
@@ -606,6 +606,8 @@ def get_info_data(ticker: str) -> dict:
     except:
         info_dict["num_of_analysts"] = 0
 
+    info_dict["yahooquery"] = _fetch_yahooquery_snapshot_safe(ticker)
+
     try:
         info_dict["wall_st_raw"] = {
             "targets": raw_price_targets,
@@ -613,6 +615,7 @@ def get_info_data(ticker: str) -> dict:
             "down_upgrades": deepcopy(info_dict.get("down_upgrades")),
             "earnings_estimate": deepcopy(info_dict.get("earnings_estimate")),
             "revenue_estimate": deepcopy(info_dict.get("revenue_estimate")),
+            "earnings_surprise": deepcopy((info_dict.get("yahooquery") or {}).get("earnings_surprise")),
             "num_of_analysts": info_dict.get("num_of_analysts", 0),
             "currency": {
                 "original_price_currency": price_curr_name,
@@ -628,11 +631,10 @@ def get_info_data(ticker: str) -> dict:
             "down_upgrades": info_dict.get("down_upgrades"),
             "earnings_estimate": info_dict.get("earnings_estimate"),
             "revenue_estimate": info_dict.get("revenue_estimate"),
+            "earnings_surprise": (info_dict.get("yahooquery") or {}).get("earnings_surprise"),
             "num_of_analysts": info_dict.get("num_of_analysts", 0),
             "currency": {},
         }
-
-    info_dict["yahooquery"] = _fetch_yahooquery_snapshot_safe(ticker)
 
     # --- News ---
     try:
@@ -1628,6 +1630,10 @@ def news_insights_result(info_dict) -> Tuple[str, str]:
     """
 
     header = "News Review"
+    yq = info_dict.get("yahooquery") if isinstance(info_dict, dict) else {}
+    corporate_events = {}
+    if isinstance(yq, dict):
+        corporate_events = yq.get("corporate_events") if isinstance(yq.get("corporate_events"), dict) else {}
 
     prompt = f"""
 You are a senior investment analyst specializing in interpreting news flow for public companies.
@@ -1635,6 +1641,7 @@ You are a senior investment analyst specializing in interpreting news flow for p
 Inputs:
 - company_short_name: the company's short name
 - news: a collection of all recent news items related to the company
+- corporate_events: optional yahooquery corporate events, filtered to events from the 3 months before the report date plus any future events
 
 Objective:
 Produce a holistic, analyst-grade summary of everything the news collectively says about the company,
@@ -1642,9 +1649,12 @@ its trajectory, risks, and market perception.
 
 Guiding principles:
 - Treat the news as a dataset, not as individual headlines.
+- Treat corporate_events as higher-confidence event metadata when present, but do not over-weight generic or stale-looking records.
+- If corporate_events is empty, analyze the news normally and do not mention absent events.
 - Synthesize patterns, repetition, and emphasis across items.
 - Identify what the news collectively implies about strategy, fundamentals, and expectations.
 - Distinguish between structural developments and short-term noise.
+- Separate confirmed corporate events from softer news sentiment when both are present.
 - Read between the lines like a professional investor.
 
 What to extract:
@@ -1669,7 +1679,10 @@ Company: {info_dict["short_name"]}
 News dataset:
 {info_dict["news"]}
 
-Now summarize what the news says about this company as an investment.
+Filtered corporate events:
+{json.dumps(corporate_events, ensure_ascii=False)[:40000]}
+
+Now summarize what the news and any filtered corporate events say about this company as an investment.
 """.strip()
 
     try:
@@ -1971,6 +1984,11 @@ def analyst_expectations_insights_result(info_dict) -> Tuple[str, str]:
     """
 
     header = "Analyst Expectations Insights"
+    yq = info_dict.get("yahooquery") if isinstance(info_dict, dict) else {}
+    earnings_surprise = {}
+    if isinstance(yq, dict):
+        earnings_surprise = yq.get("earnings_surprise") if isinstance(yq.get("earnings_surprise"), dict) else {}
+    has_earnings_surprise = bool((earnings_surprise or {}).get("rows"))
 
     financial_currency = info_dict["info"]["original_financial_currency"]
     if financial_currency != 'USD':
@@ -1978,7 +1996,7 @@ def analyst_expectations_insights_result(info_dict) -> Tuple[str, str]:
     else:
         curr_statement = ""
 
-    if info_dict.get("num_of_analysts", 0) <= 0:
+    if info_dict.get("num_of_analysts", 0) <= 0 and not has_earnings_surprise:
         return header, "No analysts found"
 
     prompt = f"""
@@ -1991,24 +2009,28 @@ You are given several short JSON datasets about analysts' views on a company:
 - down_upgrades
 - earnings_estimate
 - revenue_estimate
+- earnings_surprise: optional yahooquery actual-vs-estimate earnings history
 
 Your objective:
 Synthesize what these datasets collectively imply about analysts' beliefs, expectations, conviction,
-and the risks they are (and are not) underwriting.
+estimate reliability, and the risks they are (and are not) underwriting.
 
 How to think:
 - Analysts' price targets and ratings reflect narratives and incentives, not just math.
 - The important signal is dispersion, direction of change, and consistency across datasets.
 - Look for gaps between rating optimism and forecast realism.
 - Focus on what has changed recently and what that reveals about belief updates.
+- Use earnings_surprise to judge whether consensus has historically been too optimistic, too conservative, or noisy.
+- Do not treat an earnings beat/miss pattern as a mechanical valuation input; use it as evidence about expectation risk.
 
 What to extract (insights must be grounded in the provided JSONs):
 1) Consensus belief and narrative
 2) Conviction and disagreement
 3) Expectation drift
 4) Embedded financial assumptions
-5) Asymmetry and risk posture
-6) What the data suggests analysts may be missing
+5) Estimate reliability from actual-vs-estimate history
+6) Asymmetry and risk posture
+7) What the data suggests analysts may be missing
 
 Output rules:
 - 5 to 12 bullet points only
@@ -2035,9 +2057,12 @@ Earnings estimate:
 Revenue estimate:
 {info_dict["revenue_estimate"]}
 
+Earnings surprise history:
+{json.dumps(earnings_surprise, ensure_ascii=False)[:40000]}
+
 {curr_statement}
 
-Now extract the key insights about what analysts collectively believe about this company and its stock.
+Now extract the key insights about what analysts collectively believe, how reliable those expectations have been, and what this means for valuators using the estimates.
 """.strip()
 
     try:
@@ -2097,6 +2122,15 @@ def holders_insights_result(info_dict, ticker) -> Tuple[str, str]:
             holders_dict[k] = info_dict[k]
             list_of_legit_keys.append(k)
 
+    yq = info_dict.get("yahooquery") if isinstance(info_dict, dict) else {}
+    share_purchase_activity = {}
+    if isinstance(yq, dict):
+        raw_activity = yq.get("share_purchase_activity")
+        if isinstance(raw_activity, dict) and raw_activity:
+            share_purchase_activity = raw_activity
+            holders_dict["share_purchase_activity"] = raw_activity
+            list_of_legit_keys.append("share_purchase_activity")
+
     if not holders_dict:
         return header, "No holders data available"
 
@@ -2132,6 +2166,7 @@ Your objectives:
 
 3) Insider Trading Analysis
 - Analyze patterns of insider buying and selling
+- Use share_purchase_activity, when present, to assess net buy/sell behavior and whether it confirms or contradicts raw insider tables
 - Separate routine transactions from signal-rich behavior
 - Focus on senior executives and repeated patterns
 

--- a/src/ai_hedge/legacy_port.py
+++ b/src/ai_hedge/legacy_port.py
@@ -497,6 +497,20 @@ import pandas as pd
 import warnings
 warnings.filterwarnings('ignore')
 
+
+def _fetch_yahooquery_snapshot_safe(ticker: str) -> Dict[str, Any]:
+    try:
+        from .yahooquery_data import fetch_yahooquery_snapshot
+
+        return fetch_yahooquery_snapshot(ticker)
+    except Exception as exc:
+        return {
+            "status": "error",
+            "ticker": str(ticker or "").upper(),
+            "error": f"{type(exc).__name__}: {str(exc)[:240]}",
+        }
+
+
 def get_info_data(ticker: str) -> dict:
     info_dict = {}
     ticker_obj = yf.Ticker(ticker)
@@ -617,6 +631,8 @@ def get_info_data(ticker: str) -> dict:
             "num_of_analysts": info_dict.get("num_of_analysts", 0),
             "currency": {},
         }
+
+    info_dict["yahooquery"] = _fetch_yahooquery_snapshot_safe(ticker)
 
     # --- News ---
     try:
@@ -1881,6 +1897,65 @@ def financials_all_insights_result(financial_dict, info_dict) -> Tuple[str, str]
 
 from typing import Tuple
 
+
+def multiple_insights_result(info_dict) -> Tuple[str, str]:
+    """
+    Generate a valuation-multiple context section from yahooquery valuation data.
+
+    This function is thread-safe and suitable for parallel execution.
+    """
+
+    header = "Multiple Analysis"
+    yq = info_dict.get("yahooquery") if isinstance(info_dict, dict) else {}
+    if not isinstance(yq, dict) or yq.get("status") != "success":
+        error = yq.get("error") if isinstance(yq, dict) else "No yahooquery payload found."
+        return header, f"Yahooquery valuation measures are not available. {error or ''}".strip()
+
+    prompt = f"""
+You are a senior equity analyst writing the valuation-multiple context chapter for a company analysis.
+
+You are given:
+1) yahooquery valuation_measures, including historical rows of market cap, enterprise value, P/E, forward P/E, PEG, P/B, P/S, EV/Revenue, and EV/EBITDA.
+2) yahooquery financial_data with current financial, margin, analyst, liquidity, and leverage fields.
+3) The existing info_dict["info"] company context from the product pipeline.
+
+Objective:
+Extract the important valuation information from the multiple data and explain what it says about how the market currently prices the company.
+
+Rules:
+- Use only the supplied data.
+- This is company context, not a buy/sell recommendation.
+- Highlight current valuation level, historical movement in multiples, growth expectations embedded in PEG/forward P/E, balance-sheet effects in EV multiples, and margin/ROE context from financial_data.
+- When data is missing or mixed by period, say so plainly.
+- For non-USD or .TA tickers, do not assume USD; use the currency fields as context.
+- Keep it concise and user-friendly.
+- Output 6 to 12 bullets only.
+- No tables.
+
+{ANALYSIS_CALIBRATION_RULES}
+
+yahooquery payload:
+{json.dumps(yq, ensure_ascii=False)[:90000]}
+
+info_dict["info"]:
+{json.dumps(info_dict.get("info", {}), ensure_ascii=False)[:60000]}
+
+Now write the valuation-multiple context chapter.
+""".strip()
+
+    try:
+        answer = deepseek_simple_text(
+            api_key=DEEPSEEK_API_KEY,
+            prompt=prompt,
+            model="deepseek-chat",
+            temperature=0.25,
+            short_answer=False,
+        )
+        return header, answer
+    except Exception as e:
+        return header + " (Error)", f"Failed to generate section: {type(e).__name__}: {str(e)[:300]}"
+
+
 def analyst_expectations_insights_result(info_dict) -> Tuple[str, str]:
     """
     Synthesize the market-implied "analyst belief system" from consensus datasets.
@@ -2977,6 +3052,7 @@ def make_analysis_file(
         (financials_annual_insights_result, (financial_dict, info_dict), {}),
         (financials_quarterly_insights_result, (financial_dict, info_dict), {}),
         (financials_all_insights_result, (financial_dict, info_dict), {}),
+        (multiple_insights_result, (info_dict,), {}),
         (analyst_expectations_insights_result, (info_dict,), {}),
         (holders_insights_result, (info_dict, ticker), {}),
         # (options_analyst_insights_result, (info_dict,), {}),

--- a/src/ai_hedge/yahooquery_data.py
+++ b/src/ai_hedge/yahooquery_data.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
 import numpy as np
@@ -65,6 +65,91 @@ def _df_records(df: Any) -> List[Dict[str, Any]]:
     return [_json_safe(row) for row in records if isinstance(row, dict)]
 
 
+def _dict_for_symbol(payload: Any, symbol: str) -> Dict[str, Any]:
+    if not isinstance(payload, dict):
+        return {}
+    candidate = payload.get(symbol) or payload
+    return _json_safe(candidate if isinstance(candidate, dict) else {})
+
+
+def _fetch_attr(obj: Any, name: str) -> Any:
+    try:
+        attr = getattr(obj, name)
+        return attr() if callable(attr) else attr
+    except Exception as exc:
+        return {"error": f"{type(exc).__name__}: {str(exc)[:240]}"}
+
+
+def _parse_date(value: Any) -> Optional[datetime]:
+    if value is None:
+        return None
+    if isinstance(value, pd.Timestamp):
+        if pd.isna(value):
+            return None
+        dt = value.to_pydatetime()
+    elif isinstance(value, datetime):
+        dt = value
+    else:
+        text = str(value).strip()
+        if not text or text.lower() in {"nan", "nat", "none"}:
+            return None
+        for fmt in ("%Y-%m-%d", "%Y-%m-%d %H:%M:%S", "%m/%d/%Y", "%d/%m/%Y"):
+            try:
+                dt = datetime.strptime(text[:19], fmt)
+                break
+            except ValueError:
+                dt = None
+        if dt is None:
+            try:
+                dt = datetime.fromisoformat(text.replace("Z", "+00:00"))
+            except Exception:
+                return None
+    if dt.tzinfo is not None:
+        dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
+    return dt
+
+
+def _first_event_date(row: Dict[str, Any]) -> Optional[datetime]:
+    date_keys = (
+        "eventDate",
+        "date",
+        "startDate",
+        "endDate",
+        "createdDate",
+        "updatedDate",
+        "pubDate",
+    )
+    for key in date_keys:
+        dt = _parse_date(row.get(key))
+        if dt is not None:
+            return dt
+    return None
+
+
+def _filter_corporate_events(
+    rows: List[Dict[str, Any]],
+    *,
+    report_date: datetime,
+    months_back: int = 3,
+) -> List[Dict[str, Any]]:
+    cutoff = report_date - timedelta(days=30 * months_back)
+    filtered: List[Dict[str, Any]] = []
+    for row in rows:
+        dt = _first_event_date(row)
+        if dt is None:
+            continue
+        if dt >= cutoff:
+            clean_row = dict(row)
+            clean_row.setdefault("event_date", dt.date().isoformat())
+            clean_row["timing"] = "future" if dt.date() > report_date.date() else "recent"
+            filtered.append(clean_row)
+    return sorted(
+        filtered,
+        key=lambda row: str(row.get("event_date") or row.get("date") or row.get("eventDate") or ""),
+        reverse=True,
+    )
+
+
 def _latest_records(records: List[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
     latest: Dict[str, Dict[str, Any]] = {}
     for row in records:
@@ -110,30 +195,39 @@ def fetch_yahooquery_snapshot(ticker: str) -> Dict[str, Any]:
             "error": f"yahooquery import failed: {type(exc).__name__}: {str(exc)[:240]}",
         }
 
+    report_date = datetime.now(timezone.utc)
     try:
         ticker_obj = Ticker(symbol)
-        valuation_measures = ticker_obj.valuation_measures
-        financial_data = ticker_obj.financial_data
     except Exception as exc:
         return {
             "status": "error",
             "ticker": symbol,
-            "error": f"yahooquery fetch failed: {type(exc).__name__}: {str(exc)[:240]}",
+            "error": f"yahooquery init failed: {type(exc).__name__}: {str(exc)[:240]}",
         }
 
+    valuation_measures = _fetch_attr(ticker_obj, "valuation_measures")
+    financial_data = _fetch_attr(ticker_obj, "financial_data")
+    earning_history = _fetch_attr(ticker_obj, "earning_history")
+    corporate_events = _fetch_attr(ticker_obj, "corporate_events")
+    share_purchase_activity = _fetch_attr(ticker_obj, "share_purchase_activity")
+
     valuation_rows = _df_records(valuation_measures)
-    if isinstance(financial_data, dict):
-        raw_financial_data = financial_data.get(symbol) or financial_data
-    else:
-        raw_financial_data = {}
-    financial_data_clean = _json_safe(raw_financial_data if isinstance(raw_financial_data, dict) else {})
+    financial_data_clean = _dict_for_symbol(financial_data, symbol)
+    earning_history_rows = _df_records(earning_history)
+    corporate_event_rows = _df_records(corporate_events)
+    recent_corporate_events = _filter_corporate_events(
+        corporate_event_rows,
+        report_date=report_date.replace(tzinfo=None),
+    )
+    share_purchase_clean = _dict_for_symbol(share_purchase_activity, symbol)
     latest_by_period = _latest_records(valuation_rows)
     latest = _latest_preferred(valuation_rows)
 
     return {
         "status": "success",
         "ticker": symbol,
-        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "generated_at": report_date.isoformat(),
+        "report_date": report_date.date().isoformat(),
         "valuation_measures": {
             "rows": valuation_rows,
             "columns": list(valuation_measures.columns) if isinstance(valuation_measures, pd.DataFrame) else [],
@@ -142,5 +236,21 @@ def fetch_yahooquery_snapshot(ticker: str) -> Dict[str, Any]:
             "recent_average": _average_recent(valuation_rows),
         },
         "financial_data": financial_data_clean,
+        "earnings_surprise": {
+            "rows": earning_history_rows,
+            "columns": list(earning_history.columns) if isinstance(earning_history, pd.DataFrame) else [],
+            "error": earning_history.get("error") if isinstance(earning_history, dict) else None,
+        },
+        "corporate_events": {
+            "rows": recent_corporate_events,
+            "all_rows_count": len(corporate_event_rows),
+            "filtered_rows_count": len(recent_corporate_events),
+            "filter": {
+                "report_date": report_date.date().isoformat(),
+                "past_months_included": 3,
+                "future_events_included": True,
+            },
+            "error": corporate_events.get("error") if isinstance(corporate_events, dict) else None,
+        },
+        "share_purchase_activity": share_purchase_clean,
     }
-

--- a/src/ai_hedge/yahooquery_data.py
+++ b/src/ai_hedge/yahooquery_data.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import math
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import pandas as pd
+
+
+VALUATION_MULTIPLE_KEYS = [
+    "MarketCap",
+    "EnterpriseValue",
+    "PeRatio",
+    "ForwardPeRatio",
+    "PegRatio",
+    "PbRatio",
+    "PsRatio",
+    "EnterprisesValueRevenueRatio",
+    "EnterprisesValueEBITDARatio",
+]
+
+
+def _safe_number(value: Any) -> Optional[float]:
+    try:
+        num = float(value)
+    except Exception:
+        return None
+    if math.isnan(num) or math.isinf(num):
+        return None
+    return num
+
+
+def _json_safe(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, (np.integer,)):
+        return int(value)
+    if isinstance(value, (np.floating,)):
+        num = float(value)
+        return num if math.isfinite(num) else None
+    if isinstance(value, (pd.Timestamp, datetime)):
+        return value.isoformat()
+    if isinstance(value, dict):
+        return {str(k): _json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(v) for v in value]
+    return str(value)
+
+
+def _df_records(df: Any) -> List[Dict[str, Any]]:
+    if df is None or not isinstance(df, pd.DataFrame) or df.empty:
+        return []
+    tmp = df.copy()
+    if isinstance(tmp.index, pd.MultiIndex):
+        tmp = tmp.reset_index()
+    else:
+        tmp = tmp.reset_index()
+    tmp = tmp.dropna(axis=0, how="all").dropna(axis=1, how="all")
+    records = tmp.to_dict(orient="records")
+    return [_json_safe(row) for row in records if isinstance(row, dict)]
+
+
+def _latest_records(records: List[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    latest: Dict[str, Dict[str, Any]] = {}
+    for row in records:
+        period_type = str(row.get("periodType") or "Unknown").upper()
+        date = str(row.get("asOfDate") or "")
+        current = latest.get(period_type)
+        if current is None or date >= str(current.get("asOfDate") or ""):
+            latest[period_type] = row
+    return latest
+
+
+def _latest_preferred(records: List[Dict[str, Any]]) -> Dict[str, Any]:
+    latest_by_period = _latest_records(records)
+    if latest_by_period.get("TTM"):
+        return latest_by_period["TTM"]
+    if latest_by_period:
+        return sorted(latest_by_period.values(), key=lambda r: str(r.get("asOfDate") or ""))[-1]
+    return {}
+
+
+def _average_recent(records: List[Dict[str, Any]], limit: int = 4) -> Dict[str, Optional[float]]:
+    ordered = sorted(records, key=lambda r: str(r.get("asOfDate") or ""))
+    recent = ordered[-limit:]
+    averages: Dict[str, Optional[float]] = {}
+    for key in VALUATION_MULTIPLE_KEYS:
+        nums = [_safe_number(row.get(key)) for row in recent]
+        nums = [n for n in nums if n is not None]
+        averages[key] = round(sum(nums) / len(nums), 6) if nums else None
+    return averages
+
+
+def fetch_yahooquery_snapshot(ticker: str) -> Dict[str, Any]:
+    symbol = str(ticker or "").strip().upper()
+    if not symbol:
+        return {"status": "error", "ticker": symbol, "error": "Missing ticker"}
+
+    try:
+        from yahooquery import Ticker
+    except Exception as exc:
+        return {
+            "status": "unavailable",
+            "ticker": symbol,
+            "error": f"yahooquery import failed: {type(exc).__name__}: {str(exc)[:240]}",
+        }
+
+    try:
+        ticker_obj = Ticker(symbol)
+        valuation_measures = ticker_obj.valuation_measures
+        financial_data = ticker_obj.financial_data
+    except Exception as exc:
+        return {
+            "status": "error",
+            "ticker": symbol,
+            "error": f"yahooquery fetch failed: {type(exc).__name__}: {str(exc)[:240]}",
+        }
+
+    valuation_rows = _df_records(valuation_measures)
+    if isinstance(financial_data, dict):
+        raw_financial_data = financial_data.get(symbol) or financial_data
+    else:
+        raw_financial_data = {}
+    financial_data_clean = _json_safe(raw_financial_data if isinstance(raw_financial_data, dict) else {})
+    latest_by_period = _latest_records(valuation_rows)
+    latest = _latest_preferred(valuation_rows)
+
+    return {
+        "status": "success",
+        "ticker": symbol,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "valuation_measures": {
+            "rows": valuation_rows,
+            "columns": list(valuation_measures.columns) if isinstance(valuation_measures, pd.DataFrame) else [],
+            "latest": latest,
+            "latest_by_period": latest_by_period,
+            "recent_average": _average_recent(valuation_rows),
+        },
+        "financial_data": financial_data_clean,
+    }
+


### PR DESCRIPTION
## Summary

- Add yahooquery as a dependency and normalize valuation_measures / financial_data into a shared JSON-safe payload.
- Add a new parallel DeepSeek chat Multiple Analysis chapter using yahooquery multiples plus info_dict[info].
- Feed yahooquery multiples into the Financials agent and add a live deterministic Info tab before Overview with price performance, valuation multiples, quality metrics, and historical multiple rows.
- Enrich existing analysis calls with yahooquery earnings surprise history, report-date-filtered corporate events, and share purchase activity.
- Feed earnings surprise rows into the Wall ST payload/synthesis so current estimates can be read alongside actual-vs-estimate history.

## Preview

URL: pending preview workflow for frontend changes

## Test plan

- [x] Sampled yahooquery valuation_measures + financial_data for AAPL, NVDA, MSFT, TSLA, and STRS.TA.
- [x] `python scripts\live_yahooquery_info.py --ticker STRS.TA`
- [x] `python scripts\live_yahooquery_info.py --ticker AAPL`
- [x] `python scripts\live_yahooquery_info.py --ticker NVDA`, `MSFT`, and `TSLA` via prompt-plumbing smoke test.
- [x] Confirmed Analyst Expectations prompts receive earnings surprise data for NVDA, MSFT, and TSLA.
- [x] Confirmed News Review prompts receive filtered corporate events for NVDA, MSFT, and TSLA.
- [x] Confirmed Holders Analysis prompts receive share_purchase_activity for NVDA, MSFT, and TSLA.
- [x] `python -m compileall src\ai_hedge\yahooquery_data.py src\ai_hedge\financials_agent.py src\ai_hedge\legacy_port.py scripts\live_yahooquery_info.py`
- [x] `python -m compileall src\ai_hedge\yahooquery_data.py src\ai_hedge\legacy_port.py src\ai_hedge\dashboard.py scripts\live_yahooquery_info.py`
- [x] `$env:PYTHONPATH='src'; python -m pytest tests\test_wall_st_payload.py`
- [x] `cd frontend; npm run build`
- [x] Local HTTP verification on existing dev server: `/dashboard/STRS.TA/info` renders Info, Valuation Multiples, Financial Data, Multiple History, and the deterministic/no-LLM note; null multiples render as `N/A`, not `0.00`.
- [x] Local HTTP verification: `/dashboard/AAPL/info` returns 200.

## Notes for reviewer

- The new Info tab is live yahooquery data only; it does not call an LLM.
- Corporate events are filtered relative to the report fetch date: last 3 months plus all future events.
- The in-app browser surface was unavailable in this Codex session, so local UI verification used the running Next dev server over HTTP plus production build.
- Build still reports the existing Next/Turbopack warning about `next.config.ts` NFT tracing via the dream-team chat route; this is pre-existing and unrelated to this PR.