### PR TITLE
Set screener peer weights to 50/50

### DIFF
--- a/scripts/screener_sp500_profiles.py
+++ b/scripts/screener_sp500_profiles.py
@@ -69,8 +69,8 @@ QUALITY_CONFIGS = {
     "roe": {"direction": "higher", "weight": 0.10, "clamp": {"min": -0.3, "max": 0.5}},
     "debtToEquity": {"direction": "lower", "weight": 0.10},
 }
-INDUSTRY_SCORE_WEIGHT = 0.6
-SECTOR_SCORE_WEIGHT = 0.4
+INDUSTRY_SCORE_WEIGHT = 0.5
+SECTOR_SCORE_WEIGHT = 0.5
 
 
 class _TableParser(HTMLParser):


### PR DESCRIPTION
## Summary

- Changed screener peer-relative scoring to weight industry and sector percentiles equally.
- Keeps valuation/quality category weights unchanged; only the sector-vs-industry blend changed.

## Preview

URL: n/a - backend/script-only screener scoring change

## Test plan

- [x] `python -m py_compile scripts\screener_sp500_profiles.py`
- [x] Focused Python check: imported `scripts.screener_sp500_profiles`, asserted both peer weights are `0.5`, and verified `_blended_percentile` matches a 50/50 industry/sector calculation.

## Notes for reviewer

Existing screener caches may need refresh before users see scores recalculated with the new 50/50 peer blend.