### PR TITLE
Use live quote market cap in info tab

### DIFF
--- a/.github/workflows/preview-site.yml
+++ b/.github/workflows/preview-site.yml
@@ -101,14 +101,14 @@ jobs:
           [ -z "$prod_size" ] || [ "$prod_size" = "null" ] && prod_size=1
 
           # Use most recent existing snapshot if any, else create one and wait.
-          snap=$(flyctl volumes snapshots list "$prod_vol" --json \
+          snap=$(flyctl volumes snapshots list "$prod_vol" --app "${{ env.PROD_APP }}" --json \
             | jq -r 'sort_by(.created_at) | reverse | .[0] | select(.status=="created") | .id // empty')
           if [ -z "$snap" ]; then
             echo "No ready snapshot — creating one."
-            flyctl volumes snapshots create "$prod_vol"
+            flyctl volumes snapshots create "$prod_vol" --app "${{ env.PROD_APP }}"
             for i in $(seq 1 20); do
               sleep 15
-              snap=$(flyctl volumes snapshots list "$prod_vol" --json \
+              snap=$(flyctl volumes snapshots list "$prod_vol" --app "${{ env.PROD_APP }}" --json \
                 | jq -r 'sort_by(.created_at) | reverse | .[0] | select(.status=="created") | .id // empty')
               if [ -n "$snap" ]; then break; fi
               echo "Waiting for snapshot... ($i/20)"

--- a/frontend/src/app/(app)/dashboard/[ticker]/info/info-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/info/info-client.tsx
@@ -38,6 +38,11 @@ const MULTIPLE_MAP: Array<{ key: string; label: string; kind: "currency" | "rati
   { key: "EnterprisesValueEBITDARatio", label: "EV/EBITDA", kind: "ratio" },
 ];
 
+const LIVE_QUOTE_MULTIPLE_KEYS: Record<string, string> = {
+  MarketCap: "marketCap",
+  EnterpriseValue: "enterpriseValue",
+};
+
 const FINANCIAL_CARD_MAP: MetricCard[] = [
   { label: "Current Price", value: "currentPrice", kind: "currency" },
   { label: "Target Mean", value: "targetMeanPrice", kind: "currency" },
@@ -121,6 +126,10 @@ function financialData(info: YahooqueryInfo): Record<string, unknown> {
   return info.financial_data || {};
 }
 
+function liveQuote(info: YahooqueryInfo): Record<string, unknown> {
+  return info.live_quote || {};
+}
+
 function MetricTile({ card, currency }: { card: MetricCard; currency: string }) {
   return (
     <article className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-3">
@@ -177,17 +186,26 @@ export function InfoClient({
   const rows = rowsFromInfo(info);
   const latest = latestMultiple(info);
   const finance = financialData(info);
-  const currency = String(finance.financialCurrency || (ticker.endsWith(".TA") ? "ILS" : "USD")).toUpperCase();
+  const quote = liveQuote(info);
+  const currency = String(
+    quote.financialCurrency || finance.financialCurrency || (ticker.endsWith(".TA") ? "ILS" : "USD"),
+  ).toUpperCase();
   const recommendation = String(finance.recommendationKey || "none").replace(/_/g, " ");
   const status = String(info.status || "").toLowerCase();
-  const multipleCards = MULTIPLE_MAP.map((item) => ({
-    label: item.label,
-    value: latest[item.key],
-    kind: item.kind,
-    note: item.key in (info.valuation_measures?.recent_average || {})
-      ? `Recent avg ${fmtValue(info.valuation_measures?.recent_average?.[item.key], item.kind, currency)}`
-      : undefined,
-  }));
+  const multipleCards = MULTIPLE_MAP.map((item) => {
+    const liveKey = LIVE_QUOTE_MULTIPLE_KEYS[item.key];
+    const liveValue = liveKey ? quote[liveKey] : undefined;
+    return {
+      label: item.label,
+      value: liveValue ?? latest[item.key],
+      kind: item.kind,
+      note: liveKey && liveValue !== undefined
+        ? "Live quote"
+        : item.key in (info.valuation_measures?.recent_average || {})
+          ? `Recent avg ${fmtValue(info.valuation_measures?.recent_average?.[item.key], item.kind, currency)}`
+          : undefined,
+    };
+  });
   const financeCards = FINANCIAL_CARD_MAP.map((item) => ({
     label: item.label,
     value: finance[String(item.value)],

--- a/frontend/src/lib/dashboard-server.ts
+++ b/frontend/src/lib/dashboard-server.ts
@@ -63,6 +63,7 @@ export type YahooqueryInfo = {
     latest_by_period?: Record<string, Record<string, unknown>>;
     recent_average?: Record<string, number | null>;
   };
+  live_quote?: Record<string, unknown>;
   financial_data?: Record<string, unknown>;
 };
 

--- a/src/ai_hedge/yahooquery_data.py
+++ b/src/ai_hedge/yahooquery_data.py
@@ -80,6 +80,32 @@ def _fetch_attr(obj: Any, name: str) -> Any:
         return {"error": f"{type(exc).__name__}: {str(exc)[:240]}"}
 
 
+def _live_quote_payload(info: Any) -> Dict[str, Any]:
+    if not isinstance(info, dict):
+        return {}
+    keys = (
+        "symbol",
+        "currency",
+        "financialCurrency",
+        "currentPrice",
+        "regularMarketPrice",
+        "sharesOutstanding",
+        "impliedSharesOutstanding",
+        "marketCap",
+        "enterpriseValue",
+    )
+    return _json_safe({key: info.get(key) for key in keys if info.get(key) is not None})
+
+
+def _fetch_live_quote(symbol: str) -> Dict[str, Any]:
+    try:
+        import yfinance as yf
+
+        return _live_quote_payload(yf.Ticker(symbol).info)
+    except Exception as exc:
+        return {"error": f"{type(exc).__name__}: {str(exc)[:240]}"}
+
+
 def _parse_date(value: Any) -> Optional[datetime]:
     if value is None:
         return None
@@ -210,6 +236,7 @@ def fetch_yahooquery_snapshot(ticker: str) -> Dict[str, Any]:
     earning_history = _fetch_attr(ticker_obj, "earning_history")
     corporate_events = _fetch_attr(ticker_obj, "corporate_events")
     share_purchase_activity = _fetch_attr(ticker_obj, "share_purchase_activity")
+    live_quote = _fetch_live_quote(symbol)
 
     valuation_rows = _df_records(valuation_measures)
     financial_data_clean = _dict_for_symbol(financial_data, symbol)
@@ -235,6 +262,7 @@ def fetch_yahooquery_snapshot(ticker: str) -> Dict[str, Any]:
             "latest_by_period": latest_by_period,
             "recent_average": _average_recent(valuation_rows),
         },
+        "live_quote": live_quote,
         "financial_data": financial_data_clean,
         "earnings_surprise": {
             "rows": earning_history_rows,

--- a/tests/test_yahooquery_data.py
+++ b/tests/test_yahooquery_data.py
@@ -1,0 +1,26 @@
+from ai_hedge.yahooquery_data import _live_quote_payload
+
+
+def test_live_quote_payload_keeps_market_cap_and_enterprise_value_in_provider_currency():
+    payload = _live_quote_payload(
+        {
+            "symbol": "AXN.TA",
+            "currency": "ILA",
+            "financialCurrency": "ILS",
+            "currentPrice": 724.6,
+            "sharesOutstanding": 18277780,
+            "marketCap": 132440792,
+            "enterpriseValue": 110804120,
+            "longName": "Ignored",
+        }
+    )
+
+    assert payload == {
+        "symbol": "AXN.TA",
+        "currency": "ILA",
+        "financialCurrency": "ILS",
+        "currentPrice": 724.6,
+        "sharesOutstanding": 18277780,
+        "marketCap": 132440792,
+        "enterpriseValue": 110804120,
+    }


### PR DESCRIPTION
## Summary

- Add a live quote block to the Info tab yahooquery payload using yfinance quote data.
- Make the Info tab prefer live quote `marketCap` and `enterpriseValue` for the Market Cap and EV cards, while leaving the other valuation multiples on yahooquery valuation history.
- Include the Fly preview snapshot app lookup fix so the preview workflow can pass on this frontend/src PR.

## Preview

URL: pending Site Preview workflow.

## Test plan

- [x] `PYTHONPATH=src python -m py_compile src\\ai_hedge\\yahooquery_data.py scripts\\live_yahooquery_info.py`
- [x] `PYTHONPATH=src python -m pytest -q tests\\test_yahooquery_data.py`
- [x] `PYTHONPATH=src python scripts\\live_yahooquery_info.py --ticker AXN.TA` shows `live_quote.marketCap = 132440792` and `live_quote.enterpriseValue = 110804120`.
- [x] `npx eslint --max-warnings=0 src/app/(app)/dashboard/[ticker]/info/info-client.tsx src/lib/dashboard-server.ts`
- [x] `npm run build`
- [x] Local production smoke: `http://127.0.0.1:3011/dashboard/AXN.TA/info` returned 200 and contained Info/Market Cap content.
- [x] `git diff --check`

## Notes for reviewer

- This changes the Info tab only for the displayed Market Cap and Enterprise Value cards. The historical multiple table still uses yahooquery valuation rows.
- For AXN.TA, yahooquery valuation history still reports the stale 92.4M row, but the Info tab card now uses live quote market cap around 132.4M ILS.