### PR TITLE
[codex] Fix PDF price and info tab issues

### DIFF
--- a/frontend/src/app/(app)/dashboard/[ticker]/financials/financials-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/financials/financials-client.tsx
@@ -80,9 +80,52 @@ function qualityClass(value?: string): string {
 }
 
 function periodChip(period: FinancialPeriod): string {
-  const raw = String(period.label || period.date || period.key || "").trim();
-  const prefix = String(period.period_type || "").toLowerCase() === "annual" ? "FY" : "Q";
-  return `${prefix} ${raw}`.replace(/^FY FY\s+/i, "FY ").replace(/^Q Q/i, "Q");
+  const raw = String(period.label || period.key || "").trim();
+  const dateYear = String(period.date || "").match(/^(\d{4})-\d{2}-\d{2}/)?.[1] || "";
+  const dateMonth = Number(String(period.date || "").match(/^\d{4}-(\d{2})-\d{2}/)?.[1] || "");
+  if (String(period.period_type || "").toLowerCase() === "annual") {
+    const yearFromDate = dateYear ? Number(dateYear) - (dateMonth === 1 ? 1 : 0) : null;
+    const year = yearFromDate || Number(raw.match(/\b(20\d{2}|19\d{2})\b/)?.[1] || "");
+    return year ? `FY ${year}` : raw || "FY";
+  }
+  const quarter = raw.match(/\bQ\s*([1-4])\b/i)?.[1] || "";
+  const rawYear = raw.match(/\b(20\d{2}|19\d{2})\b/)?.[1] || "";
+  if (quarter && rawYear) return `Q${quarter} ${rawYear}`;
+  if (quarter && dateYear && quarter === "4" && Number.isFinite(dateMonth) && dateMonth <= 3) {
+    return `Q4 ${Number(dateYear) - 1}`;
+  }
+  if (quarter && dateYear) return `Q${quarter} ${dateYear}`;
+  if (quarter) return `Q${quarter}`;
+  return raw || String(period.date || period.key || "");
+}
+
+function normalizePeriodLabels(periods: FinancialPeriod[]): FinancialPeriod[] {
+  let prevQuarter: number | null = null;
+  let prevYear: number | null = null;
+  return periods.map((period) => {
+    if (String(period.period_type || "").toLowerCase() !== "quarterly") return period;
+    const raw = String(period.label || period.key || "").trim();
+    const quarter = Number(raw.match(/\bQ\s*([1-4])\b/i)?.[1] || "");
+    const dateYearRaw = String(period.date || "").match(/^(\d{4})-\d{2}-\d{2}/)?.[1] || "";
+    const dateYear = dateYearRaw ? Number(dateYearRaw) : null;
+    if (!Number.isFinite(quarter) || quarter < 1 || quarter > 4) {
+      prevQuarter = null;
+      prevYear = null;
+      return period;
+    }
+    let displayYear = dateYear;
+    if (prevQuarter !== null && prevYear !== null && quarter === prevQuarter + 1) {
+      displayYear = prevYear;
+    } else if (prevQuarter === 4 && prevYear !== null && quarter === 1) {
+      displayYear = dateYear || prevYear + 1;
+    }
+    prevQuarter = quarter;
+    prevYear = displayYear;
+    return {
+      ...period,
+      label: displayYear ? `Q${quarter} ${displayYear}` : `Q${quarter}`,
+    };
+  });
 }
 
 function isAnnualPeriod(period: FinancialPeriod): boolean {
@@ -223,7 +266,8 @@ export function FinancialsClient({
   const payload = data.financials || {};
   const status = String(payload.status || "").toLowerCase();
   const analysis = payload.analysis || {};
-  const periods = Array.isArray(analysis.periods) ? (analysis.periods as FinancialPeriod[]) : EMPTY_PERIODS;
+  const rawPeriods = Array.isArray(analysis.periods) ? (analysis.periods as FinancialPeriod[]) : EMPTY_PERIODS;
+  const periods = normalizePeriodLabels(rawPeriods);
   const rows = Array.isArray(analysis.rows) ? (analysis.rows as FinancialRow[]) : EMPTY_ROWS;
   const currentMetrics = Array.isArray(analysis.current_metrics) ? (analysis.current_metrics as CurrentMetric[]) : EMPTY_CURRENT_METRICS;
   const takeaways = asList(analysis.key_takeaways);

--- a/frontend/src/app/(app)/dashboard/[ticker]/info/info-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/info/info-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Activity, BadgeDollarSign, BarChart3, CalendarDays, Database, Landmark, LineChart, RefreshCw, ShieldCheck } from "lucide-react";
+import { Activity, BadgeDollarSign, CalendarDays, Gauge, History, Info, RefreshCw, ShieldCheck, TrendingUp } from "lucide-react";
 
 import { ReportChipRow } from "@/components/dashboard-chrome";
 import type { ReportListItem } from "@/lib/dashboard-types";
@@ -92,6 +92,16 @@ function toneClass(value: unknown): string {
   return n > 0 ? "text-[color:var(--success)]" : "text-[color:var(--danger)]";
 }
 
+function metricToneClass(card: MetricCard): string {
+  const n = num(card.value);
+  if (n === null || Math.abs(n) <= 1e-9) return "text-[color:var(--text-primary)]";
+  const label = card.label.toLowerCase();
+  const isGrowthOrReturn = label.includes("growth") || label === "roa" || label === "roe" || label.includes("return");
+  if (isGrowthOrReturn) return n > 0 ? "text-[color:var(--success)]" : "text-[color:var(--danger)]";
+  if (label.includes("margin")) return n < 0 ? "text-[color:var(--danger)]" : "text-[color:var(--text-primary)]";
+  return "text-[color:var(--text-primary)]";
+}
+
 function dateLabel(value: unknown): string {
   const raw = String(value || "").trim();
   if (!raw) return "N/A";
@@ -115,7 +125,7 @@ function MetricTile({ card, currency }: { card: MetricCard; currency: string }) 
   return (
     <article className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-3">
       <p className="text-[10px] uppercase tracking-[0.14em] text-[color:var(--text-muted)]">{card.label}</p>
-      <p className="mt-2 font-mono text-lg font-semibold text-[color:var(--text-primary)]">
+      <p className={`mt-2 font-mono text-lg font-semibold ${metricToneClass(card)}`}>
         {fmtValue(card.value, card.kind, currency)}
       </p>
       {card.note ? <p className="mt-2 text-xs leading-relaxed text-[color:var(--text-secondary)]">{card.note}</p> : null}
@@ -127,7 +137,7 @@ function PricePerformance({ rows }: { rows: ReturnsMap }) {
   return (
     <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
       <h2 className="inline-flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.16em] text-[color:var(--text-secondary)]">
-        <LineChart size={15} />
+        <TrendingUp size={15} />
         Price Performance
       </h2>
       <div className="mt-3 grid grid-cols-2 gap-2 text-xs md:grid-cols-4 xl:grid-cols-8">
@@ -192,8 +202,8 @@ export function InfoClient({
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div>
             <h1 className="inline-flex items-center gap-2 font-display text-2xl text-[color:var(--text-primary)]">
-              <Database size={19} className="text-[color:var(--accent)]" />
-              Info
+              <Info size={19} className="text-[color:var(--accent)]" />
+              Information
             </h1>
             <p className="text-xs uppercase tracking-[0.18em] text-[color:var(--text-muted)]">
               {ticker} - live yahooquery profile, multiples, and market context
@@ -238,7 +248,7 @@ export function InfoClient({
 
         <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
           <h2 className="inline-flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.16em] text-[color:var(--text-secondary)]">
-            <ShieldCheck size={15} />
+            <Gauge size={15} />
             Quality Snapshot
           </h2>
           <div className="mt-3 grid gap-3 sm:grid-cols-2">
@@ -251,7 +261,7 @@ export function InfoClient({
 
       <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
         <h2 className="inline-flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.16em] text-[color:var(--text-secondary)]">
-          <Landmark size={15} />
+          <ShieldCheck size={15} />
           Financial Data
         </h2>
         <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
@@ -265,7 +275,7 @@ export function InfoClient({
         <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
           <div>
             <h2 className="inline-flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.16em] text-[color:var(--text-secondary)]">
-              <BarChart3 size={15} />
+              <History size={15} />
               Multiple History
             </h2>
             <p className="mt-1 text-sm text-[color:var(--text-muted)]">Historical yahooquery valuation rows, newest first.</p>

--- a/frontend/src/components/shell/topbar.tsx
+++ b/frontend/src/components/shell/topbar.tsx
@@ -3,7 +3,7 @@
 import { Suspense, useEffect, useState } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
-import { BarChart3, Calculator, CandlestickChart, Database, Download, FileQuestion, FileText, Landmark, Menu, Scale, Store, Users } from "lucide-react";
+import { BarChart3, Calculator, CandlestickChart, Download, FileQuestion, FileText, Info, Landmark, Menu, Scale, Store, Users } from "lucide-react";
 import type { ComponentType } from "react";
 
 import { AuthMenu } from "@/components/shell/auth-menu";
@@ -13,7 +13,7 @@ import type { ReportListItem } from "@/lib/dashboard-types";
 type SectionItem = { slug: string; label: string; icon: ComponentType<{ size?: number }> };
 
 const SECTIONS: SectionItem[] = [
-  { slug: "info", label: "Info", icon: Database },
+  { slug: "info", label: "Info", icon: Info },
   { slug: "overview", label: "Overview", icon: FileText },
   { slug: "valuation", label: "Valuation", icon: BarChart3 },
   { slug: "financials", label: "Financials", icon: Calculator },

--- a/src/ai_hedge/financials_agent.py
+++ b/src/ai_hedge/financials_agent.py
@@ -326,6 +326,100 @@ def _snapshot_value_from_rows(rows: List[Any], metric: str) -> Optional[float]:
     return None
 
 
+def _date_year(date: str) -> str:
+    match = re.match(r"^\s*(\d{4})-\d{2}-\d{2}", str(date or ""))
+    return match.group(1) if match else ""
+
+
+def _date_month(date: str) -> Optional[int]:
+    match = re.match(r"^\s*\d{4}-(\d{2})-\d{2}", str(date or ""))
+    if not match:
+        return None
+    try:
+        return int(match.group(1))
+    except Exception:
+        return None
+
+
+def _normalize_period_label(label: Any, *, date: str, period_type: str, key: str) -> str:
+    date_year = _date_year(date)
+    raw = str(label or "").strip()
+    source = raw or str(key or "").strip()
+    if str(period_type or "").lower() == "annual":
+        year_match = re.search(r"\b(20\d{2}|19\d{2})\b", source or "")
+        year = int(date_year) if date_year else None
+        if year is not None and _date_month(date) == 1:
+            year -= 1
+        if year is None and year_match:
+            year = int(year_match.group(1))
+        return f"FY {year}".strip() if year else (raw or key)
+
+    q_match = re.search(r"\bQ\s*([1-4])\b", source, flags=re.IGNORECASE)
+    quarter = q_match.group(1) if q_match else ""
+    if not quarter and date:
+        try:
+            month = int(str(date)[5:7])
+            quarter = str(((month - 1) // 3) + 1)
+        except Exception:
+            quarter = ""
+    if quarter and date_year:
+        return f"Q{quarter} {date_year}"
+    if quarter:
+        return f"Q{quarter}"
+    return raw or key
+
+
+def _quarter_from_label_or_date(label: Any, date: str) -> str:
+    match = re.search(r"\bQ\s*([1-4])\b", str(label or ""), flags=re.IGNORECASE)
+    if match:
+        return match.group(1)
+    if date:
+        try:
+            month = int(str(date)[5:7])
+            return str(((month - 1) // 3) + 1)
+        except Exception:
+            return ""
+    return ""
+
+
+def _normalize_quarter_period_labels(periods: List[Dict[str, Any]]) -> None:
+    prev_quarter: Optional[int] = None
+    prev_year: Optional[int] = None
+    for period in periods:
+        if period.get("period_type") != "quarterly":
+            continue
+        quarter_txt = _quarter_from_label_or_date(period.get("label"), str(period.get("date") or ""))
+        try:
+            quarter = int(quarter_txt)
+        except Exception:
+            prev_quarter = None
+            prev_year = None
+            continue
+        date_year_txt = _date_year(str(period.get("date") or ""))
+        date_year = int(date_year_txt) if date_year_txt else None
+        if (
+            prev_quarter is not None
+            and prev_year is not None
+            and quarter == prev_quarter + 1
+        ):
+            display_year = prev_year
+        elif (
+            prev_quarter == 4
+            and prev_year is not None
+            and quarter == 1
+        ):
+            display_year = date_year or (prev_year + 1)
+        else:
+            display_year = date_year
+        if display_year is not None:
+            period["label"] = f"Q{quarter} {display_year}"
+            prev_year = display_year
+        else:
+            period["label"] = f"Q{quarter}"
+            prev_year = None
+        prev_quarter = quarter
+
+
 def normalize_financials_analysis(raw: Dict[str, Any], *, ticker: str, currency: str) -> Dict[str, Any]:
     analysis = dict(raw) if isinstance(raw, dict) else {}
     periods = []
@@ -341,13 +435,20 @@ def normalize_financials_analysis(raw: Dict[str, Any], *, ticker: str, currency:
         if not key or key in seen:
             continue
         seen.add(key)
+        normalized_type = "annual" if period_type == "annual" else "quarterly"
         periods.append({
             "key": key,
-            "label": str(period.get("label") or key).strip(),
+            "label": _normalize_period_label(
+                period.get("label"),
+                date=date,
+                period_type=normalized_type,
+                key=key,
+            ),
             "date": date,
-            "period_type": "annual" if period_type == "annual" else "quarterly",
+            "period_type": normalized_type,
         })
     periods.sort(key=lambda p: (p.get("date") or "", 0 if p.get("period_type") == "quarterly" else 1))
+    _normalize_quarter_period_labels(periods)
 
     period_keys = {p["key"] for p in periods}
     rows = []

--- a/src/ai_hedge/runner.py
+++ b/src/ai_hedge/runner.py
@@ -1,6 +1,7 @@
 ﻿from __future__ import annotations
 
 import os
+import re
 import shutil
 import sys
 import json
@@ -223,6 +224,15 @@ def _build_sec_currency_clarification(info_dict: Optional[Dict[str, Any]]) -> st
     )
 
 
+def _build_sec_source_of_truth_guidance() -> str:
+    return (
+        "### SEC/MAYA Source-of-Truth Guidance for Valuation\n\n"
+        "If the earlier analysis sections and the SEC/MAYA filing summary disagree on a factual financial point, "
+        "treat the SEC/MAYA filing summary as the source of truth for that contradiction. "
+        "Use the broader analysis as context, but anchor valuation assumptions to the filing-backed evidence."
+    )
+
+
 def _filing_source_label(form_type: str, raw: Dict[str, Any]) -> str:
     explicit = str(raw.get("source", "") or "").strip().upper()
     if explicit in {"SEC", "MAYA"}:
@@ -413,6 +423,40 @@ def _fmt_money(value: Any) -> str:
         return f"${float(value):,.2f}"
     except Exception:
         return "N/A"
+
+
+def _extract_analysis_current_price(analysis_text: str) -> Optional[float]:
+    for line in str(analysis_text or "").splitlines()[:40]:
+        if not line.strip().lower().startswith("current price"):
+            continue
+        _, _, raw_value = line.partition(":")
+        match = re.search(r"[-+]?\d[\d,]*(?:\.\d+)?", raw_value)
+        if not match:
+            continue
+        value = _first_float(match.group(0).replace(",", ""))
+        if value is not None and value > 0:
+            return value
+    return None
+
+
+def _resolve_prices_explain_current_price(
+    explain_payload: Dict[str, Any],
+    *,
+    analysis_text: str = "",
+    variables_dict: Optional[Dict[str, Any]] = None,
+) -> Any:
+    analysis_price = _extract_analysis_current_price(analysis_text)
+    if analysis_price is not None:
+        return analysis_price
+
+    variables = variables_dict if isinstance(variables_dict, dict) else {}
+    variables_price = _first_float(variables.get("price"))
+    if variables_price is not None and variables_price > 0:
+        return variables_price
+
+    if isinstance(explain_payload, dict):
+        return explain_payload.get("current_price")
+    return None
 
 
 def _fmt_number(value: Any, decimals: int = 4) -> str:
@@ -1226,11 +1270,17 @@ def _build_prices_explain_text(
     ticker: str,
     explain_payload: Dict[str, Any],
     final_dict: Optional[Dict[str, Any]] = None,
+    analysis_text: str = "",
+    variables_dict: Optional[Dict[str, Any]] = None,
 ) -> str:
     methods = explain_payload.get("methods", {}) if isinstance(explain_payload, dict) else {}
     aggregate_targets = explain_payload.get("aggregate_targets", {}) if isinstance(explain_payload, dict) else {}
     aggregate_investments = explain_payload.get("aggregate_investments", {}) if isinstance(explain_payload, dict) else {}
-    current_price = explain_payload.get("current_price") if isinstance(explain_payload, dict) else None
+    current_price = _resolve_prices_explain_current_price(
+        explain_payload if isinstance(explain_payload, dict) else {},
+        analysis_text=analysis_text,
+        variables_dict=variables_dict,
+    )
 
     lines: List[str] = [
         f"# {ticker} Prices Explain",
@@ -1543,11 +1593,12 @@ def _run_ticker_valuation_impl(
             sec_candidate = str(sec_out.get("text", "")).strip()
             if sec_out.get("status") == "success" and sec_candidate:
                 currency_clarification = _build_sec_currency_clarification(info_dict)
-                sec_short_text = (
-                    f"{sec_candidate}\n\n{currency_clarification}"
-                    if currency_clarification
-                    else sec_candidate
-                )
+                sec_guidance_blocks = [
+                    sec_candidate,
+                    currency_clarification,
+                    _build_sec_source_of_truth_guidance(),
+                ]
+                sec_short_text = "\n\n".join(block for block in sec_guidance_blocks if str(block or "").strip())
                 legacy.append_text_to_file(
                     text=sec_short_text,
                     header="SEC Summary",
@@ -1732,10 +1783,18 @@ def _run_ticker_valuation_impl(
     dashboard_signal_snapshot_text = ""
     explain_text = ""
     try:
+        analysis_text_for_prices = ""
+        if analysis_dst.exists():
+            try:
+                analysis_text_for_prices = analysis_dst.read_text(encoding="utf-8")
+            except Exception:
+                analysis_text_for_prices = ""
         explain_text = _build_prices_explain_text(
             ticker,
             explain_payload,
             final_dict if isinstance(final_dict, dict) else {},
+            analysis_text=analysis_text_for_prices,
+            variables_dict=variables_dict if isinstance(variables_dict, dict) else {},
         )
         prices_explain_txt.write_text(explain_text, encoding="utf-8")
     except Exception as explain_err:

--- a/tests/test_financials_agent.py
+++ b/tests/test_financials_agent.py
@@ -138,3 +138,82 @@ def test_normalize_financials_analysis_sorts_q4_before_fy_and_moves_market_snaps
     assert market_cap["value"] == 1000
     amortization = next(row for row in normalized["rows"] if row["metric"] == "(+) Amortization of Intangible Assets")
     assert amortization["values"] == {"2025-09-30_Q": None, "2025-09-30_A": None}
+
+
+def test_normalize_financials_analysis_uses_report_date_year_for_labels():
+    normalized = normalize_financials_analysis(
+        {
+            "ticker": "TEST",
+            "periods": [
+                {"key": "2026-01-31_A", "label": "FY 2027", "date": "2026-01-31", "period_type": "annual"},
+                {"key": "2026-04-30_Q", "label": "Q1 2027", "date": "2026-04-30", "period_type": "quarterly"},
+            ],
+            "rows": [],
+        },
+        ticker="TEST",
+        currency="USD",
+    )
+
+    assert [p["label"] for p in normalized["periods"]] == ["FY 2025", "Q1 2026"]
+
+
+def test_normalize_financials_analysis_keeps_january_q4_in_sequence_year():
+    normalized = normalize_financials_analysis(
+        {
+            "ticker": "CGNT",
+            "periods": [
+                {"key": "2025-04-30_Q", "label": "Q1 2025", "date": "2025-04-30", "period_type": "quarterly"},
+                {"key": "2025-07-31_Q", "label": "Q2 2025", "date": "2025-07-31", "period_type": "quarterly"},
+                {"key": "2025-10-31_Q", "label": "Q3 2025", "date": "2025-10-31", "period_type": "quarterly"},
+                {"key": "2026-01-31_Q", "label": "Q4 2026", "date": "2026-01-31", "period_type": "quarterly"},
+                {"key": "2026-01-31_A", "label": "FY 2026", "date": "2026-01-31", "period_type": "annual"},
+                {"key": "2026-04-30_Q", "label": "Q1 2026", "date": "2026-04-30", "period_type": "quarterly"},
+            ],
+            "rows": [],
+        },
+        ticker="CGNT",
+        currency="USD",
+    )
+
+    assert [p["label"] for p in normalized["periods"]] == [
+        "Q1 2025",
+        "Q2 2025",
+        "Q3 2025",
+        "Q4 2025",
+        "FY 2025",
+        "Q1 2026",
+    ]
+
+
+def test_normalize_financials_analysis_handles_january_retail_fiscal_calendar():
+    normalized = normalize_financials_analysis(
+        {
+            "ticker": "WMT",
+            "periods": [
+                {"key": "2023-01-31_A", "label": "FY 2022", "date": "2023-01-31", "period_type": "annual"},
+                {"key": "2024-01-31_A", "label": "FY 2023", "date": "2024-01-31", "period_type": "annual"},
+                {"key": "2025-01-31_A", "label": "FY 2024", "date": "2025-01-31", "period_type": "annual"},
+                {"key": "2025-04-30_Q", "label": "Q1 2026", "date": "2025-04-30", "period_type": "quarterly"},
+                {"key": "2025-07-31_Q", "label": "Q2 2026", "date": "2025-07-31", "period_type": "quarterly"},
+                {"key": "2025-10-31_Q", "label": "Q3 2026", "date": "2025-10-31", "period_type": "quarterly"},
+                {"key": "2026-01-31_Q", "label": "Q4 2026", "date": "2026-01-31", "period_type": "quarterly"},
+                {"key": "2026-01-31_A", "label": "FY 2025", "date": "2026-01-31", "period_type": "annual"},
+                {"key": "2026-04-30_Q", "label": "Q1 2027", "date": "2026-04-30", "period_type": "quarterly"},
+            ],
+            "rows": [],
+        },
+        ticker="WMT",
+        currency="USD",
+    )
+
+    assert [p["label"] for p in normalized["periods"]] == [
+        "FY 2022",
+        "FY 2023",
+        "FY 2024",
+        "Q1 2025",
+        "Q2 2025",
+        "Q3 2025",
+        "Q4 2025",
+        "FY 2025",
+        "Q1 2026",
+    ]

--- a/tests/test_runner_fallback.py
+++ b/tests/test_runner_fallback.py
@@ -79,6 +79,33 @@ def test_build_sec_currency_clarification_skips_usd_financials():
     assert text == ""
 
 
+def test_build_sec_source_of_truth_guidance_mentions_contradictions():
+    text = runner._build_sec_source_of_truth_guidance()
+
+    assert "source of truth" in text
+    assert "disagree" in text
+    assert "SEC/MAYA filing summary" in text
+    assert "valuation assumptions" in text
+
+
+def test_prices_explain_uses_analysis_current_price_for_usd_targets():
+    text = runner._build_prices_explain_text(
+        "PAYT.TA",
+        {
+            "current_price": 6800.0,
+            "methods": {},
+            "aggregate_targets": {"Scenario DCF": 21.8},
+            "aggregate_investments": {"Scenario DCF": -25000},
+        },
+        analysis_text="# PAYT.TA - Analysis file\n\nCurrent Price: 22.0\n\nMarket Cap: 123",
+        variables_dict={"price": 22.0},
+    )
+
+    assert "Current Price: $22.00" in text
+    assert "| Scenario DCF | $21.80 (-0.91%) | $-25,000.00 |" in text
+    assert "-99" not in text
+
+
 def test_attach_market_agent_markdown_persists_analysis_section(tmp_path):
     analysis_text = """
 # What It Does:


### PR DESCRIPTION
﻿## Summary

- Fix Prices Explain current-price display and change math so USD targets compare against the USD analysis price instead of local ILA/agorot quotes.
- Polish the Info page header/icons and color growth/return metrics green/red while only flagging negative margins red.
- Normalize Financials period label years from the reported date and add SEC/MAYA source-of-truth guidance for valuators.

## Preview

URL: pending preview workflow

## Test plan

- [x] PYTHONPATH=src python -m pytest tests/test_runner_fallback.py tests/test_financials_agent.py --basetemp .pytest-basetemp-pdf-info
- [x] python -m compileall src\ai_hedge\runner.py src\ai_hedge\financials_agent.py
- [x] npm run build

## Notes for reviewer

- The preview URL should be checked once the site-preview workflow posts it, because this PR touches frontend files.
- A targeted ESLint attempt using the old npm -- --file shape failed because this repo uses eslint.config.js and no longer supports that flag; a direct npx eslint file run hung with no output, so the production build is the frontend validation used here.
