### PR TITLE
Fix comparison and market return charts

### DIFF
--- a/frontend/src/app/(app)/compare/page.tsx
+++ b/frontend/src/app/(app)/compare/page.tsx
@@ -2,11 +2,12 @@
 
 import type { CSSProperties } from "react";
 import { useEffect, useMemo, useState } from "react";
-import { Check, ClipboardCopy, GitCompareArrows, Loader2, Plus, X } from "lucide-react";
+import { Check, Download, GitCompareArrows, Loader2, Plus, X } from "lucide-react";
 import {
   CartesianGrid,
   Line,
   LineChart as RechartsLineChart,
+  ReferenceLine,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -132,14 +133,6 @@ function formatReturn(value: number | null): string {
   return `${value > 0 ? "+" : ""}${value.toFixed(1)}%`;
 }
 
-function formatPrice(value: unknown, currency?: string): string {
-  const n = numeric(value);
-  if (n === null) return "-";
-  return `${currency ? `${currency} ` : ""}${n.toLocaleString(undefined, {
-    maximumFractionDigits: n >= 100 ? 1 : 2,
-  })}`;
-}
-
 function formatRatio(value: unknown): string {
   const n = numeric(value);
   if (n === null || n <= 0) return "-";
@@ -169,20 +162,16 @@ function returnTone(value: number | null): string {
   return "text-[color:var(--text-secondary)]";
 }
 
-async function writeClipboard(text: string): Promise<void> {
-  if (navigator.clipboard?.writeText) {
-    await navigator.clipboard.writeText(text);
-    return;
-  }
-  const textarea = document.createElement("textarea");
-  textarea.value = text;
-  textarea.setAttribute("readonly", "true");
-  textarea.style.position = "fixed";
-  textarea.style.left = "-9999px";
-  document.body.appendChild(textarea);
-  textarea.select();
-  document.execCommand("copy");
-  document.body.removeChild(textarea);
+function downloadTextFile(filename: string, text: string) {
+  const blob = new Blob([text], { type: "text/plain;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
 }
 
 function ChartTooltip({
@@ -223,8 +212,8 @@ export default function ComparePage() {
   const [data, setData] = useState<ComparePayload | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
-  const [copyingFinancials, setCopyingFinancials] = useState(false);
-  const [copyStatus, setCopyStatus] = useState<{ tone: "success" | "error"; message: string } | null>(null);
+  const [downloadingFinancials, setDownloadingFinancials] = useState(false);
+  const [downloadStatus, setDownloadStatus] = useState<{ tone: "success" | "error"; message: string } | null>(null);
 
   function addTicker(entry: TickerEntry | null) {
     if (!entry) return;
@@ -239,10 +228,10 @@ export default function ComparePage() {
     setTickers((prev) => prev.filter((item) => item !== ticker));
   }
 
-  async function copyFinancials() {
-    if (!tickers.length || copyingFinancials) return;
-    setCopyingFinancials(true);
-    setCopyStatus(null);
+  async function downloadFinancials() {
+    if (!tickers.length || downloadingFinancials) return;
+    setDownloadingFinancials(true);
+    setDownloadStatus(null);
     try {
       const qs = new URLSearchParams({ tickers: tickers.join(","), financials: "1" });
       const res = await fetch(`/api/compare?${qs.toString()}`, { cache: "no-store" });
@@ -254,33 +243,38 @@ export default function ComparePage() {
         data: {},
         not_found: payload.not_found || [],
       };
-      const copiedCount = Object.keys(financials.data || {}).length;
-      if (!copiedCount) throw new Error("No financial statements were available for the selected tickers.");
-      await writeClipboard(JSON.stringify(financials, null, 2));
-      setCopyStatus({
+      const downloadedCount = Object.keys(financials.data || {}).length;
+      if (!downloadedCount) throw new Error("No financial statements were available for the selected tickers.");
+      const timestamp = new Date().toISOString().slice(0, 10);
+      downloadTextFile(`comparison-financials-${timestamp}.txt`, JSON.stringify(financials, null, 2));
+      setDownloadStatus({
         tone: "success",
-        message: `Copied financial JSON for ${copiedCount} ticker${copiedCount === 1 ? "" : "s"}.`,
+        message: `Downloaded financial JSON for ${downloadedCount} ticker${downloadedCount === 1 ? "" : "s"}.`,
       });
     } catch (err) {
-      setCopyStatus({
+      setDownloadStatus({
         tone: "error",
-        message: err instanceof Error ? err.message : "Could not copy financials.",
+        message: err instanceof Error ? err.message : "Could not download financials.",
       });
     } finally {
-      setCopyingFinancials(false);
+      setDownloadingFinancials(false);
     }
   }
 
   useEffect(() => {
     if (!tickers.length) {
-      setData(null);
-      setError("");
+      queueMicrotask(() => {
+        setData(null);
+        setError("");
+      });
       return;
     }
     const controller = new AbortController();
-    setLoading(true);
-    setError("");
-    setCopyStatus(null);
+    queueMicrotask(() => {
+      setLoading(true);
+      setError("");
+      setDownloadStatus(null);
+    });
     const qs = new URLSearchParams({ tickers: tickers.join(",") });
     fetch(`/api/compare?${qs.toString()}`, { cache: "no-store", signal: controller.signal })
       .then(async (res) => {
@@ -378,18 +372,18 @@ export default function ComparePage() {
           </button>
           <button
             type="button"
-            onClick={copyFinancials}
-            disabled={!tickers.length || copyingFinancials}
+            onClick={downloadFinancials}
+            disabled={!tickers.length || downloadingFinancials}
             className="inline-flex h-10 w-full items-center justify-center gap-1.5 rounded-lg border border-[color:var(--border-strong)] bg-black/20 px-3 text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--text-secondary)] transition hover:border-[color:var(--accent)] hover:text-[color:var(--accent)] disabled:cursor-not-allowed disabled:border-[color:var(--border-subtle)] disabled:text-[color:var(--text-disabled)] sm:w-auto"
           >
-            {copyingFinancials ? (
+            {downloadingFinancials ? (
               <Loader2 size={13} className="animate-spin" />
-            ) : copyStatus?.tone === "success" ? (
+            ) : downloadStatus?.tone === "success" ? (
               <Check size={13} />
             ) : (
-              <ClipboardCopy size={13} />
+              <Download size={13} />
             )}
-            Copy Financials
+            Download Financials
           </button>
         </div>
         <div className="mt-3 flex flex-wrap gap-2">
@@ -410,15 +404,15 @@ export default function ComparePage() {
             </span>
           ))}
         </div>
-        {copyStatus ? (
+        {downloadStatus ? (
           <p
             className={`mt-3 rounded-lg border bg-black/25 px-3 py-2 text-xs ${
-              copyStatus.tone === "success"
+              downloadStatus.tone === "success"
                 ? "border-[color:var(--success)] text-[color:var(--success)]"
                 : "border-[color:var(--danger)] text-[color:var(--danger)]"
             }`}
           >
-            {copyStatus.message}
+            {downloadStatus.message}
           </p>
         ) : null}
         {data?.not_found?.length ? (
@@ -476,6 +470,7 @@ export default function ComparePage() {
                   tickFormatter={(value) => formatReturn(Number(value))}
                 />
                 <Tooltip content={<ChartTooltip />} wrapperStyle={{ outline: "none" }} />
+                <ReferenceLine y={0} stroke={tokens["--chart-current"]} strokeWidth={2.4} ifOverflow="extendDomain" />
                 {comparison.series.map((item, idx) => (
                   <Line
                     key={item.ticker}

--- a/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
@@ -15,6 +15,7 @@ import {
   CartesianGrid,
   Line,
   LineChart as RechartsLineChart,
+  ReferenceLine,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -116,17 +117,20 @@ function infoRecord(value: unknown): Record<string, unknown> {
 }
 
 const marketMarkdownComponents: Components = {
-  table({ node: _node, ...props }) {
+  table({ node, ...props }) {
+    void node;
     return (
       <div className="hib-market-table-wrap">
         <table className="hib-market-table" {...props} />
       </div>
     );
   },
-  th({ node: _node, ...props }) {
+  th({ node, ...props }) {
+    void node;
     return <th className="hib-market-table-head" {...props} />;
   },
-  td({ node: _node, ...props }) {
+  td({ node, ...props }) {
+    void node;
     return <td className="hib-market-table-cell" {...props} />;
   },
 };
@@ -374,14 +378,18 @@ function MarketReturnComparison({ market, ticker }: { market: MarketReviewPayloa
 
   useEffect(() => {
     if (savedSeries.length >= 2 || tickerList.length < 2) {
-      setLoadState(savedSeries.length >= 2 ? "ready" : "idle");
-      setLoadError("");
+      queueMicrotask(() => {
+        setLoadState(savedSeries.length >= 2 ? "ready" : "idle");
+        setLoadError("");
+      });
       return;
     }
 
     const controller = new AbortController();
-    setLoadState("loading");
-    setLoadError("");
+    queueMicrotask(() => {
+      setLoadState("loading");
+      setLoadError("");
+    });
     const qs = new URLSearchParams({ tickers: tickerList.join(",") });
     fetch(`/api/dashboard/${encodeURIComponent(ticker.toUpperCase())}/market-returns?${qs.toString()}`, {
       cache: "no-store",
@@ -522,6 +530,7 @@ function MarketReturnComparison({ market, ticker }: { market: MarketReviewPayloa
                   tickFormatter={(value) => formatReturn(Number(value))}
                 />
                 <Tooltip content={<ReturnTooltip />} wrapperStyle={{ outline: "none" }} />
+                <ReferenceLine y={0} stroke={tokens["--chart-current"]} strokeWidth={2.4} ifOverflow="extendDomain" />
                 {comparison.activeSeries.map((item, idx) => (
                   <Line
                     key={item.ticker}

--- a/frontend/src/lib/yahoo-lookup.ts
+++ b/frontend/src/lib/yahoo-lookup.ts
@@ -127,6 +127,70 @@ export type YahooChartResult = {
   prices: YahooPricePoint[];
 };
 
+function isTelAvivTicker(ticker: string): boolean {
+  return ticker.trim().toUpperCase().endsWith(".TA");
+}
+
+function confirmsScaleBreak(
+  rows: YahooPricePoint[],
+  startIdx: number,
+  reference: number,
+  factor: number,
+  direction: "up" | "down",
+): boolean {
+  const available = Math.min(3, rows.length - startIdx);
+  if (available < 2) return false;
+
+  for (let offset = 0; offset < available; offset += 1) {
+    const adjusted = rows[startIdx + offset].close * factor;
+    const ratio = adjusted / reference;
+    if (direction === "up" && ratio < 10) return false;
+    if (direction === "down" && ratio > 0.1) return false;
+  }
+  return true;
+}
+
+function isNearPriorScale(current: number, normalizedRows: YahooPricePoint[]): boolean {
+  if (normalizedRows.length < 2) return false;
+  const prior = normalizedRows[normalizedRows.length - 2].close;
+  if (!prior) return false;
+  const ratio = current / prior;
+  return ratio >= 0.5 && ratio <= 2;
+}
+
+export function normalizeYahooPriceHistory(ticker: string, rows: YahooPricePoint[]): YahooPricePoint[] {
+  if (!isTelAvivTicker(ticker) || rows.length < 3) return rows;
+
+  const normalized: YahooPricePoint[] = [];
+  let factor = 1;
+
+  for (let idx = 0; idx < rows.length; idx += 1) {
+    const row = rows[idx];
+    if (!normalized.length) {
+      normalized.push({ ...row });
+      continue;
+    }
+
+    const previous = normalized[normalized.length - 1].close;
+    const current = row.close * factor;
+    const ratio = current / previous;
+
+    if (ratio >= 10 && !isNearPriorScale(current, normalized) && confirmsScaleBreak(rows, idx, previous, factor, "up")) {
+      factor /= 100;
+    } else if (
+      ratio <= 0.1 &&
+      !isNearPriorScale(current, normalized) &&
+      confirmsScaleBreak(rows, idx, previous, factor, "down")
+    ) {
+      factor *= 100;
+    }
+
+    normalized.push({ ...row, close: row.close * factor });
+  }
+
+  return normalized;
+}
+
 export async function yahooChartHistory(ticker: string, range = "5y", timeoutMs = 6000): Promise<YahooChartResult> {
   const sym = ticker.trim().toUpperCase();
   if (!sym) return { meta: {}, prices: [] };
@@ -161,7 +225,7 @@ export async function yahooChartHistory(ticker: string, range = "5y", timeoutMs 
         close,
       });
     }
-    return { meta: result?.meta || {}, prices: rows };
+    return { meta: result?.meta || {}, prices: normalizeYahooPriceHistory(sym, rows) };
   } catch (err) {
     console.warn(`[yahoo-lookup] price history failed for ${sym}`, err);
     return { meta: {}, prices: [] };

--- a/src/ai_hedge/competitor_market_review.py
+++ b/src/ai_hedge/competitor_market_review.py
@@ -196,9 +196,83 @@ def _clean_price_history_frame(df: Any) -> List[Dict[str, Any]]:
     return rows
 
 
+def _is_tel_aviv_ticker(ticker: str) -> bool:
+    return str(ticker or "").strip().upper().endswith(".TA")
+
+
+def _confirms_scale_break(
+    rows: List[Dict[str, Any]],
+    start_idx: int,
+    reference: float,
+    factor: float,
+    direction: str,
+) -> bool:
+    available = min(3, len(rows) - start_idx)
+    if available < 2:
+        return False
+    for offset in range(available):
+        try:
+            adjusted = float(rows[start_idx + offset]["close"]) * factor
+        except Exception:
+            return False
+        ratio = adjusted / reference if reference else 0
+        if direction == "up" and ratio < 10:
+            return False
+        if direction == "down" and ratio > 0.1:
+            return False
+    return True
+
+
+def _is_near_prior_scale(current: float, normalized: List[Dict[str, Any]]) -> bool:
+    if len(normalized) < 2:
+        return False
+    try:
+        prior = float(normalized[-2]["close"])
+    except Exception:
+        return False
+    if not prior:
+        return False
+    ratio = current / prior
+    return 0.5 <= ratio <= 2
+
+
+def normalize_price_history_for_ticker(ticker: str, rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    if not _is_tel_aviv_ticker(ticker) or len(rows) < 3:
+        return rows
+
+    normalized: List[Dict[str, Any]] = []
+    factor = 1.0
+    for idx, row in enumerate(rows):
+        if not normalized:
+            normalized.append(dict(row))
+            continue
+        try:
+            raw_close = float(row["close"])
+            previous = float(normalized[-1]["close"])
+        except Exception:
+            normalized.append(dict(row))
+            continue
+        current = raw_close * factor
+        ratio = current / previous if previous else 0
+        if (
+            ratio >= 10
+            and not _is_near_prior_scale(current, normalized)
+            and _confirms_scale_break(rows, idx, previous, factor, "up")
+        ):
+            factor /= 100
+        elif (
+            ratio <= 0.1
+            and not _is_near_prior_scale(current, normalized)
+            and _confirms_scale_break(rows, idx, previous, factor, "down")
+        ):
+            factor *= 100
+        normalized.append({**row, "close": raw_close * factor})
+    return normalized
+
+
 def fetch_price_history(ticker: str, *, period: str = "5y") -> List[Dict[str, Any]]:
     df = yf.download(ticker, period=period, interval="1d", progress=False, auto_adjust=False)
-    return _clean_price_history_frame(df)
+    return normalize_price_history_for_ticker(ticker, _clean_price_history_frame(df))
 
 
 def build_market_return_comparison(

--- a/tests/test_competitor_market_review.py
+++ b/tests/test_competitor_market_review.py
@@ -209,6 +209,56 @@ def test_build_market_return_comparison_includes_original_and_competitors(monkey
     assert downloads == [("MAIN", "5y", "1d"), ("PEER", "5y", "1d"), ("BAD", "5y", "1d")]
 
 
+def test_normalize_price_history_for_ta_rescales_persistent_upward_unit_switch():
+    rows = [
+        {"date": "2024-01-01", "close": 14.8},
+        {"date": "2024-01-02", "close": 1452.0},
+        {"date": "2024-01-03", "close": 1460.0},
+        {"date": "2024-01-04", "close": 1471.0},
+    ]
+
+    normalized = cmr.normalize_price_history_for_ticker("TEST.TA", rows)
+
+    assert [round(row["close"], 2) for row in normalized] == [14.8, 14.52, 14.6, 14.71]
+
+
+def test_normalize_price_history_for_ta_rescales_persistent_downward_unit_switch():
+    rows = [
+        {"date": "2024-01-01", "close": 1480.0},
+        {"date": "2024-01-02", "close": 14.52},
+        {"date": "2024-01-03", "close": 14.6},
+    ]
+
+    normalized = cmr.normalize_price_history_for_ticker("TEST.TA", rows)
+
+    assert [round(row["close"], 2) for row in normalized] == [1480.0, 1452.0, 1460.0]
+
+
+def test_normalize_price_history_for_ta_ignores_unconfirmed_single_point_spike():
+    rows = [
+        {"date": "2024-01-01", "close": 14.8},
+        {"date": "2024-01-02", "close": 1452.0},
+        {"date": "2024-01-03", "close": 14.9},
+        {"date": "2024-01-04", "close": 15.0},
+    ]
+
+    normalized = cmr.normalize_price_history_for_ticker("TEST.TA", rows)
+
+    assert [row["close"] for row in normalized] == [14.8, 1452.0, 14.9, 15.0]
+
+
+def test_normalize_price_history_does_not_rescale_non_ta_ticker():
+    rows = [
+        {"date": "2024-01-01", "close": 14.8},
+        {"date": "2024-01-02", "close": 1452.0},
+        {"date": "2024-01-03", "close": 1460.0},
+    ]
+
+    normalized = cmr.normalize_price_history_for_ticker("TEST", rows)
+
+    assert normalized is rows
+
+
 def test_review_prompt_requires_original_company_financial_comparison():
     prompt = cmr.build_review_prompt(
         {


### PR DESCRIPTION
## Summary

- Added a bold zero-return reference line to the Comparison and Market return charts so above/below-zero performance is easier to read.
- Normalized persistent Yahoo `.TA` historical price unit switches before return calculations in both live frontend routes and saved market-review payload generation.
- Changed the Comparison financials action from clipboard copy to downloading the financial JSON as a `.txt` file.

## Preview

URL: https://pr-111-hedge-in-a-box-site.fly.dev

## Test plan

- [x] `PYTHONPATH=src python -m pytest tests/test_competitor_market_review.py --basetemp C:\Users\User\Desktop\AI_HEDGE_2_pytest_tmp`
- [x] `npx eslint --no-cache --no-warn-ignored -- src/app/(app)/compare/page.tsx src/app/(app)/dashboard/[ticker]/market/market-client.tsx src/lib/yahoo-lookup.ts`
- [x] `npm run build` (passes; existing Turbopack NFT warning from `next.config.ts` / dream-team chat route remains)
- [x] Preview `/compare` returned 200 and rendered `Download Financials` + `Stock Comparison`.
- [x] Preview `/api/compare?tickers=AAPL,MSFT` returned 200 with `status: success`, 2 series, and 1254 AAPL prices.
- [x] Preview `/dashboard/AAPL/market` returned 200 and rendered `Market` + `Return Comparison`.

## Notes for reviewer

- The `.TA` normalization only applies after a 10x / 0.1x scale break is confirmed by following observations, and it avoids correcting isolated one-day spikes that immediately return near the prior scale.
- Browser automation was unavailable in this Codex environment, so preview verification used HTTP route/API checks plus local build/lint/tests.