### PR TITLE
Fix pytest local test setup

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+addopts = --basetemp=.tmp/pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+
+for path in (ROOT, SRC):
+    value = str(path)
+    if value not in sys.path:
+        sys.path.insert(0, value)


### PR DESCRIPTION
## Summary

- Add a repo-level pytest configuration so test discovery stays scoped to `tests/` and pytest uses a repo-local temp directory under `.tmp/pytest`.
- Add a shared test bootstrap that makes the repo root and `src/` importable during collection, covering top-level script tests and package imports without per-shell `PYTHONPATH` setup.

## Preview

URL: n/a - test infrastructure only; no frontend preview expected.

## Test plan

- [x] Rebased onto current `main` after PR #123
- [x] `python -m pytest -q` - 93 passed

## Notes for reviewer

This fixes two local reliability problems seen from a clean branch: top-level script imports during collection and Windows global pytest temp-directory permission failures. Generated pytest temp files remain under `.tmp/`, which is already gitignored.