### PR TITLE
Add market peer return comparison

### DIFF
--- a/frontend/src/app/(app)/compare/page.tsx
+++ b/frontend/src/app/(app)/compare/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
+import type { CSSProperties } from "react";
 import { useEffect, useMemo, useState } from "react";
-import { GitCompareArrows, Loader2, Plus, X } from "lucide-react";
+import { Check, ClipboardCopy, GitCompareArrows, Loader2, Plus, X } from "lucide-react";
 import {
   CartesianGrid,
   Line,
@@ -86,6 +87,12 @@ type ComparePayload = {
   series?: CompareSeries[];
   not_found?: string[];
   error?: string;
+  financials?: {
+    generated_at?: string;
+    tickers?: string[];
+    data?: Record<string, unknown>;
+    not_found?: string[];
+  };
 };
 
 type TableRow = CompareSeries & {
@@ -162,6 +169,22 @@ function returnTone(value: number | null): string {
   return "text-[color:var(--text-secondary)]";
 }
 
+async function writeClipboard(text: string): Promise<void> {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "true");
+  textarea.style.position = "fixed";
+  textarea.style.left = "-9999px";
+  document.body.appendChild(textarea);
+  textarea.select();
+  document.execCommand("copy");
+  document.body.removeChild(textarea);
+}
+
 function ChartTooltip({
   active,
   payload,
@@ -200,6 +223,8 @@ export default function ComparePage() {
   const [data, setData] = useState<ComparePayload | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  const [copyingFinancials, setCopyingFinancials] = useState(false);
+  const [copyStatus, setCopyStatus] = useState<{ tone: "success" | "error"; message: string } | null>(null);
 
   function addTicker(entry: TickerEntry | null) {
     if (!entry) return;
@@ -214,6 +239,38 @@ export default function ComparePage() {
     setTickers((prev) => prev.filter((item) => item !== ticker));
   }
 
+  async function copyFinancials() {
+    if (!tickers.length || copyingFinancials) return;
+    setCopyingFinancials(true);
+    setCopyStatus(null);
+    try {
+      const qs = new URLSearchParams({ tickers: tickers.join(","), financials: "1" });
+      const res = await fetch(`/api/compare?${qs.toString()}`, { cache: "no-store" });
+      if (!res.ok) throw new Error(`Financials export failed (${res.status})`);
+      const payload = (await res.json()) as ComparePayload;
+      const financials = payload.financials || {
+        generated_at: new Date().toISOString(),
+        tickers,
+        data: {},
+        not_found: payload.not_found || [],
+      };
+      const copiedCount = Object.keys(financials.data || {}).length;
+      if (!copiedCount) throw new Error("No financial statements were available for the selected tickers.");
+      await writeClipboard(JSON.stringify(financials, null, 2));
+      setCopyStatus({
+        tone: "success",
+        message: `Copied financial JSON for ${copiedCount} ticker${copiedCount === 1 ? "" : "s"}.`,
+      });
+    } catch (err) {
+      setCopyStatus({
+        tone: "error",
+        message: err instanceof Error ? err.message : "Could not copy financials.",
+      });
+    } finally {
+      setCopyingFinancials(false);
+    }
+  }
+
   useEffect(() => {
     if (!tickers.length) {
       setData(null);
@@ -223,6 +280,7 @@ export default function ComparePage() {
     const controller = new AbortController();
     setLoading(true);
     setError("");
+    setCopyStatus(null);
     const qs = new URLSearchParams({ tickers: tickers.join(",") });
     fetch(`/api/compare?${qs.toString()}`, { cache: "no-store", signal: controller.signal })
       .then(async (res) => {
@@ -307,7 +365,7 @@ export default function ComparePage() {
       </header>
 
       <section className="mb-4 rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
-        <div className="grid gap-3 sm:grid-cols-[minmax(0,32rem)_auto] sm:items-center">
+        <div className="grid gap-3 sm:grid-cols-[minmax(0,32rem)_auto_auto] sm:items-center">
           <TickerSearch value={selected} onChange={(entry) => setSelected(entry)} />
           <button
             type="button"
@@ -317,6 +375,21 @@ export default function ComparePage() {
           >
             <Plus size={13} />
             Add Ticker
+          </button>
+          <button
+            type="button"
+            onClick={copyFinancials}
+            disabled={!tickers.length || copyingFinancials}
+            className="inline-flex h-10 w-full items-center justify-center gap-1.5 rounded-lg border border-[color:var(--border-strong)] bg-black/20 px-3 text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--text-secondary)] transition hover:border-[color:var(--accent)] hover:text-[color:var(--accent)] disabled:cursor-not-allowed disabled:border-[color:var(--border-subtle)] disabled:text-[color:var(--text-disabled)] sm:w-auto"
+          >
+            {copyingFinancials ? (
+              <Loader2 size={13} className="animate-spin" />
+            ) : copyStatus?.tone === "success" ? (
+              <Check size={13} />
+            ) : (
+              <ClipboardCopy size={13} />
+            )}
+            Copy Financials
           </button>
         </div>
         <div className="mt-3 flex flex-wrap gap-2">
@@ -337,6 +410,17 @@ export default function ComparePage() {
             </span>
           ))}
         </div>
+        {copyStatus ? (
+          <p
+            className={`mt-3 rounded-lg border bg-black/25 px-3 py-2 text-xs ${
+              copyStatus.tone === "success"
+                ? "border-[color:var(--success)] text-[color:var(--success)]"
+                : "border-[color:var(--danger)] text-[color:var(--danger)]"
+            }`}
+          >
+            {copyStatus.message}
+          </p>
+        ) : null}
         {data?.not_found?.length ? (
           <p className="mt-3 rounded-lg border border-[color:var(--danger)] bg-black/25 px-3 py-2 text-xs text-[color:var(--danger)]">
             Couldn&apos;t find {data.not_found.join(", ")} after checking Yahoo. That ticker may be delisted, mistyped, or using a different exchange suffix.
@@ -480,8 +564,8 @@ export default function ComparePage() {
                     <td className="hib-market-table-cell font-mono text-xs">#{idx + 1}</td>
                     <td className="hib-market-table-cell min-w-0">
                       <span
-                        style={tickerColor ? { color: tickerColor } : undefined}
-                        className="block truncate font-mono font-semibold"
+                        style={tickerColor ? ({ "--series-color": tickerColor } as CSSProperties) : undefined}
+                        className="hib-series-label block truncate font-mono font-semibold"
                       >
                         {row.ticker}
                       </span>

--- a/frontend/src/app/(app)/compare/page.tsx
+++ b/frontend/src/app/(app)/compare/page.tsx
@@ -1,0 +1,433 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { GitCompareArrows, Loader2, Plus, X } from "lucide-react";
+import {
+  CartesianGrid,
+  Line,
+  LineChart as RechartsLineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { TickerSearch } from "@/components/shell/ticker-search";
+import type { TickerEntry } from "@/lib/ticker-catalog";
+import { useThemeTokens } from "@/lib/theme-tokens";
+
+const MAX_TICKERS = 10;
+
+const PERIODS = [
+  { key: "1D", label: "1D", days: 1 },
+  { key: "1W", label: "1W", days: 7 },
+  { key: "1M", label: "1M", days: 30 },
+  { key: "3M", label: "3M", days: 90 },
+  { key: "6M", label: "6M", days: 182 },
+  { key: "YTD", label: "YTD", days: null },
+  { key: "1Y", label: "1Y", days: 365 },
+  { key: "3Y", label: "3Y", days: 365 * 3 },
+  { key: "5Y", label: "5Y", days: 365 * 5 },
+] as const;
+
+const CHART_TOKENS = [
+  "--chart-grid",
+  "--chart-axis",
+  "--chart-current",
+  "--chart-series-1",
+  "--chart-series-2",
+  "--chart-series-4",
+  "--chart-series-6",
+  "--chart-bear",
+] as const;
+
+type PricePoint = { date: string; close: number };
+
+type CompareSeries = {
+  ticker: string;
+  company_name: string;
+  exchange?: string;
+  currency?: string;
+  current_price?: number | null;
+  volume?: number | null;
+  fifty_two_week_high?: number | null;
+  fifty_two_week_low?: number | null;
+  prices: PricePoint[];
+};
+
+type ComparePayload = {
+  status?: string;
+  series?: CompareSeries[];
+  not_found?: string[];
+  error?: string;
+};
+
+type TableRow = CompareSeries & {
+  returnPct: number | null;
+  startPrice: number | null;
+  endPrice: number | null;
+};
+
+function numeric(value: unknown): number | null {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function parseDate(value: string): Date | null {
+  const date = new Date(`${value}T00:00:00`);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function periodStartDate(periodKey: string, latestDate: Date): Date {
+  if (periodKey === "YTD") return new Date(latestDate.getFullYear(), 0, 1);
+  const option = PERIODS.find((item) => item.key === periodKey);
+  const start = new Date(latestDate);
+  start.setDate(start.getDate() - (option?.days ?? 365));
+  return start;
+}
+
+function slicePricesForPeriod(prices: PricePoint[], start: Date): PricePoint[] {
+  const filtered = prices.filter((point) => {
+    const date = parseDate(point.date);
+    return date ? date >= start : false;
+  });
+  return filtered.length >= 2 ? filtered : prices.slice(-2);
+}
+
+function formatReturn(value: number | null): string {
+  if (value === null || !Number.isFinite(value)) return "-";
+  return `${value > 0 ? "+" : ""}${value.toFixed(1)}%`;
+}
+
+function formatPrice(value: unknown, currency?: string): string {
+  const n = numeric(value);
+  if (n === null) return "-";
+  return `${currency ? `${currency} ` : ""}${n.toLocaleString(undefined, {
+    maximumFractionDigits: n >= 100 ? 1 : 2,
+  })}`;
+}
+
+function formatLarge(value: unknown): string {
+  const n = numeric(value);
+  if (n === null) return "-";
+  const abs = Math.abs(n);
+  if (abs >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`;
+  if (abs >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (abs >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return n.toLocaleString(undefined, { maximumFractionDigits: 0 });
+}
+
+function returnTone(value: number | null): string {
+  if (value === null) return "text-[color:var(--text-muted)]";
+  if (value > 0) return "text-[color:var(--success)]";
+  if (value < 0) return "text-[color:var(--danger)]";
+  return "text-[color:var(--text-secondary)]";
+}
+
+function ChartTooltip({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean;
+  payload?: Array<{ name?: string; value?: number; color?: string }>;
+  label?: string;
+}) {
+  if (!active || !payload?.length) return null;
+  return (
+    <div className="hib-chart-tooltip rounded-lg border border-white/15 bg-zinc-950/95 px-3 py-2 shadow-xl">
+      <p className="mb-1 text-xs font-semibold tracking-[0.08em] text-[color:var(--text-primary)]">{label}</p>
+      <div className="grid gap-1">
+        {payload
+          .filter((item) => typeof item.value === "number" && Number.isFinite(item.value))
+          .sort((a, b) => Number(b.value) - Number(a.value))
+          .map((item) => (
+            <p key={item.name} className="flex min-w-36 items-center justify-between gap-3 text-xs">
+              <span className="font-mono" style={{ color: item.color }}>
+                {item.name}
+              </span>
+              <span className="font-semibold text-[color:var(--text-secondary)]">{formatReturn(Number(item.value))}</span>
+            </p>
+          ))}
+      </div>
+    </div>
+  );
+}
+
+export default function ComparePage() {
+  const tokens = useThemeTokens(CHART_TOKENS);
+  const [selected, setSelected] = useState<TickerEntry | null>(null);
+  const [tickers, setTickers] = useState<string[]>(["AAPL", "MSFT", "GOOGL"]);
+  const [period, setPeriod] = useState<(typeof PERIODS)[number]["key"]>("1Y");
+  const [data, setData] = useState<ComparePayload | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  function addTicker(entry: TickerEntry | null) {
+    if (!entry) return;
+    const ticker = entry.s.trim().toUpperCase();
+    setSelected(null);
+    setError("");
+    if (!ticker || tickers.includes(ticker) || tickers.length >= MAX_TICKERS) return;
+    setTickers((prev) => [...prev, ticker]);
+  }
+
+  function removeTicker(ticker: string) {
+    setTickers((prev) => prev.filter((item) => item !== ticker));
+  }
+
+  useEffect(() => {
+    if (!tickers.length) {
+      setData(null);
+      setError("");
+      return;
+    }
+    const controller = new AbortController();
+    setLoading(true);
+    setError("");
+    const qs = new URLSearchParams({ tickers: tickers.join(",") });
+    fetch(`/api/compare?${qs.toString()}`, { cache: "no-store", signal: controller.signal })
+      .then(async (res) => {
+        if (!res.ok) throw new Error(`Compare lookup failed (${res.status})`);
+        return (await res.json()) as ComparePayload;
+      })
+      .then((payload) => {
+        setData(payload);
+        setError(String(payload.error || ""));
+      })
+      .catch((err: Error) => {
+        if (err.name === "AbortError") return;
+        setData(null);
+        setError(err.message || "Compare lookup failed.");
+      })
+      .finally(() => setLoading(false));
+    return () => controller.abort();
+  }, [tickers]);
+
+  const comparison = useMemo(() => {
+    const series = (data?.series || [])
+      .map((item) => ({
+        ...item,
+        ticker: item.ticker.toUpperCase(),
+        prices: [...(item.prices || [])].sort((a, b) => a.date.localeCompare(b.date)),
+      }))
+      .filter((item) => item.ticker && item.prices.length >= 2);
+    const latestDate = series
+      .flatMap((item) => item.prices.map((point) => parseDate(point.date)))
+      .filter((date): date is Date => Boolean(date))
+      .sort((a, b) => b.getTime() - a.getTime())[0];
+    if (!latestDate) return { chartData: [], tableRows: [] as TableRow[], series };
+    const start = periodStartDate(period, latestDate);
+    const dateMap = new Map<string, Record<string, string | number>>();
+    const tableRows: TableRow[] = [];
+    for (const item of series) {
+      const prices = slicePricesForPeriod(item.prices, start);
+      const startPrice = prices[0]?.close ?? null;
+      const endPrice = prices[prices.length - 1]?.close ?? null;
+      const returnPct = startPrice && endPrice ? (endPrice / startPrice - 1) * 100 : null;
+      tableRows.push({ ...item, startPrice, endPrice, returnPct });
+      if (!startPrice) continue;
+      for (const point of prices) {
+        const row = dateMap.get(point.date) || { date: point.date };
+        row[item.ticker] = (point.close / startPrice - 1) * 100;
+        dateMap.set(point.date, row);
+      }
+    }
+    return {
+      chartData: Array.from(dateMap.values()).sort((a, b) => String(a.date).localeCompare(String(b.date))),
+      tableRows: tableRows.sort((a, b) => {
+        if (a.returnPct === null && b.returnPct === null) return a.ticker.localeCompare(b.ticker);
+        if (a.returnPct === null) return 1;
+        if (b.returnPct === null) return -1;
+        return b.returnPct - a.returnPct;
+      }),
+      series,
+    };
+  }, [data, period]);
+
+  const lineColor = (idx: number) => {
+    const palette = [
+      tokens["--chart-current"],
+      tokens["--chart-series-2"],
+      tokens["--chart-series-4"],
+      tokens["--chart-series-6"],
+      tokens["--chart-bear"],
+      tokens["--chart-series-1"],
+    ].filter(Boolean);
+    return palette[idx % palette.length] || tokens["--chart-axis"];
+  };
+
+  return (
+    <div className="min-w-0 px-4 py-5 sm:px-8">
+      <header className="mb-5 flex flex-wrap items-end justify-between gap-4">
+        <div className="min-w-0">
+          <p className="text-xs uppercase tracking-[0.2em] text-[color:var(--text-muted)]">Compare</p>
+          <h1 className="font-display text-2xl text-[color:var(--text-primary)]">Stock Comparison</h1>
+        </div>
+        <div className="text-xs text-[color:var(--text-muted)]">{tickers.length}/{MAX_TICKERS} tickers</div>
+      </header>
+
+      <section className="mb-4 rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
+        <div className="grid gap-3 lg:grid-cols-[minmax(18rem,28rem)_auto] lg:items-start">
+          <TickerSearch value={selected} onChange={(entry) => setSelected(entry)} />
+          <button
+            type="button"
+            onClick={() => addTicker(selected)}
+            disabled={!selected || tickers.length >= MAX_TICKERS}
+            className="hib-run-btn inline-flex h-12 items-center justify-center gap-2 rounded-xl border border-[color:var(--accent)] bg-[color:var(--accent)] px-4 text-sm font-semibold uppercase tracking-[0.14em] text-[color:var(--text-on-accent)] transition hover:bg-[color:var(--accent-hover)] disabled:cursor-not-allowed disabled:text-[color:var(--text-disabled)] disabled:opacity-50"
+          >
+            <Plus size={15} />
+            Add Ticker
+          </button>
+        </div>
+        <div className="mt-3 flex flex-wrap gap-2">
+          {tickers.map((ticker) => (
+            <span
+              key={ticker}
+              className="inline-flex items-center gap-2 rounded-lg border border-white/10 bg-black/25 px-2.5 py-1.5 font-mono text-xs font-semibold text-[color:var(--text-secondary)]"
+            >
+              {ticker}
+              <button
+                type="button"
+                onClick={() => removeTicker(ticker)}
+                aria-label={`Remove ${ticker}`}
+                className="rounded-md p-0.5 text-[color:var(--text-muted)] hover:bg-white/5 hover:text-[color:var(--text-primary)]"
+              >
+                <X size={12} />
+              </button>
+            </span>
+          ))}
+        </div>
+        {data?.not_found?.length ? (
+          <p className="mt-3 rounded-lg border border-[color:var(--danger)] bg-black/25 px-3 py-2 text-xs text-[color:var(--danger)]">
+            Couldn&apos;t find {data.not_found.join(", ")} after checking Yahoo. That ticker may be delisted, mistyped, or using a different exchange suffix.
+          </p>
+        ) : error ? (
+          <p className="mt-3 rounded-lg border border-[color:var(--danger)] bg-black/25 px-3 py-2 text-xs text-[color:var(--danger)]">
+            {error}
+          </p>
+        ) : null}
+      </section>
+
+      <section className="mb-4 rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-2 text-[color:var(--text-primary)]">
+            <GitCompareArrows size={17} className="text-[color:var(--accent)]" />
+            <h2 className="font-display text-lg">Return Chart</h2>
+            {loading ? <Loader2 size={14} className="animate-spin text-[color:var(--text-muted)]" /> : null}
+          </div>
+          <div className="flex max-w-full flex-wrap gap-1">
+            {PERIODS.map((option) => {
+              const active = option.key === period;
+              return (
+                <button
+                  key={option.key}
+                  type="button"
+                  onClick={() => setPeriod(option.key)}
+                  className={`rounded-lg border px-2.5 py-1 text-xs font-semibold transition ${
+                    active
+                      ? "border-[color:var(--accent)] bg-[color:var(--accent)] text-[color:var(--text-on-accent)]"
+                      : "border-white/10 bg-black/25 text-[color:var(--text-secondary)] hover:border-[color:var(--border-strong)] hover:text-[color:var(--text-primary)]"
+                  }`}
+                >
+                  {option.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+        <div className="hib-chart h-[28rem] min-h-[20rem] min-w-0">
+          {comparison.series.length >= 1 ? (
+            <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={300}>
+              <RechartsLineChart data={comparison.chartData} margin={{ top: 8, right: 18, bottom: 8, left: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke={tokens["--chart-grid"]} />
+                <XAxis
+                  dataKey="date"
+                  minTickGap={30}
+                  tick={{ fill: tokens["--chart-axis"], fontSize: 11 }}
+                  tickFormatter={(value) => String(value).slice(5)}
+                />
+                <YAxis
+                  width={58}
+                  tick={{ fill: tokens["--chart-axis"], fontSize: 11 }}
+                  tickFormatter={(value) => formatReturn(Number(value))}
+                />
+                <Tooltip content={<ChartTooltip />} wrapperStyle={{ outline: "none" }} />
+                {comparison.series.map((item, idx) => (
+                  <Line
+                    key={item.ticker}
+                    type="monotone"
+                    dataKey={item.ticker}
+                    name={item.ticker}
+                    stroke={lineColor(idx)}
+                    strokeWidth={idx === 0 ? 3 : 2}
+                    strokeDasharray={idx >= 6 ? "6 4" : undefined}
+                    dot={false}
+                    connectNulls
+                    isAnimationActive={false}
+                  />
+                ))}
+              </RechartsLineChart>
+            </ResponsiveContainer>
+          ) : (
+            <div className="flex h-full items-center justify-center rounded-xl border border-white/10 bg-black/25 p-4 text-center text-sm text-[color:var(--text-muted)]">
+              {loading ? "Loading comparison..." : "Add tickers to start comparing."}
+            </div>
+          )}
+        </div>
+      </section>
+
+      <section className="rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <h2 className="font-display text-lg text-[color:var(--text-primary)]">Comparison Table</h2>
+          <p className="text-xs text-[color:var(--text-muted)]">Sorted by {period} return</p>
+        </div>
+        <div className="hib-market-table-wrap">
+          <table className="hib-market-table min-w-[62rem] table-fixed">
+            <colgroup>
+              <col className="w-[5rem]" />
+              <col className="w-[14rem]" />
+              <col className="w-[8rem]" />
+              <col className="w-[8rem]" />
+              <col className="w-[8rem]" />
+              <col className="w-[8rem]" />
+              <col className="w-[9rem]" />
+              <col className="w-[7rem]" />
+            </colgroup>
+            <thead>
+              <tr>
+                <th className="hib-market-table-head">Rank</th>
+                <th className="hib-market-table-head">Company</th>
+                <th className="hib-market-table-head">Return</th>
+                <th className="hib-market-table-head">Start</th>
+                <th className="hib-market-table-head">Latest</th>
+                <th className="hib-market-table-head">52W Low</th>
+                <th className="hib-market-table-head">52W High</th>
+                <th className="hib-market-table-head">Volume</th>
+              </tr>
+            </thead>
+            <tbody>
+              {comparison.tableRows.map((row, idx) => (
+                <tr key={row.ticker}>
+                  <td className="hib-market-table-cell font-mono text-xs">#{idx + 1}</td>
+                  <td className="hib-market-table-cell min-w-0">
+                    <span className="block truncate font-mono font-semibold">{row.ticker}</span>
+                    <span className="block truncate text-[color:var(--text-muted)]">{row.company_name || row.exchange || "Company"}</span>
+                  </td>
+                  <td className={`hib-market-table-cell font-mono font-semibold ${returnTone(row.returnPct)}`}>
+                    {formatReturn(row.returnPct)}
+                  </td>
+                  <td className="hib-market-table-cell font-mono">{formatPrice(row.startPrice, row.currency)}</td>
+                  <td className="hib-market-table-cell font-mono">{formatPrice(row.endPrice ?? row.current_price, row.currency)}</td>
+                  <td className="hib-market-table-cell font-mono">{formatPrice(row.fifty_two_week_low, row.currency)}</td>
+                  <td className="hib-market-table-cell font-mono">{formatPrice(row.fifty_two_week_high, row.currency)}</td>
+                  <td className="hib-market-table-cell font-mono">{formatLarge(row.volume)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/app/(app)/compare/page.tsx
+++ b/frontend/src/app/(app)/compare/page.tsx
@@ -294,6 +294,7 @@ export default function ComparePage() {
     ].filter(Boolean);
     return palette[idx % palette.length] || tokens["--chart-axis"];
   };
+  const colorByTicker = new Map(comparison.series.map((item, idx) => [item.ticker, lineColor(idx)]));
 
   return (
     <div className="min-w-0 px-4 py-5 sm:px-8">
@@ -473,11 +474,17 @@ export default function ComparePage() {
             <tbody>
               {comparison.tableRows.map((row, idx) => {
                 const fundamentals = row.fundamentals || {};
+                const tickerColor = colorByTicker.get(row.ticker);
                 return (
                   <tr key={row.ticker}>
                     <td className="hib-market-table-cell font-mono text-xs">#{idx + 1}</td>
                     <td className="hib-market-table-cell min-w-0">
-                      <span className="block truncate font-mono font-semibold">{row.ticker}</span>
+                      <span
+                        style={tickerColor ? { color: tickerColor } : undefined}
+                        className="block truncate font-mono font-semibold"
+                      >
+                        {row.ticker}
+                      </span>
                       <span className="block truncate text-[color:var(--text-muted)]">
                         {fundamentals.company_name || row.company_name || row.exchange || "Company"}
                       </span>

--- a/frontend/src/app/(app)/compare/page.tsx
+++ b/frontend/src/app/(app)/compare/page.tsx
@@ -307,15 +307,15 @@ export default function ComparePage() {
       </header>
 
       <section className="mb-4 rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
-        <div className="grid gap-3 lg:grid-cols-[minmax(18rem,28rem)_auto] lg:items-start">
+        <div className="grid gap-3 sm:grid-cols-[minmax(0,32rem)_auto] sm:items-center">
           <TickerSearch value={selected} onChange={(entry) => setSelected(entry)} />
           <button
             type="button"
             onClick={() => addTicker(selected)}
             disabled={!selected || tickers.length >= MAX_TICKERS}
-            className="hib-run-btn inline-flex h-12 items-center justify-center gap-2 rounded-xl border border-[color:var(--accent)] bg-[color:var(--accent)] px-4 text-sm font-semibold uppercase tracking-[0.14em] text-[color:var(--text-on-accent)] transition hover:bg-[color:var(--accent-hover)] disabled:cursor-not-allowed disabled:text-[color:var(--text-disabled)] disabled:opacity-50"
+            className="inline-flex h-10 w-full items-center justify-center gap-1.5 rounded-lg border border-[color:var(--accent)] bg-black/20 px-3 text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--accent)] transition hover:bg-[color:var(--accent)] hover:text-[color:var(--text-on-accent)] disabled:cursor-not-allowed disabled:border-[color:var(--border-subtle)] disabled:text-[color:var(--text-disabled)] sm:w-auto"
           >
-            <Plus size={15} />
+            <Plus size={13} />
             Add Ticker
           </button>
         </div>

--- a/frontend/src/app/(app)/compare/page.tsx
+++ b/frontend/src/app/(app)/compare/page.tsx
@@ -36,12 +36,37 @@ const CHART_TOKENS = [
   "--chart-current",
   "--chart-series-1",
   "--chart-series-2",
+  "--chart-series-3",
   "--chart-series-4",
   "--chart-series-6",
   "--chart-bear",
 ] as const;
 
 type PricePoint = { date: string; close: number };
+
+type CompareFundamentals = {
+  ticker?: string;
+  symbol?: string;
+  company_name?: string;
+  market_cap?: number | null;
+  enterprise_value?: number | null;
+  net_cash_debt?: number | null;
+  trailing_pe?: number | null;
+  forward_pe?: number | null;
+  ev_sales?: number | null;
+  ev_ebitda?: number | null;
+  p_fcf?: number | null;
+  revenue_growth?: number | null;
+  earnings_growth?: number | null;
+  gross_margin?: number | null;
+  operating_margin?: number | null;
+  profit_margin?: number | null;
+  roe?: number | null;
+  current_ratio?: number | null;
+  debt_to_equity?: number | null;
+  dividend_yield?: number | null;
+  target_upside?: number | null;
+};
 
 type CompareSeries = {
   ticker: string;
@@ -52,6 +77,7 @@ type CompareSeries = {
   volume?: number | null;
   fifty_two_week_high?: number | null;
   fifty_two_week_low?: number | null;
+  fundamentals?: CompareFundamentals | null;
   prices: PricePoint[];
 };
 
@@ -105,6 +131,18 @@ function formatPrice(value: unknown, currency?: string): string {
   return `${currency ? `${currency} ` : ""}${n.toLocaleString(undefined, {
     maximumFractionDigits: n >= 100 ? 1 : 2,
   })}`;
+}
+
+function formatRatio(value: unknown): string {
+  const n = numeric(value);
+  if (n === null || n <= 0) return "-";
+  return `${n.toFixed(1)}x`;
+}
+
+function formatPercentValue(value: unknown): string {
+  const n = numeric(value);
+  if (n === null) return "-";
+  return `${n > 0 ? "+" : ""}${n.toFixed(1)}%`;
 }
 
 function formatLarge(value: unknown): string {
@@ -247,11 +285,11 @@ export default function ComparePage() {
 
   const lineColor = (idx: number) => {
     const palette = [
-      tokens["--chart-current"],
-      tokens["--chart-series-2"],
       tokens["--chart-series-4"],
-      tokens["--chart-series-6"],
+      tokens["--chart-series-2"],
+      tokens["--chart-series-3"],
       tokens["--chart-bear"],
+      tokens["--chart-series-6"],
       tokens["--chart-series-1"],
     ].filter(Boolean);
     return palette[idx % palette.length] || tokens["--chart-axis"];
@@ -383,15 +421,27 @@ export default function ComparePage() {
           <p className="text-xs text-[color:var(--text-muted)]">Sorted by {period} return</p>
         </div>
         <div className="hib-market-table-wrap">
-          <table className="hib-market-table min-w-[62rem] table-fixed">
+          <table className="hib-market-table min-w-[112rem] table-fixed">
             <colgroup>
-              <col className="w-[5rem]" />
+              <col className="w-[4rem]" />
               <col className="w-[14rem]" />
-              <col className="w-[8rem]" />
-              <col className="w-[8rem]" />
+              <col className="w-[7rem]" />
               <col className="w-[8rem]" />
               <col className="w-[8rem]" />
               <col className="w-[9rem]" />
+              <col className="w-[6rem]" />
+              <col className="w-[6rem]" />
+              <col className="w-[5rem]" />
+              <col className="w-[6rem]" />
+              <col className="w-[6rem]" />
+              <col className="w-[7rem]" />
+              <col className="w-[7rem]" />
+              <col className="w-[7rem]" />
+              <col className="w-[7rem]" />
+              <col className="w-[5rem]" />
+              <col className="w-[6rem]" />
+              <col className="w-[6rem]" />
+              <col className="w-[7rem]" />
               <col className="w-[7rem]" />
             </colgroup>
             <thead>
@@ -399,31 +449,68 @@ export default function ComparePage() {
                 <th className="hib-market-table-head">Rank</th>
                 <th className="hib-market-table-head">Company</th>
                 <th className="hib-market-table-head">Return</th>
-                <th className="hib-market-table-head">Start</th>
-                <th className="hib-market-table-head">Latest</th>
-                <th className="hib-market-table-head">52W Low</th>
-                <th className="hib-market-table-head">52W High</th>
-                <th className="hib-market-table-head">Volume</th>
+                <th className="hib-market-table-head">Market Cap</th>
+                <th className="hib-market-table-head">EV</th>
+                <th className="hib-market-table-head">Net Cash / Debt</th>
+                <th className="hib-market-table-head">P/E</th>
+                <th className="hib-market-table-head">Forward P/E</th>
+                <th className="hib-market-table-head">EV/Sales</th>
+                <th className="hib-market-table-head">EV/EBITDA</th>
+                <th className="hib-market-table-head">P/FCF</th>
+                <th className="hib-market-table-head">Rev Growth</th>
+                <th className="hib-market-table-head">EPS Growth</th>
+                <th className="hib-market-table-head">Gross Margin</th>
+                <th className="hib-market-table-head">Op Margin</th>
+                <th className="hib-market-table-head">Net Margin</th>
+                <th className="hib-market-table-head">ROE</th>
+                <th className="hib-market-table-head">Current Ratio</th>
+                <th className="hib-market-table-head">Debt / Equity</th>
+                <th className="hib-market-table-head">Dividend</th>
+                <th className="hib-market-table-head">Target Upside</th>
               </tr>
             </thead>
             <tbody>
-              {comparison.tableRows.map((row, idx) => (
-                <tr key={row.ticker}>
-                  <td className="hib-market-table-cell font-mono text-xs">#{idx + 1}</td>
-                  <td className="hib-market-table-cell min-w-0">
-                    <span className="block truncate font-mono font-semibold">{row.ticker}</span>
-                    <span className="block truncate text-[color:var(--text-muted)]">{row.company_name || row.exchange || "Company"}</span>
-                  </td>
-                  <td className={`hib-market-table-cell font-mono font-semibold ${returnTone(row.returnPct)}`}>
-                    {formatReturn(row.returnPct)}
-                  </td>
-                  <td className="hib-market-table-cell font-mono">{formatPrice(row.startPrice, row.currency)}</td>
-                  <td className="hib-market-table-cell font-mono">{formatPrice(row.endPrice ?? row.current_price, row.currency)}</td>
-                  <td className="hib-market-table-cell font-mono">{formatPrice(row.fifty_two_week_low, row.currency)}</td>
-                  <td className="hib-market-table-cell font-mono">{formatPrice(row.fifty_two_week_high, row.currency)}</td>
-                  <td className="hib-market-table-cell font-mono">{formatLarge(row.volume)}</td>
-                </tr>
-              ))}
+              {comparison.tableRows.map((row, idx) => {
+                const fundamentals = row.fundamentals || {};
+                return (
+                  <tr key={row.ticker}>
+                    <td className="hib-market-table-cell font-mono text-xs">#{idx + 1}</td>
+                    <td className="hib-market-table-cell min-w-0">
+                      <span className="block truncate font-mono font-semibold">{row.ticker}</span>
+                      <span className="block truncate text-[color:var(--text-muted)]">
+                        {fundamentals.company_name || row.company_name || row.exchange || "Company"}
+                      </span>
+                    </td>
+                    <td className={`hib-market-table-cell font-mono font-semibold ${returnTone(row.returnPct)}`}>
+                      {formatReturn(row.returnPct)}
+                    </td>
+                    <td className="hib-market-table-cell font-mono">{formatLarge(fundamentals.market_cap)}</td>
+                    <td className="hib-market-table-cell font-mono">{formatLarge(fundamentals.enterprise_value)}</td>
+                    <td className="hib-market-table-cell font-mono">{formatLarge(fundamentals.net_cash_debt)}</td>
+                    <td className="hib-market-table-cell font-mono">{formatRatio(fundamentals.trailing_pe)}</td>
+                    <td className="hib-market-table-cell font-mono">{formatRatio(fundamentals.forward_pe)}</td>
+                    <td className="hib-market-table-cell font-mono">{formatRatio(fundamentals.ev_sales)}</td>
+                    <td className="hib-market-table-cell font-mono">{formatRatio(fundamentals.ev_ebitda)}</td>
+                    <td className="hib-market-table-cell font-mono">{formatRatio(fundamentals.p_fcf)}</td>
+                    <td className={`hib-market-table-cell font-mono ${returnTone(numeric(fundamentals.revenue_growth))}`}>
+                      {formatPercentValue(fundamentals.revenue_growth)}
+                    </td>
+                    <td className={`hib-market-table-cell font-mono ${returnTone(numeric(fundamentals.earnings_growth))}`}>
+                      {formatPercentValue(fundamentals.earnings_growth)}
+                    </td>
+                    <td className="hib-market-table-cell font-mono">{formatPercentValue(fundamentals.gross_margin)}</td>
+                    <td className="hib-market-table-cell font-mono">{formatPercentValue(fundamentals.operating_margin)}</td>
+                    <td className="hib-market-table-cell font-mono">{formatPercentValue(fundamentals.profit_margin)}</td>
+                    <td className="hib-market-table-cell font-mono">{formatPercentValue(fundamentals.roe)}</td>
+                    <td className="hib-market-table-cell font-mono">{formatRatio(fundamentals.current_ratio)}</td>
+                    <td className="hib-market-table-cell font-mono">{formatRatio(fundamentals.debt_to_equity)}</td>
+                    <td className="hib-market-table-cell font-mono">{formatPercentValue(fundamentals.dividend_yield)}</td>
+                    <td className={`hib-market-table-cell font-mono ${returnTone(numeric(fundamentals.target_upside))}`}>
+                      {formatPercentValue(fundamentals.target_upside)}
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         </div>

--- a/frontend/src/app/(app)/compare/page.tsx
+++ b/frontend/src/app/(app)/compare/page.tsx
@@ -421,7 +421,7 @@ export default function ComparePage() {
           <p className="text-xs text-[color:var(--text-muted)]">Sorted by {period} return</p>
         </div>
         <div className="hib-market-table-wrap">
-          <table className="hib-market-table min-w-[112rem] table-fixed">
+          <table className="hib-market-table min-w-[145rem] table-fixed">
             <colgroup>
               <col className="w-[4rem]" />
               <col className="w-[14rem]" />
@@ -443,6 +443,7 @@ export default function ComparePage() {
               <col className="w-[6rem]" />
               <col className="w-[7rem]" />
               <col className="w-[7rem]" />
+              <col className="w-[10rem]" />
             </colgroup>
             <thead>
               <tr>
@@ -481,8 +482,8 @@ export default function ComparePage() {
                         {fundamentals.company_name || row.company_name || row.exchange || "Company"}
                       </span>
                     </td>
-                    <td className={`hib-market-table-cell font-mono font-semibold ${returnTone(row.returnPct)}`}>
-                      {formatReturn(row.returnPct)}
+                    <td className="hib-market-table-cell font-mono font-semibold">
+                      <span className={returnTone(row.returnPct)}>{formatReturn(row.returnPct)}</span>
                     </td>
                     <td className="hib-market-table-cell font-mono">{formatLarge(fundamentals.market_cap)}</td>
                     <td className="hib-market-table-cell font-mono">{formatLarge(fundamentals.enterprise_value)}</td>
@@ -492,11 +493,15 @@ export default function ComparePage() {
                     <td className="hib-market-table-cell font-mono">{formatRatio(fundamentals.ev_sales)}</td>
                     <td className="hib-market-table-cell font-mono">{formatRatio(fundamentals.ev_ebitda)}</td>
                     <td className="hib-market-table-cell font-mono">{formatRatio(fundamentals.p_fcf)}</td>
-                    <td className={`hib-market-table-cell font-mono ${returnTone(numeric(fundamentals.revenue_growth))}`}>
-                      {formatPercentValue(fundamentals.revenue_growth)}
+                    <td className="hib-market-table-cell font-mono">
+                      <span className={returnTone(numeric(fundamentals.revenue_growth))}>
+                        {formatPercentValue(fundamentals.revenue_growth)}
+                      </span>
                     </td>
-                    <td className={`hib-market-table-cell font-mono ${returnTone(numeric(fundamentals.earnings_growth))}`}>
-                      {formatPercentValue(fundamentals.earnings_growth)}
+                    <td className="hib-market-table-cell font-mono">
+                      <span className={returnTone(numeric(fundamentals.earnings_growth))}>
+                        {formatPercentValue(fundamentals.earnings_growth)}
+                      </span>
                     </td>
                     <td className="hib-market-table-cell font-mono">{formatPercentValue(fundamentals.gross_margin)}</td>
                     <td className="hib-market-table-cell font-mono">{formatPercentValue(fundamentals.operating_margin)}</td>
@@ -505,8 +510,10 @@ export default function ComparePage() {
                     <td className="hib-market-table-cell font-mono">{formatRatio(fundamentals.current_ratio)}</td>
                     <td className="hib-market-table-cell font-mono">{formatRatio(fundamentals.debt_to_equity)}</td>
                     <td className="hib-market-table-cell font-mono">{formatPercentValue(fundamentals.dividend_yield)}</td>
-                    <td className={`hib-market-table-cell font-mono ${returnTone(numeric(fundamentals.target_upside))}`}>
-                      {formatPercentValue(fundamentals.target_upside)}
+                    <td className="hib-market-table-cell whitespace-nowrap pr-4 font-mono">
+                      <span className={returnTone(numeric(fundamentals.target_upside))}>
+                        {formatPercentValue(fundamentals.target_upside)}
+                      </span>
                     </td>
                   </tr>
                 );

--- a/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
@@ -7,7 +7,7 @@ import {
   Store,
   TrendingUp,
 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import type { Components } from "react-markdown";
 import {
@@ -241,13 +241,29 @@ type ReturnTableRow = {
   latestClose: number | null;
 };
 
+type MarketReturnApiPayload = {
+  status?: string;
+  series?: Array<{
+    ticker?: string;
+    company_name?: string;
+    prices?: Array<{
+      date?: string;
+      close?: number;
+    }>;
+  }>;
+  error?: string;
+};
+
 function parseDate(value: string): Date | null {
   const date = new Date(`${value}T00:00:00`);
   return Number.isNaN(date.getTime()) ? null : date;
 }
 
-function normalizeReturnSeries(market: MarketReviewPayload): ReturnSeries[] {
-  const raw = market.return_comparison?.series;
+function normalizeReturnSeriesFromPayload(
+  payload: MarketReturnApiPayload | undefined,
+  namesByTicker: Map<string, string>,
+): ReturnSeries[] {
+  const raw = payload?.series;
   if (!Array.isArray(raw)) return [];
   return raw
     .map((series) => {
@@ -261,13 +277,26 @@ function normalizeReturnSeries(market: MarketReviewPayload): ReturnSeries[] {
             .filter((point): point is PricePoint => Boolean(point))
             .sort((a, b) => a.date.localeCompare(b.date))
         : [];
+      const ticker = markdownText(series.ticker).toUpperCase();
       return {
-        ticker: markdownText(series.ticker).toUpperCase(),
-        company_name: markdownText(series.company_name),
+        ticker,
+        company_name: markdownText(series.company_name) || namesByTicker.get(ticker) || "",
         prices,
       };
     })
     .filter((series) => series.ticker && series.prices.length >= 2);
+}
+
+function returnUniverse(market: MarketReviewPayload, ticker: string): ReturnTableRow[] {
+  return buildComparisonRows(market, ticker)
+    .map((row) => ({
+      ticker: markdownText(row.ticker).toUpperCase(),
+      company_name: markdownText(row.company_name),
+      returnPct: null,
+      latestClose: null,
+    }))
+    .filter((row, idx, rows) => row.ticker && rows.findIndex((candidate) => candidate.ticker === row.ticker) === idx)
+    .slice(0, 6);
 }
 
 function periodStartDate(periodKey: string, latestDate: Date): Date {
@@ -318,10 +347,60 @@ function ReturnTooltip({
   );
 }
 
-function MarketReturnComparison({ market }: { market: MarketReviewPayload }) {
+function MarketReturnComparison({ market, ticker }: { market: MarketReviewPayload; ticker: string }) {
   const [period, setPeriod] = useState<(typeof RETURN_PERIODS)[number]["key"]>("1Y");
+  const [remotePayload, setRemotePayload] = useState<MarketReturnApiPayload | null>(null);
+  const [loadState, setLoadState] = useState<"idle" | "loading" | "ready" | "error">("idle");
+  const [loadError, setLoadError] = useState("");
   const tokens = useThemeTokens(RETURN_CHART_TOKENS);
-  const series = useMemo(() => normalizeReturnSeries(market), [market]);
+  const universe = useMemo(() => returnUniverse(market, ticker), [market, ticker]);
+  const namesByTicker = useMemo(
+    () => new Map(universe.map((row) => [row.ticker, row.company_name])),
+    [universe],
+  );
+  const savedSeries = useMemo(
+    () => normalizeReturnSeriesFromPayload(market.return_comparison, namesByTicker),
+    [market.return_comparison, namesByTicker],
+  );
+  const remoteSeries = useMemo(
+    () => normalizeReturnSeriesFromPayload(remotePayload || undefined, namesByTicker),
+    [remotePayload, namesByTicker],
+  );
+  const series = savedSeries.length >= 2 ? savedSeries : remoteSeries;
+  const tickerList = useMemo(() => universe.map((row) => row.ticker), [universe]);
+
+  useEffect(() => {
+    if (savedSeries.length >= 2 || tickerList.length < 2) {
+      setLoadState(savedSeries.length >= 2 ? "ready" : "idle");
+      setLoadError("");
+      return;
+    }
+
+    const controller = new AbortController();
+    setLoadState("loading");
+    setLoadError("");
+    const qs = new URLSearchParams({ tickers: tickerList.join(",") });
+    fetch(`/api/dashboard/${encodeURIComponent(ticker.toUpperCase())}/market-returns?${qs.toString()}`, {
+      cache: "no-store",
+      signal: controller.signal,
+    })
+      .then(async (res) => {
+        if (!res.ok) throw new Error(`Market return lookup failed (${res.status})`);
+        return (await res.json()) as MarketReturnApiPayload;
+      })
+      .then((payload) => {
+        setRemotePayload(payload);
+        setLoadState("ready");
+        setLoadError(markdownText(payload.error));
+      })
+      .catch((err: Error) => {
+        if (err.name === "AbortError") return;
+        setRemotePayload(null);
+        setLoadState("error");
+        setLoadError(err.message || "Market return lookup failed.");
+      });
+    return () => controller.abort();
+  }, [savedSeries.length, ticker, tickerList]);
 
   const comparison = useMemo(() => {
     const latestDates = series
@@ -367,7 +446,7 @@ function MarketReturnComparison({ market }: { market: MarketReviewPayload }) {
     };
   }, [period, series]);
 
-  if (series.length < 2) return null;
+  if (universe.length < 2) return null;
 
   const colorForIndex = (idx: number) => {
     const key = `--chart-series-${(idx % 6) + 1}` as keyof typeof tokens;
@@ -413,36 +492,44 @@ function MarketReturnComparison({ market }: { market: MarketReviewPayload }) {
 
       <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_18rem]">
         <div className="hib-chart h-80 min-h-[18rem] min-w-0">
-          <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={260}>
-            <RechartsLineChart data={comparison.chartData} margin={{ top: 8, right: 16, bottom: 8, left: 0 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke={tokens["--chart-grid"]} />
-              <XAxis
-                dataKey="date"
-                minTickGap={28}
-                tick={{ fill: tokens["--chart-axis"], fontSize: 11 }}
-                tickFormatter={(value) => String(value).slice(5)}
-              />
-              <YAxis
-                width={56}
-                tick={{ fill: tokens["--chart-axis"], fontSize: 11 }}
-                tickFormatter={(value) => formatReturn(Number(value))}
-              />
-              <Tooltip content={<ReturnTooltip />} wrapperStyle={{ outline: "none" }} />
-              {comparison.activeSeries.map((item, idx) => (
-                <Line
-                  key={item.ticker}
-                  type="monotone"
-                  dataKey={item.ticker}
-                  name={item.ticker}
-                  stroke={colorForIndex(idx)}
-                  strokeWidth={2.2}
-                  dot={false}
-                  connectNulls
-                  isAnimationActive={false}
+          {series.length >= 2 ? (
+            <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={260}>
+              <RechartsLineChart data={comparison.chartData} margin={{ top: 8, right: 16, bottom: 8, left: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke={tokens["--chart-grid"]} />
+                <XAxis
+                  dataKey="date"
+                  minTickGap={28}
+                  tick={{ fill: tokens["--chart-axis"], fontSize: 11 }}
+                  tickFormatter={(value) => String(value).slice(5)}
                 />
-              ))}
-            </RechartsLineChart>
-          </ResponsiveContainer>
+                <YAxis
+                  width={56}
+                  tick={{ fill: tokens["--chart-axis"], fontSize: 11 }}
+                  tickFormatter={(value) => formatReturn(Number(value))}
+                />
+                <Tooltip content={<ReturnTooltip />} wrapperStyle={{ outline: "none" }} />
+                {comparison.activeSeries.map((item, idx) => (
+                  <Line
+                    key={item.ticker}
+                    type="monotone"
+                    dataKey={item.ticker}
+                    name={item.ticker}
+                    stroke={colorForIndex(idx)}
+                    strokeWidth={2.2}
+                    dot={false}
+                    connectNulls
+                    isAnimationActive={false}
+                  />
+                ))}
+              </RechartsLineChart>
+            </ResponsiveContainer>
+          ) : (
+            <div className="flex h-full min-h-[18rem] items-center justify-center rounded-xl border border-white/10 bg-black/25 p-4 text-center text-sm text-[color:var(--text-muted)]">
+              {loadState === "loading"
+                ? "Loading market return history..."
+                : loadError || "Return history is unavailable for this peer set."}
+            </div>
+          )}
         </div>
 
         <div className="hib-market-table-wrap">
@@ -455,7 +542,7 @@ function MarketReturnComparison({ market }: { market: MarketReviewPayload }) {
               </tr>
             </thead>
             <tbody>
-              {comparison.tableRows.map((row, idx) => (
+              {(comparison.tableRows.length ? comparison.tableRows : universe).map((row, idx) => (
                 <tr key={row.ticker}>
                   <td className="hib-market-table-cell font-mono text-xs">#{idx + 1}</td>
                   <td className="hib-market-table-cell">
@@ -743,7 +830,7 @@ export function MarketClient({ ticker, data, reportsForTicker, resolvedReportId 
       ) : null}
 
       <div className="grid gap-4">
-        <MarketReturnComparison market={market} />
+        <MarketReturnComparison market={market} ticker={ticker} />
         <PeerStrategyTable market={market} ticker={ticker} />
         <ProductOverlapTable market={market} />
         <FinancialScaleTable market={market} ticker={ticker} />

--- a/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
@@ -7,6 +7,7 @@ import {
   Store,
   TrendingUp,
 } from "lucide-react";
+import type { CSSProperties } from "react";
 import { useEffect, useMemo, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import type { Components } from "react-markdown";
@@ -574,8 +575,10 @@ function MarketReturnComparison({ market, ticker }: { market: MarketReviewPayloa
                     </td>
                     <td className="hib-market-table-cell min-w-0">
                       <span
-                        style={tickerColor ? { color: tickerColor } : undefined}
-                        className={`block truncate font-mono ${isPrimary ? "font-bold" : "font-semibold"}`}
+                        style={tickerColor ? ({ "--series-color": tickerColor } as CSSProperties) : undefined}
+                        className={`hib-series-label block truncate font-mono ${
+                          isPrimary ? "font-bold" : "font-semibold"
+                        }`}
                       >
                         {row.ticker}
                       </span>

--- a/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
@@ -462,6 +462,9 @@ function MarketReturnComparison({ market, ticker }: { market: MarketReviewPayloa
     const peerIndex = Math.max(0, idx - 1);
     return palette[peerIndex % palette.length] || tokens["--chart-axis"];
   };
+  const colorByTicker = new Map(
+    comparison.activeSeries.map((item, idx) => [item.ticker, colorForSeries(item.ticker, idx)]),
+  );
 
   return (
     <section className="min-w-0 overflow-hidden rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
@@ -559,6 +562,7 @@ function MarketReturnComparison({ market, ticker }: { market: MarketReviewPayloa
             <tbody>
               {(comparison.tableRows.length ? comparison.tableRows : universe).map((row, idx) => {
                 const isPrimary = row.ticker === primaryTicker;
+                const tickerColor = colorByTicker.get(row.ticker);
                 return (
                   <tr key={row.ticker} className={isPrimary ? "bg-black/25" : undefined}>
                     <td
@@ -570,9 +574,8 @@ function MarketReturnComparison({ market, ticker }: { market: MarketReviewPayloa
                     </td>
                     <td className="hib-market-table-cell min-w-0">
                       <span
-                        className={`block truncate font-mono ${
-                          isPrimary ? "font-bold text-[color:var(--accent)]" : "font-semibold"
-                        }`}
+                        style={tickerColor ? { color: tickerColor } : undefined}
+                        className={`block truncate font-mono ${isPrimary ? "font-bold" : "font-semibold"}`}
                       >
                         {row.ticker}
                       </span>

--- a/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
@@ -7,12 +7,23 @@ import {
   Store,
   TrendingUp,
 } from "lucide-react";
+import { useMemo, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import type { Components } from "react-markdown";
+import {
+  CartesianGrid,
+  Line,
+  LineChart as RechartsLineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
 import remarkGfm from "remark-gfm";
 
 import { ReportChipRow } from "@/components/dashboard-chrome";
 import type { DashboardPayload, MarketReviewPayload, ReportListItem } from "@/lib/dashboard-types";
+import { useThemeTokens } from "@/lib/theme-tokens";
 
 type MarketClientProps = {
   ticker: string;
@@ -20,6 +31,29 @@ type MarketClientProps = {
   reportsForTicker: ReportListItem[];
   resolvedReportId: string;
 };
+
+const RETURN_PERIODS = [
+  { key: "1D", label: "1D", days: 1 },
+  { key: "1W", label: "1W", days: 7 },
+  { key: "1M", label: "1M", days: 30 },
+  { key: "3M", label: "3M", days: 90 },
+  { key: "6M", label: "6M", days: 182 },
+  { key: "YTD", label: "YTD", days: null },
+  { key: "1Y", label: "1Y", days: 365 },
+  { key: "3Y", label: "3Y", days: 365 * 3 },
+  { key: "5Y", label: "5Y", days: 365 * 5 },
+] as const;
+
+const RETURN_CHART_TOKENS = [
+  "--chart-grid",
+  "--chart-axis",
+  "--chart-series-1",
+  "--chart-series-2",
+  "--chart-series-3",
+  "--chart-series-4",
+  "--chart-series-5",
+  "--chart-series-6",
+] as const;
 
 function markdownText(value: unknown): string {
   return String(value || "").trim();
@@ -51,6 +85,19 @@ function formatMultiple(value: unknown): string {
   const n = numeric(value);
   if (n === null || n <= 0) return "-";
   return `${n.toFixed(1)}x`;
+}
+
+function formatReturn(value: number | null): string {
+  if (value === null || !Number.isFinite(value)) return "-";
+  const sign = value > 0 ? "+" : "";
+  return `${sign}${value.toFixed(1)}%`;
+}
+
+function returnTone(value: number | null): string {
+  if (value === null) return "text-[color:var(--text-muted)]";
+  if (value > 0) return "text-[color:var(--success)]";
+  if (value < 0) return "text-[color:var(--danger)]";
+  return "text-[color:var(--text-secondary)]";
 }
 
 function formatResemblance(value: unknown): string {
@@ -173,6 +220,258 @@ function CompanyCell({ row }: { row: ComparisonRow }) {
       <span className="font-mono font-semibold">{row.ticker || "-"}</span>
       <span className="block text-[color:var(--text-muted)]">{row.company_name || "Unnamed company"}</span>
     </td>
+  );
+}
+
+type PricePoint = {
+  date: string;
+  close: number;
+};
+
+type ReturnSeries = {
+  ticker: string;
+  company_name: string;
+  prices: PricePoint[];
+};
+
+type ReturnTableRow = {
+  ticker: string;
+  company_name: string;
+  returnPct: number | null;
+  latestClose: number | null;
+};
+
+function parseDate(value: string): Date | null {
+  const date = new Date(`${value}T00:00:00`);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function normalizeReturnSeries(market: MarketReviewPayload): ReturnSeries[] {
+  const raw = market.return_comparison?.series;
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((series) => {
+      const prices = Array.isArray(series.prices)
+        ? series.prices
+            .map((point) => {
+              const close = numeric(point.close);
+              const date = markdownText(point.date);
+              return close !== null && close > 0 && date ? { date, close } : null;
+            })
+            .filter((point): point is PricePoint => Boolean(point))
+            .sort((a, b) => a.date.localeCompare(b.date))
+        : [];
+      return {
+        ticker: markdownText(series.ticker).toUpperCase(),
+        company_name: markdownText(series.company_name),
+        prices,
+      };
+    })
+    .filter((series) => series.ticker && series.prices.length >= 2);
+}
+
+function periodStartDate(periodKey: string, latestDate: Date): Date {
+  if (periodKey === "YTD") return new Date(latestDate.getFullYear(), 0, 1);
+  const option = RETURN_PERIODS.find((item) => item.key === periodKey);
+  const days = option?.days ?? 365;
+  const start = new Date(latestDate);
+  start.setDate(start.getDate() - days);
+  return start;
+}
+
+function slicePricesForPeriod(prices: PricePoint[], start: Date): PricePoint[] {
+  const filtered = prices.filter((point) => {
+    const date = parseDate(point.date);
+    return date ? date >= start : false;
+  });
+  if (filtered.length >= 2) return filtered;
+  return prices.slice(-2);
+}
+
+function ReturnTooltip({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean;
+  payload?: Array<{ name?: string; value?: number; color?: string }>;
+  label?: string;
+}) {
+  if (!active || !payload?.length) return null;
+  return (
+    <div className="hib-chart-tooltip rounded-lg border border-white/15 bg-zinc-950/95 px-3 py-2 shadow-xl">
+      <p className="mb-1 text-xs font-semibold tracking-[0.08em] text-[color:var(--text-primary)]">{label}</p>
+      <div className="grid gap-1">
+        {payload
+          .filter((item) => typeof item.value === "number" && Number.isFinite(item.value))
+          .sort((a, b) => Number(b.value) - Number(a.value))
+          .map((item) => (
+            <p key={item.name} className="flex min-w-36 items-center justify-between gap-3 text-xs">
+              <span className="font-mono" style={{ color: item.color }}>
+                {item.name}
+              </span>
+              <span className="font-semibold text-[color:var(--text-secondary)]">{formatReturn(Number(item.value))}</span>
+            </p>
+          ))}
+      </div>
+    </div>
+  );
+}
+
+function MarketReturnComparison({ market }: { market: MarketReviewPayload }) {
+  const [period, setPeriod] = useState<(typeof RETURN_PERIODS)[number]["key"]>("1Y");
+  const tokens = useThemeTokens(RETURN_CHART_TOKENS);
+  const series = useMemo(() => normalizeReturnSeries(market), [market]);
+
+  const comparison = useMemo(() => {
+    const latestDates = series
+      .flatMap((item) => item.prices.map((point) => parseDate(point.date)))
+      .filter((date): date is Date => Boolean(date))
+      .sort((a, b) => b.getTime() - a.getTime());
+    const latestDate = latestDates[0];
+    if (!latestDate) return { chartData: [], tableRows: [], activeSeries: [] };
+    const start = periodStartDate(period, latestDate);
+    const dateMap = new Map<string, Record<string, string | number>>();
+    const tableRows: ReturnTableRow[] = [];
+    const activeSeries: ReturnSeries[] = [];
+
+    for (const item of series) {
+      const prices = slicePricesForPeriod(item.prices, start);
+      const base = prices[0]?.close;
+      const latest = prices[prices.length - 1]?.close;
+      const returnPct = base && latest ? (latest / base - 1) * 100 : null;
+      tableRows.push({
+        ticker: item.ticker,
+        company_name: item.company_name,
+        returnPct,
+        latestClose: latest ?? null,
+      });
+      if (!base || prices.length < 2) continue;
+      activeSeries.push(item);
+      for (const point of prices) {
+        const row = dateMap.get(point.date) || { date: point.date };
+        row[item.ticker] = (point.close / base - 1) * 100;
+        dateMap.set(point.date, row);
+      }
+    }
+
+    return {
+      chartData: Array.from(dateMap.values()).sort((a, b) => String(a.date).localeCompare(String(b.date))),
+      tableRows: tableRows.sort((a, b) => {
+        if (a.returnPct === null && b.returnPct === null) return a.ticker.localeCompare(b.ticker);
+        if (a.returnPct === null) return 1;
+        if (b.returnPct === null) return -1;
+        return b.returnPct - a.returnPct;
+      }),
+      activeSeries,
+    };
+  }, [period, series]);
+
+  if (series.length < 2) return null;
+
+  const colorForIndex = (idx: number) => {
+    const key = `--chart-series-${(idx % 6) + 1}` as keyof typeof tokens;
+    return tokens[key] || tokens["--chart-axis"];
+  };
+
+  return (
+    <section className="min-w-0 overflow-hidden rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
+      <div className="mb-3 flex min-w-0 flex-wrap items-start justify-between gap-3">
+        <div className="flex min-w-0 items-start gap-3">
+          <div className="shrink-0 rounded-xl border border-white/10 bg-black/25 p-2 text-[color:var(--accent)]">
+            <TrendingUp size={18} />
+          </div>
+          <div className="min-w-0">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[color:var(--text-muted)]">
+              Return Comparison
+            </p>
+            <h2 className="break-words font-display text-lg text-[color:var(--text-primary)]">
+              Market Peer Performance
+            </h2>
+          </div>
+        </div>
+        <div className="flex max-w-full flex-wrap gap-1">
+          {RETURN_PERIODS.map((option) => {
+            const active = option.key === period;
+            return (
+              <button
+                key={option.key}
+                type="button"
+                onClick={() => setPeriod(option.key)}
+                className={`rounded-lg border px-2.5 py-1 text-xs font-semibold transition ${
+                  active
+                    ? "border-[color:var(--accent)] bg-[color:var(--accent)] text-[color:var(--text-on-accent)]"
+                    : "border-white/10 bg-black/25 text-[color:var(--text-secondary)] hover:border-[color:var(--border-strong)] hover:text-[color:var(--text-primary)]"
+                }`}
+              >
+                {option.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_18rem]">
+        <div className="hib-chart h-80 min-h-[18rem] min-w-0">
+          <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={260}>
+            <RechartsLineChart data={comparison.chartData} margin={{ top: 8, right: 16, bottom: 8, left: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke={tokens["--chart-grid"]} />
+              <XAxis
+                dataKey="date"
+                minTickGap={28}
+                tick={{ fill: tokens["--chart-axis"], fontSize: 11 }}
+                tickFormatter={(value) => String(value).slice(5)}
+              />
+              <YAxis
+                width={56}
+                tick={{ fill: tokens["--chart-axis"], fontSize: 11 }}
+                tickFormatter={(value) => formatReturn(Number(value))}
+              />
+              <Tooltip content={<ReturnTooltip />} wrapperStyle={{ outline: "none" }} />
+              {comparison.activeSeries.map((item, idx) => (
+                <Line
+                  key={item.ticker}
+                  type="monotone"
+                  dataKey={item.ticker}
+                  name={item.ticker}
+                  stroke={colorForIndex(idx)}
+                  strokeWidth={2.2}
+                  dot={false}
+                  connectNulls
+                  isAnimationActive={false}
+                />
+              ))}
+            </RechartsLineChart>
+          </ResponsiveContainer>
+        </div>
+
+        <div className="hib-market-table-wrap">
+          <table className="hib-market-table min-w-[18rem]">
+            <thead>
+              <tr>
+                <th className="hib-market-table-head">Rank</th>
+                <th className="hib-market-table-head">Ticker</th>
+                <th className="hib-market-table-head">Return</th>
+              </tr>
+            </thead>
+            <tbody>
+              {comparison.tableRows.map((row, idx) => (
+                <tr key={row.ticker}>
+                  <td className="hib-market-table-cell font-mono text-xs">#{idx + 1}</td>
+                  <td className="hib-market-table-cell">
+                    <span className="font-mono font-semibold">{row.ticker}</span>
+                    <span className="block text-[color:var(--text-muted)]">{row.company_name || "Company"}</span>
+                  </td>
+                  <td className={`hib-market-table-cell font-mono font-semibold ${returnTone(row.returnPct)}`}>
+                    {formatReturn(row.returnPct)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
   );
 }
 
@@ -444,6 +743,7 @@ export function MarketClient({ ticker, data, reportsForTicker, resolvedReportId 
       ) : null}
 
       <div className="grid gap-4">
+        <MarketReturnComparison market={market} />
         <PeerStrategyTable market={market} ticker={ticker} />
         <ProductOverlapTable market={market} />
         <FinancialScaleTable market={market} ticker={ticker} />

--- a/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
@@ -47,6 +47,7 @@ const RETURN_PERIODS = [
 const RETURN_CHART_TOKENS = [
   "--chart-grid",
   "--chart-axis",
+  "--chart-current",
   "--chart-series-1",
   "--chart-series-2",
   "--chart-series-3",
@@ -368,6 +369,7 @@ function MarketReturnComparison({ market, ticker }: { market: MarketReviewPayloa
   );
   const series = savedSeries.length >= 2 ? savedSeries : remoteSeries;
   const tickerList = useMemo(() => universe.map((row) => row.ticker), [universe]);
+  const primaryTicker = universe[0]?.ticker || ticker.toUpperCase();
 
   useEffect(() => {
     if (savedSeries.length >= 2 || tickerList.length < 2) {
@@ -448,7 +450,8 @@ function MarketReturnComparison({ market, ticker }: { market: MarketReviewPayloa
 
   if (universe.length < 2) return null;
 
-  const colorForIndex = (idx: number) => {
+  const colorForSeries = (seriesTicker: string, idx: number) => {
+    if (seriesTicker === primaryTicker) return tokens["--chart-current"] || tokens["--chart-series-3"];
     const key = `--chart-series-${(idx % 6) + 1}` as keyof typeof tokens;
     return tokens[key] || tokens["--chart-axis"];
   };
@@ -490,7 +493,7 @@ function MarketReturnComparison({ market, ticker }: { market: MarketReviewPayloa
         </div>
       </div>
 
-      <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_18rem]">
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_14rem]">
         <div className="hib-chart h-80 min-h-[18rem] min-w-0">
           {series.length >= 2 ? (
             <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={260}>
@@ -514,8 +517,8 @@ function MarketReturnComparison({ market, ticker }: { market: MarketReviewPayloa
                     type="monotone"
                     dataKey={item.ticker}
                     name={item.ticker}
-                    stroke={colorForIndex(idx)}
-                    strokeWidth={2.2}
+                    stroke={colorForSeries(item.ticker, idx)}
+                    strokeWidth={item.ticker === primaryTicker ? 3.2 : 2}
                     dot={false}
                     connectNulls
                     isAnimationActive={false}
@@ -533,7 +536,12 @@ function MarketReturnComparison({ market, ticker }: { market: MarketReviewPayloa
         </div>
 
         <div className="hib-market-table-wrap">
-          <table className="hib-market-table min-w-[18rem]">
+          <table className="hib-market-table min-w-[14rem] table-fixed">
+            <colgroup>
+              <col className="w-[3rem]" />
+              <col className="w-[7rem]" />
+              <col className="w-[4rem]" />
+            </colgroup>
             <thead>
               <tr>
                 <th className="hib-market-table-head">Rank</th>
@@ -542,18 +550,43 @@ function MarketReturnComparison({ market, ticker }: { market: MarketReviewPayloa
               </tr>
             </thead>
             <tbody>
-              {(comparison.tableRows.length ? comparison.tableRows : universe).map((row, idx) => (
-                <tr key={row.ticker}>
-                  <td className="hib-market-table-cell font-mono text-xs">#{idx + 1}</td>
-                  <td className="hib-market-table-cell">
-                    <span className="font-mono font-semibold">{row.ticker}</span>
-                    <span className="block text-[color:var(--text-muted)]">{row.company_name || "Company"}</span>
-                  </td>
-                  <td className={`hib-market-table-cell font-mono font-semibold ${returnTone(row.returnPct)}`}>
-                    {formatReturn(row.returnPct)}
-                  </td>
-                </tr>
-              ))}
+              {(comparison.tableRows.length ? comparison.tableRows : universe).map((row, idx) => {
+                const isPrimary = row.ticker === primaryTicker;
+                return (
+                  <tr key={row.ticker} className={isPrimary ? "bg-black/25" : undefined}>
+                    <td
+                      className={`hib-market-table-cell font-mono text-xs ${
+                        isPrimary ? "font-bold text-[color:var(--accent)]" : ""
+                      }`}
+                    >
+                      #{idx + 1}
+                    </td>
+                    <td className="hib-market-table-cell min-w-0">
+                      <span
+                        className={`block truncate font-mono ${
+                          isPrimary ? "font-bold text-[color:var(--accent)]" : "font-semibold"
+                        }`}
+                      >
+                        {row.ticker}
+                      </span>
+                      <span
+                        className={`block truncate text-[color:var(--text-muted)] ${
+                          isPrimary ? "font-semibold text-[color:var(--text-secondary)]" : ""
+                        }`}
+                      >
+                        {row.company_name || "Company"}
+                      </span>
+                    </td>
+                    <td
+                      className={`hib-market-table-cell whitespace-nowrap font-mono ${
+                        isPrimary ? "font-bold" : "font-semibold"
+                      } ${returnTone(row.returnPct)}`}
+                    >
+                      {formatReturn(row.returnPct)}
+                    </td>
+                  </tr>
+                );
+              })}
             </tbody>
           </table>
         </div>

--- a/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
@@ -459,7 +459,8 @@ function MarketReturnComparison({ market, ticker }: { market: MarketReviewPayloa
       tokens["--chart-series-6"],
       tokens["--chart-series-1"],
     ].filter(Boolean);
-    return palette[idx % palette.length] || tokens["--chart-axis"];
+    const peerIndex = Math.max(0, idx - 1);
+    return palette[peerIndex % palette.length] || tokens["--chart-axis"];
   };
 
   return (
@@ -586,9 +587,9 @@ function MarketReturnComparison({ market, ticker }: { market: MarketReviewPayloa
                     <td
                       className={`hib-market-table-cell whitespace-nowrap font-mono ${
                         isPrimary ? "font-bold" : "font-semibold"
-                      } ${returnTone(row.returnPct)}`}
+                      }`}
                     >
-                      {formatReturn(row.returnPct)}
+                      <span className={returnTone(row.returnPct)}>{formatReturn(row.returnPct)}</span>
                     </td>
                   </tr>
                 );

--- a/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
@@ -50,6 +50,7 @@ const RETURN_CHART_TOKENS = [
   "--chart-current",
   "--chart-series-1",
   "--chart-series-2",
+  "--chart-series-3",
   "--chart-series-4",
   "--chart-series-6",
   "--chart-bear",
@@ -450,12 +451,12 @@ function MarketReturnComparison({ market, ticker }: { market: MarketReviewPayloa
   if (universe.length < 2) return null;
 
   const colorForSeries = (seriesTicker: string, idx: number) => {
-    if (seriesTicker === primaryTicker) return tokens["--chart-current"] || tokens["--chart-axis"];
+    if (seriesTicker === primaryTicker) return tokens["--chart-series-4"] || tokens["--chart-axis"];
     const palette = [
       tokens["--chart-series-2"],
-      tokens["--chart-series-4"],
-      tokens["--chart-series-6"],
+      tokens["--chart-series-3"],
       tokens["--chart-bear"],
+      tokens["--chart-series-6"],
       tokens["--chart-series-1"],
     ].filter(Boolean);
     return palette[idx % palette.length] || tokens["--chart-axis"];
@@ -498,7 +499,7 @@ function MarketReturnComparison({ market, ticker }: { market: MarketReviewPayloa
         </div>
       </div>
 
-      <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_14rem]">
+      <div className="grid gap-4">
         <div className="hib-chart h-80 min-h-[18rem] min-w-0">
           {series.length >= 2 ? (
             <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={260}>
@@ -541,11 +542,11 @@ function MarketReturnComparison({ market, ticker }: { market: MarketReviewPayloa
         </div>
 
         <div className="hib-market-table-wrap">
-          <table className="hib-market-table min-w-[14rem] table-fixed">
+          <table className="hib-market-table min-w-[34rem] table-fixed">
             <colgroup>
-              <col className="w-[3rem]" />
-              <col className="w-[7rem]" />
-              <col className="w-[4rem]" />
+              <col className="w-[5rem]" />
+              <col className="w-[20rem]" />
+              <col className="w-[9rem]" />
             </colgroup>
             <thead>
               <tr>

--- a/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
@@ -50,10 +50,9 @@ const RETURN_CHART_TOKENS = [
   "--chart-current",
   "--chart-series-1",
   "--chart-series-2",
-  "--chart-series-3",
   "--chart-series-4",
-  "--chart-series-5",
   "--chart-series-6",
+  "--chart-bear",
 ] as const;
 
 function markdownText(value: unknown): string {
@@ -451,9 +450,15 @@ function MarketReturnComparison({ market, ticker }: { market: MarketReviewPayloa
   if (universe.length < 2) return null;
 
   const colorForSeries = (seriesTicker: string, idx: number) => {
-    if (seriesTicker === primaryTicker) return tokens["--chart-current"] || tokens["--chart-series-3"];
-    const key = `--chart-series-${(idx % 6) + 1}` as keyof typeof tokens;
-    return tokens[key] || tokens["--chart-axis"];
+    if (seriesTicker === primaryTicker) return tokens["--chart-current"] || tokens["--chart-axis"];
+    const palette = [
+      tokens["--chart-series-2"],
+      tokens["--chart-series-4"],
+      tokens["--chart-series-6"],
+      tokens["--chart-bear"],
+      tokens["--chart-series-1"],
+    ].filter(Boolean);
+    return palette[idx % palette.length] || tokens["--chart-axis"];
   };
 
   return (

--- a/frontend/src/app/api/compare/route.ts
+++ b/frontend/src/app/api/compare/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from "next/server";
+
+import { yahooChartHistory } from "@/lib/yahoo-lookup";
+
+const TICKER_RE = /^[A-Z0-9.\-]{1,16}$/;
+const MAX_TICKERS = 10;
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function normalizeTickers(raw: string | null): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const item of (raw || "").split(",")) {
+    const ticker = item.trim().toUpperCase();
+    if (!ticker || seen.has(ticker) || !TICKER_RE.test(ticker)) continue;
+    seen.add(ticker);
+    out.push(ticker);
+    if (out.length >= MAX_TICKERS) break;
+  }
+  return out;
+}
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const tickers = normalizeTickers(url.searchParams.get("tickers"));
+  if (!tickers.length) {
+    return NextResponse.json({ status: "unavailable", series: [], not_found: [], error: "Add at least one ticker." });
+  }
+
+  const settled = await Promise.all(
+    tickers.map(async (ticker) => {
+      const result = await yahooChartHistory(ticker, "5y");
+      if (result.prices.length < 2) return { ticker, ok: false as const };
+      return {
+        ticker,
+        ok: true as const,
+        company_name: result.meta.longName || result.meta.shortName || ticker,
+        exchange: result.meta.fullExchangeName || result.meta.exchangeName || "",
+        currency: result.meta.currency || "",
+        current_price: result.meta.regularMarketPrice ?? result.prices[result.prices.length - 1]?.close ?? null,
+        volume: result.meta.regularMarketVolume ?? null,
+        fifty_two_week_high: result.meta.fiftyTwoWeekHigh ?? null,
+        fifty_two_week_low: result.meta.fiftyTwoWeekLow ?? null,
+        prices: result.prices,
+      };
+    }),
+  );
+
+  const series = settled.filter((row): row is Extract<(typeof settled)[number], { ok: true }> => row.ok);
+  const notFound = settled.filter((row) => !row.ok).map((row) => row.ticker);
+
+  return NextResponse.json({
+    status: series.length ? "success" : "unavailable",
+    generated_at: new Date().toISOString(),
+    series,
+    not_found: notFound,
+    error: series.length ? "" : "We tried Yahoo, shook the data tree, and nothing tradable fell out.",
+  });
+}

--- a/frontend/src/app/api/compare/route.ts
+++ b/frontend/src/app/api/compare/route.ts
@@ -1,4 +1,6 @@
 import { NextResponse } from "next/server";
+import { spawn } from "node:child_process";
+import path from "node:path";
 
 import { yahooChartHistory } from "@/lib/yahoo-lookup";
 
@@ -7,6 +9,34 @@ const MAX_TICKERS = 10;
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
+
+type FundamentalRow = {
+  ticker?: string;
+  symbol?: string;
+  company_name?: string;
+  market_cap?: number | null;
+  enterprise_value?: number | null;
+  net_cash_debt?: number | null;
+  trailing_pe?: number | null;
+  forward_pe?: number | null;
+  ev_sales?: number | null;
+  ev_ebitda?: number | null;
+  p_fcf?: number | null;
+  revenue_growth?: number | null;
+  earnings_growth?: number | null;
+  gross_margin?: number | null;
+  operating_margin?: number | null;
+  profit_margin?: number | null;
+  roe?: number | null;
+  current_ratio?: number | null;
+  debt_to_equity?: number | null;
+  dividend_yield?: number | null;
+  target_upside?: number | null;
+};
+
+function repoRoot(): string {
+  return path.resolve(process.cwd(), "..");
+}
 
 function normalizeTickers(raw: string | null): string[] {
   const seen = new Set<string>();
@@ -21,6 +51,48 @@ function normalizeTickers(raw: string | null): string[] {
   return out;
 }
 
+function runFundamentalsScript(tickers: string[]): Promise<{ rows: FundamentalRow[]; not_found: string[] }> {
+  return new Promise((resolve) => {
+    if (!tickers.length) {
+      resolve({ rows: [], not_found: [] });
+      return;
+    }
+
+    const root = repoRoot();
+    const scriptPath = path.resolve(root, "scripts", "compare_stock_info.py");
+    const pythonExe = process.env.PYTHON_EXECUTABLE || "python";
+    const child = spawn(pythonExe, [scriptPath, "--tickers", tickers.join(","), "--workers", "6"], {
+      cwd: root,
+      env: {
+        ...process.env,
+        PYTHONUNBUFFERED: "1",
+        PYTHONPATH: path.resolve(root, "src"),
+      },
+    });
+
+    let stdout = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+    });
+    child.on("error", () => resolve({ rows: [], not_found: [] }));
+    child.on("close", (code) => {
+      if (code !== 0) {
+        resolve({ rows: [], not_found: [] });
+        return;
+      }
+      try {
+        const parsed = JSON.parse(stdout) as { rows?: FundamentalRow[]; not_found?: string[] };
+        resolve({
+          rows: Array.isArray(parsed.rows) ? parsed.rows : [],
+          not_found: Array.isArray(parsed.not_found) ? parsed.not_found.map((t) => String(t).toUpperCase()) : [],
+        });
+      } catch {
+        resolve({ rows: [], not_found: [] });
+      }
+    });
+  });
+}
+
 export async function GET(req: Request) {
   const url = new URL(req.url);
   const tickers = normalizeTickers(url.searchParams.get("tickers"));
@@ -28,8 +100,9 @@ export async function GET(req: Request) {
     return NextResponse.json({ status: "unavailable", series: [], not_found: [], error: "Add at least one ticker." });
   }
 
-  const settled = await Promise.all(
-    tickers.map(async (ticker) => {
+  const [fundamentals, settled] = await Promise.all([
+    runFundamentalsScript(tickers),
+    Promise.all(tickers.map(async (ticker) => {
       const result = await yahooChartHistory(ticker, "5y");
       if (result.prices.length < 2) return { ticker, ok: false as const };
       return {
@@ -44,11 +117,23 @@ export async function GET(req: Request) {
         fifty_two_week_low: result.meta.fiftyTwoWeekLow ?? null,
         prices: result.prices,
       };
-    }),
+    })),
+  ]);
+
+  const fundamentalsByTicker = new Map(
+    fundamentals.rows.map((row) => [String(row.ticker || row.symbol || "").toUpperCase(), row]),
   );
 
-  const series = settled.filter((row): row is Extract<(typeof settled)[number], { ok: true }> => row.ok);
-  const notFound = settled.filter((row) => !row.ok).map((row) => row.ticker);
+  const series = settled
+    .filter((row): row is Extract<(typeof settled)[number], { ok: true }> => row.ok)
+    .map((row) => ({
+      ...row,
+      fundamentals: fundamentalsByTicker.get(row.ticker) || null,
+    }));
+  const chartNotFound = settled.filter((row) => !row.ok).map((row) => row.ticker);
+  const notFound = Array.from(new Set([...chartNotFound, ...fundamentals.not_found])).filter(
+    (ticker) => !series.some((row) => row.ticker === ticker),
+  );
 
   return NextResponse.json({
     status: series.length ? "success" : "unavailable",

--- a/frontend/src/app/api/compare/route.ts
+++ b/frontend/src/app/api/compare/route.ts
@@ -32,6 +32,7 @@ type FundamentalRow = {
   debt_to_equity?: number | null;
   dividend_yield?: number | null;
   target_upside?: number | null;
+  financials_copy?: unknown;
 };
 
 function repoRoot(): string {
@@ -51,7 +52,10 @@ function normalizeTickers(raw: string | null): string[] {
   return out;
 }
 
-function runFundamentalsScript(tickers: string[]): Promise<{ rows: FundamentalRow[]; not_found: string[] }> {
+function runFundamentalsScript(
+  tickers: string[],
+  includeFinancials: boolean,
+): Promise<{ rows: FundamentalRow[]; not_found: string[] }> {
   return new Promise((resolve) => {
     if (!tickers.length) {
       resolve({ rows: [], not_found: [] });
@@ -61,7 +65,9 @@ function runFundamentalsScript(tickers: string[]): Promise<{ rows: FundamentalRo
     const root = repoRoot();
     const scriptPath = path.resolve(root, "scripts", "compare_stock_info.py");
     const pythonExe = process.env.PYTHON_EXECUTABLE || "python";
-    const child = spawn(pythonExe, [scriptPath, "--tickers", tickers.join(","), "--workers", "6"], {
+    const args = [scriptPath, "--tickers", tickers.join(","), "--workers", "6"];
+    if (includeFinancials) args.push("--include-financials");
+    const child = spawn(pythonExe, args, {
       cwd: root,
       env: {
         ...process.env,
@@ -96,12 +102,15 @@ function runFundamentalsScript(tickers: string[]): Promise<{ rows: FundamentalRo
 export async function GET(req: Request) {
   const url = new URL(req.url);
   const tickers = normalizeTickers(url.searchParams.get("tickers"));
+  const includeFinancials = ["1", "true", "yes"].includes(
+    String(url.searchParams.get("financials") || "").toLowerCase(),
+  );
   if (!tickers.length) {
     return NextResponse.json({ status: "unavailable", series: [], not_found: [], error: "Add at least one ticker." });
   }
 
   const [fundamentals, settled] = await Promise.all([
-    runFundamentalsScript(tickers),
+    runFundamentalsScript(tickers, includeFinancials),
     Promise.all(tickers.map(async (ticker) => {
       const result = await yahooChartHistory(ticker, "5y");
       if (result.prices.length < 2) return { ticker, ok: false as const };
@@ -134,12 +143,25 @@ export async function GET(req: Request) {
   const notFound = Array.from(new Set([...chartNotFound, ...fundamentals.not_found])).filter(
     (ticker) => !series.some((row) => row.ticker === ticker),
   );
+  const financialsCopy = includeFinancials
+    ? {
+        generated_at: new Date().toISOString(),
+        tickers,
+        data: Object.fromEntries(
+          fundamentals.rows
+            .map((row) => [String(row.ticker || row.symbol || "").toUpperCase(), row.financials_copy] as const)
+            .filter(([ticker, payload]) => ticker && payload),
+        ),
+        not_found: notFound,
+      }
+    : undefined;
 
   return NextResponse.json({
     status: series.length ? "success" : "unavailable",
     generated_at: new Date().toISOString(),
     series,
     not_found: notFound,
+    ...(financialsCopy ? { financials: financialsCopy } : {}),
     error: series.length ? "" : "We tried Yahoo, shook the data tree, and nothing tradable fell out.",
   });
 }

--- a/frontend/src/app/api/dashboard/[ticker]/market-returns/route.ts
+++ b/frontend/src/app/api/dashboard/[ticker]/market-returns/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+
+import { yahooPriceHistory } from "@/lib/yahoo-lookup";
+
+const TICKER_RE = /^[A-Z0-9.\-]{1,16}$/;
+const MAX_TICKERS = 6;
+
+export const runtime = "nodejs";
+
+function normalizeTickers(primary: string, raw: string | null): string[] {
+  const seen = new Set<string>();
+  const candidates = [primary, ...(raw || "").split(",")];
+  const out: string[] = [];
+  for (const candidate of candidates) {
+    const ticker = String(candidate || "").trim().toUpperCase();
+    if (!ticker || seen.has(ticker) || !TICKER_RE.test(ticker)) continue;
+    seen.add(ticker);
+    out.push(ticker);
+    if (out.length >= MAX_TICKERS) break;
+  }
+  return out;
+}
+
+export async function GET(req: Request, context: { params: Promise<{ ticker: string }> }) {
+  const { ticker } = await context.params;
+  const url = new URL(req.url);
+  const tickers = normalizeTickers(ticker, url.searchParams.get("tickers"));
+  if (tickers.length < 2) {
+    return NextResponse.json({ status: "unavailable", series: [], error: "At least two valid tickers are required." });
+  }
+
+  const settled = await Promise.all(
+    tickers.map(async (tk) => {
+      const prices = await yahooPriceHistory(tk, "5y");
+      return prices.length >= 2 ? { ticker: tk, prices } : null;
+    }),
+  );
+  const series = settled.filter((item): item is { ticker: string; prices: Awaited<ReturnType<typeof yahooPriceHistory>> } =>
+    Boolean(item),
+  );
+
+  return NextResponse.json({
+    status: series.length >= 2 ? "success" : "unavailable",
+    generated_at: new Date().toISOString(),
+    period: "5y",
+    series,
+    error: series.length >= 2 ? "" : "Yahoo price history was unavailable for enough market tickers.",
+  });
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -780,6 +780,9 @@ html[data-theme="light"] .hib-bear-prob-value {
   border-bottom: 1px solid var(--border-subtle);
   color: var(--text-primary);
 }
+.hib-series-label {
+  color: var(--series-color, var(--text-primary)) !important;
+}
 .hib-market-table tbody tr:last-child .hib-market-table-cell {
   border-bottom: 0;
 }

--- a/frontend/src/components/shell/sidebar.tsx
+++ b/frontend/src/components/shell/sidebar.tsx
@@ -8,6 +8,7 @@ import {
   ChevronRight,
   Compass,
   FileText,
+  GitCompareArrows,
   Target,
   Plus,
 } from "lucide-react";
@@ -28,6 +29,7 @@ type NavItem = {
 
 const GLOBAL_NAV: NavItem[] = [
   { href: "/reports", label: "Reports", icon: FileText },
+  { href: "/compare", label: "Compare", icon: GitCompareArrows },
   { href: "/discovery", label: "Discovery", icon: Compass },
   { href: "/hit-rate", label: "Hit Rate", icon: Target },
 ];

--- a/frontend/src/lib/dashboard-types.ts
+++ b/frontend/src/lib/dashboard-types.ts
@@ -85,6 +85,20 @@ export type MarketReviewPayload = {
     status?: string;
     error?: string;
   }>;
+  return_comparison?: {
+    status?: string;
+    generated_at?: string;
+    period?: string;
+    series?: Array<{
+      ticker?: string;
+      company_name?: string;
+      prices?: Array<{
+        date?: string;
+        close?: number;
+      }>;
+    }>;
+    error?: string;
+  };
   review_markdown?: string;
   market_agent_markdown?: string;
   error?: string;

--- a/frontend/src/lib/yahoo-lookup.ts
+++ b/frontend/src/lib/yahoo-lookup.ts
@@ -108,17 +108,37 @@ export type YahooPricePoint = {
   close: number;
 };
 
-export async function yahooPriceHistory(ticker: string, range = "5y", timeoutMs = 6000): Promise<YahooPricePoint[]> {
+export type YahooChartMeta = {
+  symbol?: string;
+  shortName?: string;
+  longName?: string;
+  currency?: string;
+  exchangeName?: string;
+  fullExchangeName?: string;
+  instrumentType?: string;
+  regularMarketPrice?: number;
+  regularMarketVolume?: number;
+  fiftyTwoWeekHigh?: number;
+  fiftyTwoWeekLow?: number;
+};
+
+export type YahooChartResult = {
+  meta: YahooChartMeta;
+  prices: YahooPricePoint[];
+};
+
+export async function yahooChartHistory(ticker: string, range = "5y", timeoutMs = 6000): Promise<YahooChartResult> {
   const sym = ticker.trim().toUpperCase();
-  if (!sym) return [];
+  if (!sym) return { meta: {}, prices: [] };
   const yahooSym = toYahooSymbol(sym);
   const url = `${CHART_URL}/${encodeURIComponent(yahooSym)}?range=${encodeURIComponent(range)}&interval=1d`;
   try {
     const res = await fetchWithTimeout(url, timeoutMs);
-    if (!res.ok) return [];
+    if (!res.ok) return { meta: {}, prices: [] };
     const json = (await res.json()) as {
       chart?: {
         result?: Array<{
+          meta?: YahooChartMeta;
           timestamp?: number[];
           indicators?: {
             quote?: Array<{
@@ -141,11 +161,15 @@ export async function yahooPriceHistory(ticker: string, range = "5y", timeoutMs 
         close,
       });
     }
-    return rows;
+    return { meta: result?.meta || {}, prices: rows };
   } catch (err) {
     console.warn(`[yahoo-lookup] price history failed for ${sym}`, err);
-    return [];
+    return { meta: {}, prices: [] };
   }
+}
+
+export async function yahooPriceHistory(ticker: string, range = "5y", timeoutMs = 6000): Promise<YahooPricePoint[]> {
+  return (await yahooChartHistory(ticker, range, timeoutMs)).prices;
 }
 
 /** Search Yahoo for matching symbols (used as autocomplete fallback). */

--- a/frontend/src/lib/yahoo-lookup.ts
+++ b/frontend/src/lib/yahoo-lookup.ts
@@ -103,6 +103,51 @@ async function fetchWithTimeout(url: string, timeoutMs: number): Promise<Respons
   }
 }
 
+export type YahooPricePoint = {
+  date: string;
+  close: number;
+};
+
+export async function yahooPriceHistory(ticker: string, range = "5y", timeoutMs = 6000): Promise<YahooPricePoint[]> {
+  const sym = ticker.trim().toUpperCase();
+  if (!sym) return [];
+  const yahooSym = toYahooSymbol(sym);
+  const url = `${CHART_URL}/${encodeURIComponent(yahooSym)}?range=${encodeURIComponent(range)}&interval=1d`;
+  try {
+    const res = await fetchWithTimeout(url, timeoutMs);
+    if (!res.ok) return [];
+    const json = (await res.json()) as {
+      chart?: {
+        result?: Array<{
+          timestamp?: number[];
+          indicators?: {
+            quote?: Array<{
+              close?: Array<number | null>;
+            }>;
+          };
+        }>;
+      };
+    };
+    const result = json.chart?.result?.[0];
+    const timestamps = Array.isArray(result?.timestamp) ? result.timestamp : [];
+    const closes = Array.isArray(result?.indicators?.quote?.[0]?.close) ? result.indicators.quote[0].close : [];
+    const rows: YahooPricePoint[] = [];
+    for (let idx = 0; idx < timestamps.length; idx += 1) {
+      const close = Number(closes[idx]);
+      const stamp = Number(timestamps[idx]);
+      if (!Number.isFinite(close) || close <= 0 || !Number.isFinite(stamp)) continue;
+      rows.push({
+        date: new Date(stamp * 1000).toISOString().slice(0, 10),
+        close,
+      });
+    }
+    return rows;
+  } catch (err) {
+    console.warn(`[yahoo-lookup] price history failed for ${sym}`, err);
+    return [];
+  }
+}
+
 /** Search Yahoo for matching symbols (used as autocomplete fallback). */
 export async function yahooSearch(query: string, limit = 8): Promise<TickerEntry[]> {
   const q = query.trim();

--- a/scripts/compare_stock_info.py
+++ b/scripts/compare_stock_info.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import argparse
 import json
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import date, datetime
 from typing import Any, Dict, List
 
+import pandas as pd
 import yfinance as yf
 
 
@@ -31,9 +33,66 @@ def _dividend_yield_pct(value: Any) -> float | None:
     return n * 100.0 if abs(n) <= 0.2 else n
 
 
-def _row(symbol: str) -> Dict[str, Any]:
+def _json_safe(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, (str, bool, int, float)):
+        if isinstance(value, float) and value != value:
+            return None
+        return value
+    if isinstance(value, (datetime, date, pd.Timestamp)):
+        return value.isoformat()
+    if isinstance(value, dict):
+        return {str(k): _json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_json_safe(v) for v in value]
+    try:
+        if pd.isna(value):
+            return None
+    except Exception:
+        pass
+    return str(value)
+
+
+def _named_annual_table(df: pd.DataFrame, title: str) -> str:
+    try:
+        if df is None or getattr(df, "empty", True):
+            return f"### {title}\nNot available\n\n"
+        table = df.copy().T
+        table.index.name = "Reporting_Period"
+        table = table.fillna("N/A")
+        csv_table = table.to_csv()
+        if not csv_table.strip():
+            return f"### {title}\nNot available\n\n"
+        return f"### {title}\n```csv\n{csv_table}```\n\n"
+    except Exception:
+        return f"### {title}\nNot available\n\n"
+
+
+def _financials_copy_payload(ticker: str, ticker_obj: yf.Ticker, info: Dict[str, Any]) -> Dict[str, Any]:
+    currency = (
+        info.get("financialCurrency")
+        or info.get("original_financial_currency")
+        or info.get("currency")
+        or ""
+    )
+    return {
+        "ticker": ticker,
+        "company_name": info.get("longName") or info.get("shortName") or ticker,
+        "currency": str(currency or "").upper() or None,
+        "source": "yfinance.Ticker",
+        "statement_format": "markdown-wrapped csv, annual periods only, original reported currency",
+        "info": _json_safe(info),
+        "annual_financials": _named_annual_table(ticker_obj.financials, "Annual Income Statement"),
+        "annual_balance_sheet": _named_annual_table(ticker_obj.balance_sheet, "Annual Balance Sheet"),
+        "annual_cash_flow": _named_annual_table(ticker_obj.cashflow, "Annual Cash Flow Statement"),
+    }
+
+
+def _row(symbol: str, include_financials: bool = False) -> Dict[str, Any]:
     ticker = _ticker_key(symbol)
-    info = yf.Ticker(ticker).info or {}
+    ticker_obj = yf.Ticker(ticker)
+    info = ticker_obj.info or {}
     if not isinstance(info, dict):
         info = {}
 
@@ -52,7 +111,7 @@ def _row(symbol: str) -> Dict[str, Any]:
     if current_price and target_price:
         upside = (target_price / current_price - 1.0) * 100.0
 
-    return {
+    row = {
         "ticker": ticker,
         "ok": True,
         "symbol": resolved or ticker,
@@ -76,12 +135,16 @@ def _row(symbol: str) -> Dict[str, Any]:
         "dividend_yield": _dividend_yield_pct(info.get("dividendYield")),
         "target_upside": upside,
     }
+    if include_financials:
+        row["financials_copy"] = _financials_copy_payload(ticker, ticker_obj, info)
+    return row
 
 
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--tickers", required=True)
     parser.add_argument("--workers", type=int, default=6)
+    parser.add_argument("--include-financials", action="store_true")
     args = parser.parse_args()
 
     tickers: List[str] = []
@@ -96,7 +159,7 @@ def main() -> int:
     rows: List[Dict[str, Any]] = []
     not_found: List[str] = []
     with ThreadPoolExecutor(max_workers=max(1, min(int(args.workers or 1), 10))) as pool:
-        futures = {pool.submit(_row, ticker): ticker for ticker in tickers}
+        futures = {pool.submit(_row, ticker, bool(args.include_financials)): ticker for ticker in tickers}
         for fut in as_completed(futures):
             ticker = futures[fut]
             try:

--- a/scripts/compare_stock_info.py
+++ b/scripts/compare_stock_info.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import argparse
+import json
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Any, Dict, List
+
+import yfinance as yf
+
+
+def _num(value: Any) -> float | None:
+    try:
+        if value is None:
+            return None
+        n = float(value)
+        if n != n:
+            return None
+        return n
+    except Exception:
+        return None
+
+
+def _ticker_key(value: str) -> str:
+    return str(value or "").strip().upper()
+
+
+def _dividend_yield_pct(value: Any) -> float | None:
+    n = _num(value)
+    if n is None:
+        return None
+    return n * 100.0 if abs(n) <= 0.2 else n
+
+
+def _row(symbol: str) -> Dict[str, Any]:
+    ticker = _ticker_key(symbol)
+    info = yf.Ticker(ticker).info or {}
+    if not isinstance(info, dict):
+        info = {}
+
+    resolved = _ticker_key(str(info.get("symbol") or ticker))
+    name = str(info.get("longName") or info.get("shortName") or "").strip()
+    quote_type = str(info.get("quoteType") or "").strip()
+    if not name and not quote_type and not info.get("regularMarketPrice") and not info.get("currentPrice"):
+        return {"ticker": ticker, "ok": False}
+
+    current_price = _num(info.get("currentPrice")) or _num(info.get("regularMarketPrice"))
+    target_price = _num(info.get("targetMeanPrice"))
+    market_cap = _num(info.get("marketCap"))
+    ev = _num(info.get("enterpriseValue"))
+    fcf = _num(info.get("freeCashflow"))
+    upside = None
+    if current_price and target_price:
+        upside = (target_price / current_price - 1.0) * 100.0
+
+    return {
+        "ticker": ticker,
+        "ok": True,
+        "symbol": resolved or ticker,
+        "company_name": name or ticker,
+        "market_cap": market_cap,
+        "enterprise_value": ev,
+        "net_cash_debt": (market_cap - ev) if market_cap is not None and ev is not None else None,
+        "trailing_pe": _num(info.get("trailingPE")),
+        "forward_pe": _num(info.get("forwardPE")),
+        "ev_sales": _num(info.get("enterpriseToRevenue")),
+        "ev_ebitda": _num(info.get("enterpriseToEbitda")),
+        "p_fcf": (market_cap / fcf) if market_cap is not None and fcf not in (None, 0) else None,
+        "revenue_growth": (_num(info.get("revenueGrowth")) * 100.0) if _num(info.get("revenueGrowth")) is not None else None,
+        "earnings_growth": (_num(info.get("earningsGrowth")) * 100.0) if _num(info.get("earningsGrowth")) is not None else None,
+        "gross_margin": (_num(info.get("grossMargins")) * 100.0) if _num(info.get("grossMargins")) is not None else None,
+        "operating_margin": (_num(info.get("operatingMargins")) * 100.0) if _num(info.get("operatingMargins")) is not None else None,
+        "profit_margin": (_num(info.get("profitMargins")) * 100.0) if _num(info.get("profitMargins")) is not None else None,
+        "roe": (_num(info.get("returnOnEquity")) * 100.0) if _num(info.get("returnOnEquity")) is not None else None,
+        "current_ratio": _num(info.get("currentRatio")),
+        "debt_to_equity": _num(info.get("debtToEquity")),
+        "dividend_yield": _dividend_yield_pct(info.get("dividendYield")),
+        "target_upside": upside,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tickers", required=True)
+    parser.add_argument("--workers", type=int, default=6)
+    args = parser.parse_args()
+
+    tickers: List[str] = []
+    seen: set[str] = set()
+    for raw in str(args.tickers or "").split(","):
+        ticker = _ticker_key(raw)
+        if not ticker or ticker in seen:
+            continue
+        seen.add(ticker)
+        tickers.append(ticker)
+
+    rows: List[Dict[str, Any]] = []
+    not_found: List[str] = []
+    with ThreadPoolExecutor(max_workers=max(1, min(int(args.workers or 1), 10))) as pool:
+        futures = {pool.submit(_row, ticker): ticker for ticker in tickers}
+        for fut in as_completed(futures):
+            ticker = futures[fut]
+            try:
+                row = fut.result()
+            except Exception:
+                row = {"ticker": ticker, "ok": False}
+            if row.get("ok"):
+                rows.append(row)
+            else:
+                not_found.append(ticker)
+
+    order = {ticker: idx for idx, ticker in enumerate(tickers)}
+    rows.sort(key=lambda row: order.get(_ticker_key(str(row.get("ticker") or "")), 999))
+    print(json.dumps({"rows": rows, "not_found": not_found}, ensure_ascii=False, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/ai_hedge/competitor_market_review.py
+++ b/src/ai_hedge/competitor_market_review.py
@@ -167,6 +167,80 @@ def _compact_info_for_llm(info: Dict[str, Any]) -> Dict[str, Any]:
     return {key: info.get(key) for key in keys if key in info}
 
 
+def _clean_price_history_frame(df: Any) -> List[Dict[str, Any]]:
+    if df is None or getattr(df, "empty", True):
+        return []
+    close = None
+    for column in ("Close", "Adj Close"):
+        try:
+            candidate = df[column]
+            if getattr(candidate, "empty", True):
+                continue
+            close = candidate
+            break
+        except Exception:
+            continue
+    if close is None:
+        return []
+
+    rows: List[Dict[str, Any]] = []
+    for idx, value in close.dropna().items():
+        try:
+            price = float(value)
+        except Exception:
+            continue
+        if price <= 0:
+            continue
+        date_value = getattr(idx, "date", lambda: idx)()
+        rows.append({"date": str(date_value), "close": price})
+    return rows
+
+
+def fetch_price_history(ticker: str, *, period: str = "5y") -> List[Dict[str, Any]]:
+    df = yf.download(ticker, period=period, interval="1d", progress=False, auto_adjust=False)
+    return _clean_price_history_frame(df)
+
+
+def build_market_return_comparison(
+    *,
+    original_company: Dict[str, Any],
+    competitors: List[Dict[str, Any]],
+    period: str = "5y",
+) -> Dict[str, Any]:
+    instruments = [original_company, *competitors]
+    seen: set[str] = set()
+    series: List[Dict[str, Any]] = []
+    errors: List[str] = []
+
+    for item in instruments:
+        ticker = str(item.get("ticker") or "").strip().upper()
+        if not ticker or ticker in seen:
+            continue
+        seen.add(ticker)
+        try:
+            prices = fetch_price_history(ticker, period=period)
+        except Exception as exc:
+            prices = []
+            errors.append(f"{ticker}: {type(exc).__name__}: {str(exc)[:160]}")
+        if not prices:
+            continue
+        series.append(
+            {
+                "ticker": ticker,
+                "company_name": str(item.get("company_name") or "").strip(),
+                "prices": prices,
+            }
+        )
+
+    return {
+        "status": "success" if series else "unavailable",
+        "generated_at": _utc_now(),
+        "period": period,
+        "series": series,
+        "error": "; ".join(errors[:3]),
+    }
+
+
 def _default_info_fetcher(ticker: str) -> Dict[str, Any]:
     from . import legacy_port as legacy
 
@@ -505,6 +579,10 @@ def run_competitor_market_review(
         "original_company": original_company,
         "competitors": competitors,
     }
+    return_comparison = build_market_return_comparison(
+        original_company=original_company,
+        competitors=competitors,
+    )
     review_markdown = generate_market_review(payload=review_payload, api_key=key)
     return {
         "status": "success",
@@ -513,6 +591,7 @@ def run_competitor_market_review(
         "name_of_market": discovery.get("name_of_market") or "",
         "original_company": original_company,
         "competitors": competitors,
+        "return_comparison": return_comparison,
         "review_markdown": review_markdown,
         "error": "",
     }

--- a/src/ai_hedge/financials_agent.py
+++ b/src/ai_hedge/financials_agent.py
@@ -17,6 +17,8 @@ REQUIRED_METRICS = [
     "Gross Margin",
     "Operating Income",
     "Operating Margin",
+    "EBITDA",
+    "EBITDA Margin",
     "Net Income (GAAP)",
     "Net Margin",
     "Tax Rate",
@@ -221,6 +223,8 @@ Balance sheet and market-value logic:
 - Net Liquidity = Liquid Assets - Total Debt.
 - Equity-to-Assets Ratio = Total Shareholders' Equity / Total Assets. It is a ratio decimal, not a percent string.
 - Tax Rate = tax provision / pretax income when both are available. If either line is missing, use null.
+- EBITDA should come from a reported EBITDA line when available. If EBITDA is not reported but can be transparently derived from operating income plus depreciation and amortization from the provided statements, mark it "derived"; otherwise use null.
+- EBITDA Margin = EBITDA / Revenue when both are available. It is a ratio decimal, not a percent string.
 - Capital Expenditures (Capex) should come from the cash flow statement when available. Use the absolute cash outflow amount as a positive currency value even if the statement reports capex as negative.
 - Capex / Revenue = Capital Expenditures (Capex) / Revenue when both are available. It is a ratio decimal, not a percent string.
 - SBC / Revenue = Stock-Based Compensation / Revenue when both are available. If SBC is not disclosed separately, use null.

--- a/tests/test_competitor_market_review.py
+++ b/tests/test_competitor_market_review.py
@@ -180,6 +180,35 @@ def test_build_original_company_context_uses_info_and_annual_income_statement():
     assert "Revenue,Net Income" in context["annual_financials"]
 
 
+def test_build_market_return_comparison_includes_original_and_competitors(monkeypatch):
+    downloads = []
+
+    def fake_download(ticker, **kwargs):
+        downloads.append((ticker, kwargs["period"], kwargs["interval"]))
+        if ticker == "BAD":
+            return pd.DataFrame()
+        return pd.DataFrame(
+            {"Close": [10.0, 11.0, 12.0]},
+            index=pd.to_datetime(["2024-01-02", "2024-01-03", "2024-01-04"]),
+        )
+
+    monkeypatch.setattr(cmr.yf, "download", fake_download)
+
+    payload = cmr.build_market_return_comparison(
+        original_company={"ticker": "MAIN", "company_name": "Main Co"},
+        competitors=[
+            {"ticker": "PEER", "company_name": "Peer Co"},
+            {"ticker": "BAD", "company_name": "Bad Co"},
+            {"ticker": "PEER", "company_name": "Duplicate"},
+        ],
+    )
+
+    assert payload["status"] == "success"
+    assert [row["ticker"] for row in payload["series"]] == ["MAIN", "PEER"]
+    assert payload["series"][0]["prices"][0] == {"date": "2024-01-02", "close": 10.0}
+    assert downloads == [("MAIN", "5y", "1d"), ("PEER", "5y", "1d"), ("BAD", "5y", "1d")]
+
+
 def test_review_prompt_requires_original_company_financial_comparison():
     prompt = cmr.build_review_prompt(
         {
@@ -219,6 +248,11 @@ def test_run_competitor_market_review_includes_original_company_payload(monkeypa
             "annual_financials": "### Annual Income Statement\n```csv\nRevenue\n```",
         },
     )
+    monkeypatch.setattr(
+        cmr,
+        "build_market_return_comparison",
+        lambda **_kwargs: {"status": "success", "series": [{"ticker": "CHKP", "prices": []}]},
+    )
 
     def fake_generate_market_review(*, payload, api_key):
         captured["payload"] = payload
@@ -237,6 +271,7 @@ def test_run_competitor_market_review_includes_original_company_payload(monkeypa
     assert "Revenue" in captured["payload"]["original_company"]["annual_financials"]
     assert captured["payload"]["competitors"] == [{"ticker": "PANW"}]
     assert out["original_company"]["ticker"] == "CHKP"
+    assert out["return_comparison"]["series"][0]["ticker"] == "CHKP"
 
 
 def test_result_degrades_to_unavailable_and_writes_sidecar(monkeypatch, tmp_path):

--- a/tests/test_financials_agent.py
+++ b/tests/test_financials_agent.py
@@ -44,9 +44,17 @@ def test_normalize_financials_analysis_preserves_required_order_and_caps_added_r
     tax_rate = next(row for row in normalized["rows"] if row["metric"] == "Tax Rate")
     capex = next(row for row in normalized["rows"] if row["metric"] == "Capital Expenditures (Capex)")
     capex_ratio = next(row for row in normalized["rows"] if row["metric"] == "Capex / Revenue")
+    ebitda = next(row for row in normalized["rows"] if row["metric"] == "EBITDA")
+    ebitda_margin = next(row for row in normalized["rows"] if row["metric"] == "EBITDA Margin")
     sbc_ratio = next(row for row in normalized["rows"] if row["metric"] == "SBC / Revenue")
+    assert REQUIRED_METRICS[REQUIRED_METRICS.index("Operating Margin") + 1 : REQUIRED_METRICS.index("Operating Margin") + 3] == [
+        "EBITDA",
+        "EBITDA Margin",
+    ]
     assert equity_to_assets["kind"] == "percent"
     assert tax_rate["kind"] == "percent"
+    assert ebitda["kind"] == "currency"
+    assert ebitda_margin["kind"] == "percent"
     assert capex["kind"] == "currency"
     assert capex_ratio["kind"] == "percent"
     assert sbc_ratio["kind"] == "percent"


### PR DESCRIPTION
## Summary
- Add a deterministic Market tab return comparison for the main company and market peers.
- Save five years of daily close prices into new market review payloads when a fresh report is generated.
- For existing reports, load the same return history from the current Market tab tickers through `/api/dashboard/[ticker]/market-returns`, so users do not need to rerun the analysis.
- Render the Market comparison at the top of the Market tab with period selectors, stacked chart/table layout, green/red return values, and a fixed high-contrast palette where the main ticker is always purple.
- Add a new global `/compare` tab, accessible from the sidebar, where users can add up to 10 tickers with the same autocomplete/free-text ticker picker used by New Analysis.
- Add `/api/compare` for live Yahoo chart-history lookups plus yfinance `Ticker.info` fundamentals via `scripts/compare_stock_info.py`.
- Replace the Compare page price-data table with a fundamentals table: size, EV, net cash/debt, multiples, growth, margins, balance sheet, dividend yield, and target upside.
- Improve Compare table return/growth/target-upside coloring and give Target Upside enough column width.
- Update the Financials LLM extraction contract so new reports always request EBITDA and EBITDA Margin immediately after Operating Income / Operating Margin.

## User impact
Users can compare the analyzed company against its Market peer set inside a report, and can also open a general Compare page to compare arbitrary tickers without starting a valuation run. The Compare table now matches the uploaded script's purpose: valuation and fundamental comparison, not only price movement. New Financials tab generations will include EBITDA and EBITDA Margin rows by default.

## Validation
- `PYTHONPATH=src pytest tests/test_competitor_market_review.py --basetemp=.pytest-tmp-market-return` -> 12 passed
- `PYTHONPATH=src pytest tests/test_financials_agent.py --basetemp=.pytest-tmp-financials-ebitda` -> 7 passed
- `python -m py_compile scripts/compare_stock_info.py` -> passed
- `python scripts/compare_stock_info.py --tickers AAPL,MSFT,NOTREALZZZ --workers 3` -> returned fundamentals for AAPL/MSFT and `not_found=[NOTREALZZZ]`
- `npm run build` -> passed after the latest Compare table and Market layout changes
- Local Market API smoke check: `GET /api/dashboard/AAPL/market-returns?tickers=AAPL,MSFT` -> `status=success`, 2 series, first series 1,254 points
- Local Compare API smoke check: `GET /api/compare?tickers=AAPL,MSFT,NOTREALZZZ` -> `status=success`, 2 series, `not_found=NOTREALZZZ`, first series includes market cap, P/E, and dividend yield fundamentals

## Notes
- Targeted ESLint for the touched frontend files previously hung without output, so the stuck `npx eslint`/`eslint` Node processes were stopped and the successful production build/TypeScript check was used for frontend validation.
- The Compare fundamentals table uses yfinance `Ticker.info`, matching the uploaded comparison script. Unavailable fields are rendered as `-` rather than inferred.