### PR TITLE
Add valuation router agent

### DIFF
--- a/frontend/src/app/(app)/dashboard/[ticker]/overview/overview-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/overview/overview-client.tsx
@@ -181,7 +181,7 @@ export function OverviewClient({
           </div>
           <div className="rounded-lg border border-white/10 bg-black/30 p-3">
             <p className="text-[10px] uppercase tracking-[0.18em] text-zinc-500">
-              Mean Target
+              Weighted Target
             </p>
             <p className={`mt-1 text-2xl font-bold ${typeof mean === "number" && typeof current === "number" ? (mean > current ? "hib-target-up" : "hib-target-down") : "text-zinc-200"}`}>
               {fmtMoney(mean, ctx, "price")}

--- a/frontend/src/app/(app)/discovery/page.tsx
+++ b/frontend/src/app/(app)/discovery/page.tsx
@@ -117,6 +117,9 @@ function SectionCard({
                   <div>
                     <p className="text-zinc-500">Return</p>
                     <p className={accent}>{fmtPct(row.return_pct)}</p>
+                    {typeof row.simple_mean_return_pct === "number" && Number.isFinite(row.simple_mean_return_pct) ? (
+                      <p className="mt-0.5 text-[11px] text-zinc-500">Simple mean {fmtPct(row.simple_mean_return_pct)}</p>
+                    ) : null}
                   </div>
                 ) : metricLabel === "allocation" ? (
                   <div>

--- a/frontend/src/app/api/discovery/route.ts
+++ b/frontend/src/app/api/discovery/route.ts
@@ -270,6 +270,12 @@ export async function GET(request: Request) {
     if (!meanTarget) continue;
 
     const returnPct = ((meanTarget - prepared.current) / prepared.current) * 100;
+    const simpleMeanTarget =
+      lens.type === "overall" ? safeNumOrNull(prepared.summary.overview.simple_mean_target_price) : null;
+    const simpleMeanReturnPct =
+      typeof simpleMeanTarget === "number" && prepared.current
+        ? ((simpleMeanTarget - prepared.current) / prepared.current) * 100
+        : null;
     const overvaluation = ((prepared.current - meanTarget) / prepared.current) * 100;
     const confidenceCv =
       typeof prepared.summary.overview.mean_disagreement_score === "number" &&
@@ -295,6 +301,8 @@ export async function GET(request: Request) {
       overvaluation_pct: overvaluation,
       dispersion: confidenceCv,
       return_pct: returnPct,
+      simple_mean_target_price: simpleMeanTarget,
+      simple_mean_return_pct: simpleMeanReturnPct,
       investment_allocation_pct: positionPct,
       confidence_cv: confidenceCv,
       points_score: typeof adjustedScore === "number" && Number.isFinite(adjustedScore) ? adjustedScore : null,

--- a/frontend/src/components/hedge-dashboard.tsx
+++ b/frontend/src/components/hedge-dashboard.tsx
@@ -272,6 +272,7 @@ export function fmtMarketCap(v: number | null | undefined, ctx: CurrencyContext)
 const fmtNum = (v?: number | null) =>
   typeof v === "number" && Number.isFinite(v) ? new Intl.NumberFormat("en-US", { maximumFractionDigits: 4 }).format(v) : "N/A";
 const fmtPct = (v?: number | null) => (typeof v === "number" && Number.isFinite(v) ? `${v >= 0 ? "+" : ""}${v.toFixed(2)}%` : "N/A");
+const fmtWeightPct = (v?: number | null) => (typeof v === "number" && Number.isFinite(v) ? `${v.toFixed(1)}%` : "N/A");
 const fmtLargeAware = (v?: number | null) => {
   if (typeof v !== "number" || !Number.isFinite(v)) return "N/A";
   const abs = Math.abs(v);
@@ -1283,9 +1284,17 @@ export function HedgeDashboard({
     typeof consensus?.mean_target_price === "number" && Number.isFinite(consensus.mean_target_price)
       ? Number(consensus.mean_target_price)
       : null;
+  const consensusSimpleMean =
+    typeof consensus?.simple_mean_target_price === "number" && Number.isFinite(consensus.simple_mean_target_price)
+      ? Number(consensus.simple_mean_target_price)
+      : null;
   const consensusChangePct =
     typeof consensusCurrent === "number" && typeof consensusMean === "number" && Math.abs(consensusCurrent) > 1e-9
       ? ((consensusMean - consensusCurrent) / consensusCurrent) * 100
+      : null;
+  const consensusSimpleChangePct =
+    typeof consensusCurrent === "number" && typeof consensusSimpleMean === "number" && Math.abs(consensusCurrent) > 1e-9
+      ? ((consensusSimpleMean - consensusCurrent) / consensusCurrent) * 100
       : null;
   const consensusCvRaw =
     typeof consensus?.cv === "number" && Number.isFinite(consensus.cv) ? Math.abs(Number(consensus.cv)) : null;
@@ -1316,8 +1325,11 @@ export function HedgeDashboard({
   const activeMethodTargetChangeClass = toneClassFromSign(activeMethodTargetChangePct);
   const selectedOutputTargetChangeClass = toneClassFromSign(selectedOutputTargetChangePct);
   const consensusMeanClass = toneClassFromTarget(consensusMean, consensusCurrent);
+  const consensusSimpleMeanClass = toneClassFromTarget(consensusSimpleMean, consensusCurrent);
   const consensusChangeClass = toneClassFromSign(consensusChangePct);
+  const consensusSimpleChangeClass = toneClassFromSign(consensusSimpleChangePct);
   const consensusMeanText = fmtTargetOrFloor(consensus?.mean_target_price, currencyContext);
+  const consensusSimpleMeanText = fmtTargetOrFloor(consensus?.simple_mean_target_price, currencyContext);
   const consensusCurrentText = fmtMoneyCompact(consensus?.current_price, currencyContext, "price");
   const consensusChangeText = typeof consensusChangePct === "number" ? fmtPct(consensusChangePct) : "N/A";
   const overallDisagreement =
@@ -1370,6 +1382,10 @@ export function HedgeDashboard({
         name: b.name,
         target,
         investment: b.investment_amount,
+        weightPct:
+          typeof b.weight_pct === "number" && Number.isFinite(Number(b.weight_pct))
+            ? Number(b.weight_pct)
+            : null,
         changePct,
         combinedScore: combinedScore(b.investment_amount, changePct),
       };
@@ -1401,6 +1417,10 @@ export function HedgeDashboard({
           name: String(member.persona || `Valuator ${idx + 1}`).trim(),
           target,
           investment,
+          weightPct:
+            typeof member.weight_pct === "number" && Number.isFinite(Number(member.weight_pct))
+              ? Number(member.weight_pct)
+              : null,
           changePct,
           combinedScore: combinedScore(investment, changePct),
         };
@@ -1849,14 +1869,23 @@ export function HedgeDashboard({
               <section className="mb-6 rounded-2xl border border-white/10 bg-zinc-950/70 p-4">
                 <div className="rounded-xl border border-white/10 bg-black/30 p-4">
                   <p className="text-sm font-semibold uppercase tracking-[0.2em] text-zinc-100">Main Results</p>
-                  <div className="mt-2 grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+                  <div className="mt-2 grid gap-3 sm:grid-cols-2 xl:grid-cols-6">
                     <div className="min-w-0 rounded-lg border border-white/10 bg-black/25 p-3">
-                      <p className="text-xs font-semibold uppercase tracking-[0.16em] text-zinc-200">Mean Target Price</p>
+                      <p className="text-xs font-semibold uppercase tracking-[0.16em] text-zinc-200">Weighted Target Price</p>
                       <AutoFitMetric
                         text={consensusMeanText}
                         maxPx={42}
                         minPx={16}
                         className={`hib-metric-value mt-1 font-bold leading-tight ${consensusMeanClass}`}
+                      />
+                    </div>
+                    <div className="min-w-0 rounded-lg border border-white/10 bg-black/25 p-3">
+                      <p className="text-xs font-semibold uppercase tracking-[0.16em] text-zinc-200">Simple Mean</p>
+                      <AutoFitMetric
+                        text={consensusSimpleMeanText}
+                        maxPx={42}
+                        minPx={16}
+                        className={`hib-metric-value mt-1 font-bold leading-tight ${consensusSimpleMeanClass}`}
                       />
                     </div>
                     <div className="min-w-0 rounded-lg border border-white/10 bg-black/25 p-3">
@@ -1940,8 +1969,11 @@ export function HedgeDashboard({
                               <span className={`font-semibold ${toneClassFromSign(row.changePct)}`}>
                                 {typeof row.changePct === "number" ? fmtPct(row.changePct) : "-"}
                               </span>
-                              <span className={`font-semibold ${toneClassFromSign(row.investment)}`}>
-                                {fmtNotionalPct(row.investment)}
+                              <span className="text-right">
+                                <span className={`block font-semibold ${toneClassFromSign(row.investment)}`}>
+                                  {fmtNotionalPct(row.investment)}
+                                </span>
+                                <span className="block text-[11px] text-zinc-500">Weight {fmtWeightPct(row.weightPct)}</span>
                               </span>
                             </div>
                             <p className={`mt-1 text-xs font-semibold ${toneClassFromSign(rowAdjustedScore)}`}>
@@ -1952,7 +1984,7 @@ export function HedgeDashboard({
                       })}
                     </div>
                     <div className="overflow-x-auto rounded-xl border border-white/10 bg-black/30">
-                    <table className="hidden w-full min-w-[640px] text-sm sm:table">
+                    <table className="hidden w-full min-w-[720px] text-sm sm:table">
                       <thead className="border-b border-white/10 text-zinc-400">
                         <tr>
                           <th className="px-3 py-2 text-left font-medium">Model Name</th>
@@ -1964,6 +1996,7 @@ export function HedgeDashboard({
                               <InfoTip text="This is the total amount the model chose to invest in the stock (negative means a short position)." />
                             </span>
                           </th>
+                          <th className="px-3 py-2 text-right font-medium">Weight</th>
                           <th className="px-3 py-2 text-right font-medium">Score</th>
                         </tr>
                       </thead>
@@ -1991,6 +2024,9 @@ export function HedgeDashboard({
                             </td>
                             <td className={`px-3 py-2 text-right font-semibold ${toneClassFromSign(row.investment)}`}>
                               {fmtNotionalPct(row.investment)}
+                            </td>
+                            <td className="px-3 py-2 text-right font-semibold text-zinc-200">
+                              {fmtWeightPct(row.weightPct)}
                             </td>
                             <td className={`px-3 py-2 text-right font-semibold ${toneClassFromSign(rowAdjustedScore)}`}>
                               {typeof rowAdjustedScore === "number" && Number.isFinite(rowAdjustedScore) ? rowAdjustedScore.toFixed(2) : "N/A"}
@@ -2025,8 +2061,11 @@ export function HedgeDashboard({
                                   <span className={`font-semibold ${toneClassFromSign(row.changePct)}`}>
                                     {typeof row.changePct === "number" ? fmtPct(row.changePct) : "-"}
                                   </span>
-                                  <span className={`font-semibold ${toneClassFromSign(row.investment)}`}>
-                                    {fmtNotionalPct(row.investment)}
+                                  <span className="text-right">
+                                    <span className={`block font-semibold ${toneClassFromSign(row.investment)}`}>
+                                      {fmtNotionalPct(row.investment)}
+                                    </span>
+                                    <span className="block text-[11px] text-zinc-500">Weight {fmtWeightPct(row.weightPct)}</span>
                                   </span>
                                 </div>
                                 <p className={`mt-1 text-xs font-semibold ${toneClassFromSign(rowAdjustedScore)}`}>
@@ -2037,13 +2076,14 @@ export function HedgeDashboard({
                           })}
                         </div>
                         <div className="overflow-x-auto rounded-xl border border-white/10 bg-black/30">
-                          <table className="hidden w-full min-w-[640px] text-sm sm:table">
+                          <table className="hidden w-full min-w-[720px] text-sm sm:table">
                             <thead className="border-b border-white/10 text-zinc-400">
                               <tr>
                                 <th className="px-3 py-2 text-left font-medium">Valuator Name</th>
                                 <th className="px-3 py-2 text-right font-medium">Target Price</th>
                                 <th className="px-3 py-2 text-right font-medium">Change vs Current</th>
                                 <th className="px-3 py-2 text-right font-medium">Investment %</th>
+                                <th className="px-3 py-2 text-right font-medium">Weight</th>
                                 <th className="px-3 py-2 text-right font-medium">Score</th>
                               </tr>
                             </thead>
@@ -2069,6 +2109,9 @@ export function HedgeDashboard({
                                     </td>
                                     <td className={`px-3 py-2 text-right font-semibold ${toneClassFromSign(row.investment)}`}>
                                       {fmtNotionalPct(row.investment)}
+                                    </td>
+                                    <td className="px-3 py-2 text-right font-semibold text-zinc-200">
+                                      {fmtWeightPct(row.weightPct)}
                                     </td>
                                     <td className={`px-3 py-2 text-right font-semibold ${toneClassFromSign(rowAdjustedScore)}`}>
                                       {typeof rowAdjustedScore === "number" && Number.isFinite(rowAdjustedScore) ? rowAdjustedScore.toFixed(2) : "N/A"}
@@ -2096,6 +2139,9 @@ export function HedgeDashboard({
                       </p>
                       <p className="text-sm text-zinc-400">
                         Mean Investment: <span className={`font-semibold ${activeMethodInvestmentClass}`}>{fmtNotionalPct(activeMethod.investment_amount)}</span>{" "}
+                      </p>
+                      <p className="text-sm text-zinc-400">
+                        Model Weight: <span className="font-semibold text-zinc-100">{fmtWeightPct(activeMethod.weight_pct)}</span>
                       </p>
                       {[...activeMethodProbabilityItems, ...activeMethodOtherMetricItems].map((item) => (
                         <p key={item.key} className="text-xs text-zinc-500">
@@ -2141,6 +2187,11 @@ export function HedgeDashboard({
                                 <p>
                                   Investment: <span className={`font-semibold ${selectedOutputInvestmentClass}`}>{fmtNotionalPct(selectedOutput.investment_amount)}</span>{" "}
                                 </p>
+                                {typeof selectedOutput.weight_pct === "number" && Number.isFinite(selectedOutput.weight_pct) ? (
+                                  <p>
+                                    Weight: <span className="font-semibold text-zinc-100">{fmtWeightPct(selectedOutput.weight_pct)}</span>
+                                  </p>
+                                ) : null}
                               </div>
                               <div className="mt-2 max-h-[28rem] overflow-auto text-sm text-zinc-200">
                                 {selectedOutput.reason_sections.length ? (
@@ -2287,12 +2338,21 @@ export function HedgeDashboard({
                     {typeof finalAdjustedScore === "number" && Number.isFinite(finalAdjustedScore) ? finalAdjustedScore.toFixed(2) : "N/A"}
                   </p>
                   <p className="mt-2 text-xl font-semibold text-zinc-100">
-                    <span>Mean Target Price: </span>
+                    <span>Weighted Target Price: </span>
                     <span className={consensusMeanClass}>{fmtTargetOrFloor(consensus?.mean_target_price, currencyContext)}</span>{" "}
                     <span className={consensusChangeClass}>
                       {typeof consensusChangePct === "number" ? `(${fmtPct(consensusChangePct)})` : "(N/A)"}
                     </span>
                   </p>
+                  {typeof consensusSimpleMean === "number" && Number.isFinite(consensusSimpleMean) ? (
+                    <p className="text-sm font-semibold text-zinc-300">
+                      <span>Simple Mean: </span>
+                      <span className={consensusSimpleMeanClass}>{consensusSimpleMeanText}</span>{" "}
+                      <span className={consensusSimpleChangeClass}>
+                        {typeof consensusSimpleChangePct === "number" ? `(${fmtPct(consensusSimpleChangePct)})` : "(N/A)"}
+                      </span>
+                    </p>
+                  ) : null}
                   <p className="text-lg font-semibold text-zinc-100">
                     <span>Mean Investment Score Input: </span>
                     <span className={toneClassFromSign(scoreCard.position_size_pct_of_notional)}>

--- a/frontend/src/components/target-price-chart.tsx
+++ b/frontend/src/components/target-price-chart.tsx
@@ -85,7 +85,7 @@ export function TargetPriceChart({ data }: { data: DashboardPayload | null }) {
       }));
     if (rows.length) return rows;
     return [
-      { name: "Mean", target: Number(consensus?.mean_target_price || 0), aboveCurrent: true, performer: "Consensus", investment: null },
+      { name: "Weighted", target: Number(consensus?.mean_target_price || 0), aboveCurrent: true, performer: "Consensus", investment: null },
       { name: "Current", target: Number(consensus?.current_price || 0), aboveCurrent: true, performer: "Market", investment: null },
     ];
   }, [consensus, consensusCurrent, data?.valuation_hub?.method_blocks, methodPerformerByName]);

--- a/frontend/src/lib/dashboard-fallback.ts
+++ b/frontend/src/lib/dashboard-fallback.ts
@@ -74,6 +74,8 @@ export function createFallbackDashboard(ticker: string): DashboardPayload {
       consensus: {
         current_price: null,
         mean_target_price: null,
+        weighted_mean_target_price: null,
+        simple_mean_target_price: null,
         std: null,
         cv: null,
         lmil: [],

--- a/frontend/src/lib/dashboard-types.ts
+++ b/frontend/src/lib/dashboard-types.ts
@@ -4,6 +4,8 @@ export type DashboardMethodBlock = {
   upside_pct: number | null;
   investment_amount: number | null;
   investment_pct: number | null;
+  weight_pct?: number | null;
+  allocation_rationale?: string;
   key_metric_means: Record<string, number>;
   sample_rationale: string;
 };
@@ -13,6 +15,8 @@ export type DashboardMethodOutput = {
   persona: string;
   target_price: number | null;
   investment_amount: number | null;
+  weight_pct?: number | null;
+  selection_rationale?: string;
   key_numeric_values: Array<{
     path: string;
     metric_key: string;
@@ -30,8 +34,38 @@ export type DashboardMethodTab = {
   name: string;
   target_price: number | null;
   investment_amount: number | null;
+  weight_pct?: number | null;
+  allocation_rationale?: string;
   key_metric_means: Record<string, number>;
   outputs: DashboardMethodOutput[];
+};
+
+export type ValuationRouterPayload = {
+  status?: string;
+  mode?: string;
+  active?: boolean;
+  rationale?: string;
+  reason?: string;
+  selected_method_names?: string[];
+  selected_dream_personas?: string[];
+  selected_methods?: Array<{
+    name?: string;
+    weight_pct?: number | null;
+    rationale?: string;
+  }>;
+  selected_personas?: Array<{
+    name?: string;
+    weight_pct?: number | null;
+    rationale?: string;
+  }>;
+  method_weights?: Record<string, number>;
+  persona_weights?: Record<string, number>;
+  requested_method_weights?: Record<string, number>;
+  final_method_weights?: Record<string, number>;
+  requested_persona_weights?: Record<string, number>;
+  final_persona_weights?: Record<string, number>;
+  failed_methods_after_retry?: string[];
+  failed_personas_after_retry?: string[];
 };
 
 export type TradingAgentsPayload = {
@@ -337,20 +371,26 @@ export type DashboardPayload = {
     consensus: {
       current_price?: number | null;
       mean_target_price?: number | null;
+      weighted_mean_target_price?: number | null;
+      simple_mean_target_price?: number | null;
       std?: number | null;
       cv?: number | null;
       lmil?: number[] | null;
     };
+    valuation_router?: ValuationRouterPayload;
     prices?: Record<string, unknown>;
     revenue?: Record<string, unknown>;
     net_income?: Record<string, unknown>;
     pe?: Record<string, unknown>;
   };
+  valuation_router?: ValuationRouterPayload;
   dream_team: Array<{
     persona: string;
     target_price: number | null;
     target_market_cap: number | null;
     investment_amount: number | null;
+    weight_pct?: number | null;
+    selection_rationale?: string;
     step_by_step_analysis?: string;
     target_market_cap_rationale?: string;
     investment_rationale?: string;
@@ -491,6 +531,8 @@ export type DiscoveryRow = {
   overvaluation_pct: number;
   dispersion: number;
   return_pct: number;
+  simple_mean_target_price?: number | null;
+  simple_mean_return_pct?: number | null;
   investment_allocation_pct: number | null;
   confidence_cv: number;
   points_score?: number | null;

--- a/frontend/src/lib/hit-rate-aggregate.test.ts
+++ b/frontend/src/lib/hit-rate-aggregate.test.ts
@@ -54,7 +54,7 @@ test("Overall model uses dashboard mean target and mean investment with correct 
     },
   ];
   payload.valuation_hub.consensus.mean_target_price = 80;
-  payload.decision_card.mean_investment_amount = -5000;
+  payload.decision_card!.mean_investment_amount = -5000;
 
   const reports: HitRateSourceReport[] = [{ ticker: "TEST", payload }];
   const live = new Map<string, number | null>([["TEST", 120]]); // actual direction is up vs baseline 100
@@ -78,10 +78,32 @@ test("Overall model uses dashboard mean target and mean investment with correct 
   assert.equal(overall.allocations.hit_rate_pct, 0);
 });
 
+test("Simple Mean model row does not contribute to weighted overview", () => {
+  const payload = basePayload();
+  payload.valuation_hub.consensus.mean_target_price = 80;
+  payload.valuation_hub.consensus.simple_mean_target_price = 130;
+  payload.decision_card!.mean_investment_amount = -5000;
+
+  const reports: HitRateSourceReport[] = [{ ticker: "TEST", payload }];
+  const live = new Map<string, number | null>([["TEST", 120]]);
+
+  const agg = computeHitRateAggregation(reports, live);
+  const simpleMean = agg.by_model.find((row) => row.key === "Simple Mean");
+  assert.ok(simpleMean);
+
+  assert.equal(simpleMean.targets.hits, 1);
+  assert.equal(simpleMean.targets.misses, 0);
+  assert.equal(simpleMean.targets.considered, 1);
+
+  assert.equal(agg.overview.targets.hits, 0);
+  assert.equal(agg.overview.targets.misses, 1);
+  assert.equal(agg.overview.targets.considered, 1);
+});
+
 test("Overall target < 0 is floored to 0 and neutral allocations are excluded from denominator", () => {
   const payload = basePayload();
   payload.valuation_hub.consensus.mean_target_price = -10; // floored to 0, still predicts down vs baseline 100
-  payload.decision_card.mean_investment_amount = 0; // neutral allocation verdict
+  payload.decision_card!.mean_investment_amount = 0; // neutral allocation verdict
 
   const reports: HitRateSourceReport[] = [{ ticker: "TEST", payload }];
   const live = new Map<string, number | null>([["TEST", 90]]); // actual direction is down

--- a/frontend/src/lib/hit-rate-aggregate.ts
+++ b/frontend/src/lib/hit-rate-aggregate.ts
@@ -206,7 +206,12 @@ export function computeHitRateAggregation(
             investment_amount: toNumOrNull(block.investment_amount),
           }));
 
-    const applyModelPrediction = (modelKey: string, targetPrice: number | null, investmentAmount: number | null) => {
+    const applyModelPrediction = (
+      modelKey: string,
+      targetPrice: number | null,
+      investmentAmount: number | null,
+      includeOverview = true,
+    ) => {
       if (!byModelMap.has(modelKey)) {
         byModelMap.set(modelKey, createMetricSet());
       }
@@ -217,11 +222,15 @@ export function computeHitRateAggregation(
 
       if (shouldIncludePrediction(mode, targetDirection)) {
         applyPrediction(modelMetric, "target", targetDirection, actualDirection);
-        applyPrediction(overview, "target", targetDirection, actualDirection);
+        if (includeOverview) {
+          applyPrediction(overview, "target", targetDirection, actualDirection);
+        }
       }
       if (shouldIncludePrediction(mode, allocationDirection)) {
         applyPrediction(modelMetric, "allocation", allocationDirection, actualDirection);
-        applyPrediction(overview, "allocation", allocationDirection, actualDirection);
+        if (includeOverview) {
+          applyPrediction(overview, "allocation", allocationDirection, actualDirection);
+        }
       }
     };
 
@@ -233,6 +242,14 @@ export function computeHitRateAggregation(
     const overallMeanInvestment = toNumOrNull((payload.score_card || payload.decision_card)?.mean_investment_amount);
     if (overallMeanTarget !== null || overallMeanInvestment !== null) {
       applyModelPrediction("Overall", overallMeanTarget, overallMeanInvestment);
+    }
+    const simpleMeanTarget =
+      toNumOrNull(payload.valuation_hub?.consensus?.simple_mean_target_price) ??
+      (Array.isArray(payload.valuation_hub?.prices?.["Simple Mean"])
+        ? toNumOrNull((payload.valuation_hub?.prices?.["Simple Mean"] as unknown[])[0])
+        : null);
+    if (simpleMeanTarget !== null) {
+      applyModelPrediction("Simple Mean", simpleMeanTarget, overallMeanInvestment, false);
     }
 
     for (const tab of methodTabs) {

--- a/frontend/src/lib/ticker-summary-aggregate.test.ts
+++ b/frontend/src/lib/ticker-summary-aggregate.test.ts
@@ -53,7 +53,8 @@ function basePayload(): DashboardPayload {
 test("computes overview/model/valuator/assumptions means across reports", () => {
   const p1 = basePayload();
   p1.valuation_hub.consensus.mean_target_price = 120;
-  p1.decision_card.position_size_pct_of_notional = 10;
+  p1.valuation_hub.consensus.simple_mean_target_price = 100;
+  p1.decision_card!.position_size_pct_of_notional = 10;
   p1.valuation_hub.method_tabs = [
     {
       name: "DCF",
@@ -113,7 +114,8 @@ test("computes overview/model/valuator/assumptions means across reports", () => 
 
   const p2 = basePayload();
   p2.valuation_hub.consensus.mean_target_price = 140;
-  p2.decision_card.position_size_pct_of_notional = 20;
+  p2.valuation_hub.consensus.simple_mean_target_price = 160;
+  p2.decision_card!.position_size_pct_of_notional = 20;
   p2.valuation_hub.method_tabs = [
     {
       name: "DCF",
@@ -180,7 +182,13 @@ test("computes overview/model/valuator/assumptions means across reports", () => 
   assert.equal(agg.coverage.reports_total, 2);
   assert.equal(agg.coverage.reports_in_window, 2);
   assert.equal(agg.overview.mean_target_price, 130);
+  assert.equal(agg.overview.simple_mean_target_price, 130);
   assert.equal(agg.overview.mean_allocation_pct, 15);
+
+  const simpleMean = agg.by_model.find((row) => row.key === "Simple Mean");
+  assert.ok(simpleMean);
+  assert.equal(simpleMean.mean_target_price, 130);
+  assert.equal(simpleMean.mean_allocation_pct, 15);
 
   const dcf = agg.by_model.find((row) => row.key === "Scenario DCF");
   assert.ok(dcf);

--- a/frontend/src/lib/ticker-summary-aggregate.ts
+++ b/frontend/src/lib/ticker-summary-aggregate.ts
@@ -35,9 +35,11 @@ export type TickerSummaryAggregation = {
   };
   overview: {
     mean_target_price: number | null;
+    simple_mean_target_price: number | null;
     mean_allocation_pct: number | null;
     mean_disagreement_score: number | null;
     target_samples: number;
+    simple_target_samples: number;
     allocation_samples: number;
     disagreement_samples: number;
   };
@@ -87,6 +89,11 @@ function safeTarget(value: unknown): number | null {
   const n = toNumOrNull(value);
   if (n === null) return null;
   return n < 0 ? 0 : n;
+}
+
+function priceRowMean(value: unknown): number | null {
+  if (!Array.isArray(value) || value.length < 1) return null;
+  return safeTarget(value[0]);
 }
 
 function normalizeLabel(value: string): string {
@@ -386,6 +393,7 @@ export function computeTickerSummaryAggregation(
 ): TickerSummaryAggregation {
   const filtered = filterReportsByWindow(reports, window);
   const overviewAcc = createMeanAccumulator();
+  const simpleMeanTargetAcc = createMeanAccumulator();
   const modelMap = new Map<string, MeanAccumulator>();
   const valuatorMap = new Map<string, MeanAccumulator>();
   const assumptionsMap = new Map<string, { label: string; acc: AssumptionAccumulator }>();
@@ -414,11 +422,15 @@ export function computeTickerSummaryAggregation(
   for (const report of filtered) {
     const payload = report.payload;
     const overviewTarget = safeTarget(payload.valuation_hub?.consensus?.mean_target_price);
+    const simpleMeanTarget =
+      safeTarget(payload.valuation_hub?.consensus?.simple_mean_target_price) ??
+      priceRowMean(payload.valuation_hub?.prices?.["Simple Mean"]);
     const overviewAllocation =
       toNumOrNull((payload.score_card || payload.decision_card)?.position_size_pct_of_notional) ??
       allocationPctFromAmount((payload.score_card || payload.decision_card)?.mean_investment_amount);
     const disagreementScore = disagreementScoreForReport(payload);
     applyMean(overviewAcc, overviewTarget, overviewAllocation, disagreementScore);
+    applyMean(simpleMeanTargetAcc, simpleMeanTarget, null, null);
 
     const methodTabs = Array.isArray(payload.valuation_hub?.method_tabs) ? payload.valuation_hub.method_tabs : [];
     const methodBlocks = Array.isArray(payload.valuation_hub?.method_blocks) ? payload.valuation_hub.method_blocks : [];
@@ -440,6 +452,9 @@ export function computeTickerSummaryAggregation(
       applyModel(row.name, row.targetPrice, row.allocationPct);
     }
     applyModel("Overall", overviewTarget, overviewAllocation);
+    if (simpleMeanTarget !== null) {
+      applyModel("Simple Mean", simpleMeanTarget, overviewAllocation);
+    }
 
     for (const tab of methodTabs) {
       const outputs = Array.isArray(tab.outputs) ? tab.outputs : [];
@@ -493,9 +508,11 @@ export function computeTickerSummaryAggregation(
     },
     overview: {
       mean_target_price: mean(overviewAcc.sumTarget, overviewAcc.countTarget),
+      simple_mean_target_price: mean(simpleMeanTargetAcc.sumTarget, simpleMeanTargetAcc.countTarget),
       mean_allocation_pct: mean(overviewAcc.sumAllocation, overviewAcc.countAllocation),
       mean_disagreement_score: mean(overviewAcc.sumDisagreement, overviewAcc.countDisagreement),
       target_samples: overviewAcc.countTarget,
+      simple_target_samples: simpleMeanTargetAcc.countTarget,
       allocation_samples: overviewAcc.countAllocation,
       disagreement_samples: overviewAcc.countDisagreement,
     },

--- a/src/ai_hedge/dashboard.py
+++ b/src/ai_hedge/dashboard.py
@@ -1334,20 +1334,31 @@ def _build_method_tab(
     method_target: Optional[float],
     method_investment: Optional[float],
     price_scale_multiplier: float = 1.0,
+    weight_pct: Optional[float] = None,
+    allocation_rationale: str = "",
+    persona_weight_pct_by_name: Optional[Dict[str, float]] = None,
+    persona_rationale_by_name: Optional[Dict[str, str]] = None,
 ) -> Dict[str, Any]:
     outputs: List[Dict[str, Any]] = []
+    persona_weights = persona_weight_pct_by_name if isinstance(persona_weight_pct_by_name, dict) else {}
+    persona_rationales = persona_rationale_by_name if isinstance(persona_rationale_by_name, dict) else {}
     for idx, item in enumerate(items, start=1):
         if not isinstance(item, dict):
             continue
         raw_json = _parse_raw_json_from_item(item)
         numeric_values = _extract_numeric_values(raw_json) if raw_json else []
         reason_sections = _extract_reason_sections(raw_json) if raw_json else []
+        persona = str(item.get("persona", "") or "").strip()
         outputs.append(
             {
                 "output_id": idx,
-                "persona": str(item.get("persona", "") or "").strip(),
+                "persona": persona,
                 "target_price": _scale_price_value(item.get("target_price"), price_scale_multiplier),
                 "investment_amount": _safe_float(item.get("investment_amount")),
+                "weight_pct": _safe_float(item.get("weight_pct"))
+                if _safe_float(item.get("weight_pct")) is not None
+                else _safe_float(persona_weights.get(persona)),
+                "selection_rationale": persona_rationales.get(persona, ""),
                 "key_numeric_values": [
                     {
                         "path": path,
@@ -1371,6 +1382,8 @@ def _build_method_tab(
         "name": method_name,
         "target_price": method_target,
         "investment_amount": method_investment,
+        "weight_pct": weight_pct,
+        "allocation_rationale": allocation_rationale,
         "key_metric_means": _method_metric_snapshot(method_name, items),
         "outputs": outputs,
     }
@@ -1956,6 +1969,10 @@ def build_dashboard_payload(
     current_price = _safe_float(prices.get("Current")) or _safe_float(variables_dict.get("price")) or 0.0
     overall = prices.get("Overall") if isinstance(prices.get("Overall"), (list, tuple)) else []
     consensus_price = _safe_float(overall[0]) if len(overall) >= 1 else None
+    weighted_overall = prices.get("Weighted Overall") if isinstance(prices.get("Weighted Overall"), (list, tuple)) else []
+    simple_overall = prices.get("Simple Mean") if isinstance(prices.get("Simple Mean"), (list, tuple)) else []
+    weighted_consensus_price = _safe_float(weighted_overall[0]) if len(weighted_overall) >= 1 else consensus_price
+    simple_mean_price = _safe_float(simple_overall[0]) if len(simple_overall) >= 1 else None
     confidence_std = _safe_float(prices.get("STD"))
     confidence_cv = _safe_float(prices.get("CV"))
     lmil = prices.get("LMIL") if isinstance(prices.get("LMIL"), (list, tuple)) else []
@@ -1984,6 +2001,26 @@ def build_dashboard_payload(
     method_details = explain_payload.get("methods", {}) if isinstance(explain_payload, dict) else {}
     aggregate_targets = explain_payload.get("aggregate_targets", {}) if isinstance(explain_payload, dict) else {}
     aggregate_investments = explain_payload.get("aggregate_investments", {}) if isinstance(explain_payload, dict) else {}
+    valuation_router = explain_payload.get("valuation_router", {}) if isinstance(explain_payload, dict) else {}
+    valuation_router = valuation_router if isinstance(valuation_router, dict) else {}
+    method_weight_pct = explain_payload.get("method_weight_pct", {}) if isinstance(explain_payload, dict) else {}
+    if not isinstance(method_weight_pct, dict):
+        method_weight_pct = valuation_router.get("final_method_weights", {}) if isinstance(valuation_router, dict) else {}
+    method_weight_pct = method_weight_pct if isinstance(method_weight_pct, dict) else {}
+    persona_weight_pct = explain_payload.get("persona_weight_pct", {}) if isinstance(explain_payload, dict) else {}
+    if not isinstance(persona_weight_pct, dict):
+        persona_weight_pct = valuation_router.get("final_persona_weights", {}) if isinstance(valuation_router, dict) else {}
+    persona_weight_pct = persona_weight_pct if isinstance(persona_weight_pct, dict) else {}
+    method_rationale_by_name = {
+        str(row.get("name", "") or "").strip(): str(row.get("rationale", "") or "").strip()
+        for row in (valuation_router.get("selected_methods", []) if isinstance(valuation_router, dict) else [])
+        if isinstance(row, dict)
+    }
+    persona_rationale_by_name = {
+        str(row.get("name", "") or "").strip(): str(row.get("rationale", "") or "").strip()
+        for row in (valuation_router.get("selected_personas", []) if isinstance(valuation_router, dict) else [])
+        if isinstance(row, dict)
+    }
     target_multiplier = _resolve_model_price_multiplier(
         aggregate_targets=aggregate_targets if isinstance(aggregate_targets, dict) else {},
         consensus_price=consensus_price,
@@ -2011,6 +2048,8 @@ def build_dashboard_payload(
             if isinstance(aggregate_investments, dict)
             else None
         )
+        method_weight = _safe_float(method_weight_pct.get(method_name)) if isinstance(method_weight_pct, dict) else None
+        allocation_rationale = method_rationale_by_name.get(method_name, "")
         investment_pct = (investment_amount / 100000.0) * 100.0 if investment_amount is not None else None
         upside_pct = ((target_price - current_price) / current_price) * 100.0 if (target_price is not None and current_price) else None
 
@@ -2034,6 +2073,8 @@ def build_dashboard_payload(
                 "upside_pct": upside_pct,
                 "investment_amount": investment_amount,
                 "investment_pct": investment_pct,
+                "weight_pct": method_weight,
+                "allocation_rationale": allocation_rationale,
                 "key_metric_means": _method_metric_snapshot(method_name, items),
                 "sample_rationale": sample_rationale,
             }
@@ -2045,6 +2086,10 @@ def build_dashboard_payload(
                 method_target=target_price,
                 method_investment=investment_amount,
                 price_scale_multiplier=target_multiplier,
+                weight_pct=method_weight,
+                allocation_rationale=allocation_rationale,
+                persona_weight_pct_by_name=persona_weight_pct if method_name == "Dream Team" else {},
+                persona_rationale_by_name=persona_rationale_by_name if method_name == "Dream Team" else {},
             )
         )
 
@@ -2070,6 +2115,10 @@ def build_dashboard_payload(
                 "target_price": _scale_price_value(item.get("target_price"), target_multiplier),
                 "target_market_cap": _safe_float(raw_json.get("target_market_cap")),
                 "investment_amount": _safe_float(item.get("investment_amount")),
+                "weight_pct": _safe_float(item.get("weight_pct"))
+                if _safe_float(item.get("weight_pct")) is not None
+                else _safe_float(persona_weight_pct.get(str(item.get("persona", "") or "").strip())),
+                "selection_rationale": persona_rationale_by_name.get(str(item.get("persona", "") or "").strip(), ""),
                 "step_by_step_analysis": _extract_reason_by_alias(
                     raw_json,
                     ["step_by_step_analysis", "step_by_step", "step_analysis", "analysis_step_by_step"],
@@ -2172,9 +2221,12 @@ def build_dashboard_payload(
             "method_blocks": method_blocks,
             "method_tabs": method_tabs,
             "all_values": all_values_payload,
+            "valuation_router": valuation_router,
             "consensus": {
                 "current_price": current_price,
                 "mean_target_price": consensus_price,
+                "weighted_mean_target_price": weighted_consensus_price,
+                "simple_mean_target_price": simple_mean_price,
                 "std": confidence_std,
                 "cv": confidence_cv,
                 "lmil": lmil,
@@ -2184,6 +2236,7 @@ def build_dashboard_payload(
             "net_income": final_dict.get("Net Income", {}),
             "pe": final_dict.get("P/E", {}),
         },
+        "valuation_router": valuation_router,
         "dream_team": dream_cards,
         "forecast_forensic_matrix": {
             "current_revenue": _safe_float(final_dict.get("Revenue", {}).get("Current")),

--- a/src/ai_hedge/legacy_port.py
+++ b/src/ai_hedge/legacy_port.py
@@ -3480,6 +3480,90 @@ DREAM_TEAM_DESCRIPTION_FILES = {
     "Stanley Druckenmiller": "stanley_druckenmiller.txt",
 }
 
+DEFAULT_DREAM_TEAM_VALUATORS = [
+    "Warren Buffett",
+    "Aswath Damodaran",
+    "Charlie Munger",
+    "Peter Lynch",
+    "Peter Thiel",
+    "Howard Marks",
+    "Bill Ackman",
+    "Cathie Wood",
+    "Ray Dalio",
+    "Stanley Druckenmiller",
+]
+
+VALUATION_METHOD_ORDER = [
+    "Scenario DCF",
+    "Target Scenario",
+    "Earnings Scenario",
+    "Revenue Scenario",
+    "Composite Scenario",
+    "SOTP Scenario",
+    "Dream Team",
+]
+
+VALUATION_METHOD_DESCRIPTIONS = {
+    "Scenario DCF": (
+        "A probability-weighted discounted cash flow framework. It asks for bull, base, "
+        "and bear cases, explicit cash-flow and discount-rate assumptions, and a final "
+        "intrinsic equity target."
+    ),
+    "Target Scenario": (
+        "A direct bull/base/bear target-market-cap model. It is useful when the company "
+        "can be valued from scenario-level equity outcomes rather than a full DCF."
+    ),
+    "Earnings Scenario": (
+        "A bull/base/bear earnings and P/E model. It is strongest for profitable "
+        "companies where representative earnings and valuation multiples matter."
+    ),
+    "Revenue Scenario": (
+        "A bull/base/bear revenue and EV/sales model. It is useful when sales scale, "
+        "growth durability, or revenue multiples are more reliable than earnings."
+    ),
+    "Composite Scenario": (
+        "A multi-driver scenario model combining revenue growth, margins, financing, tax, "
+        "and P/E assumptions. It is useful when no single driver should dominate."
+    ),
+    "SOTP Scenario": (
+        "A sum-of-the-parts scenario model. It is useful for conglomerates, platforms, "
+        "segments, cash/debt bridges, or businesses where separate activities deserve "
+        "different valuation logic."
+    ),
+    "Dream Team": (
+        "A panel of investor-persona valuators. Each persona applies a distinct investing "
+        "style, and the selected persona outputs are blended into one Dream Team model."
+    ),
+}
+
+VALUATION_METHOD_ALIASES = {
+    "dcf": "Scenario DCF",
+    "scenario dcf price valuation": "Scenario DCF",
+    "scenario dcf valuation": "Scenario DCF",
+    "target": "Target Scenario",
+    "target scenario valuation": "Target Scenario",
+    "earnings": "Earnings Scenario",
+    "earnings scenario valuation": "Earnings Scenario",
+    "net income": "Earnings Scenario",
+    "net income & p/e": "Earnings Scenario",
+    "revenue": "Revenue Scenario",
+    "revenue scenario valuation": "Revenue Scenario",
+    "revenue & ev/s": "Revenue Scenario",
+    "composite": "Composite Scenario",
+    "composite scenario valuation": "Composite Scenario",
+    "sotp": "SOTP Scenario",
+    "sotp scenario valuation": "SOTP Scenario",
+    "sum of the parts": "SOTP Scenario",
+    "sum-of-the-parts": "SOTP Scenario",
+    "dream": "Dream Team",
+    "dream team model": "Dream Team",
+    "dream team target price valuation": "Dream Team",
+}
+
+VALUATION_ROUTER_MIN_METHODS = 3
+VALUATION_ROUTER_MIN_DREAM_PERSONAS = 3
+VALUATION_ROUTER_MIN_DREAM_WEIGHT_PCT = 10.0
+
 
 @lru_cache(maxsize=32)
 def _dream_team_description_for(name: str) -> str:
@@ -5331,6 +5415,538 @@ def _normalize_valuation_contexts(base_text, valuation_contexts):
     return [base]
 
 
+def _router_float(value: Any) -> Optional[float]:
+    if isinstance(value, bool):
+        return None
+    try:
+        out = float(value)
+    except Exception:
+        return None
+    if not np.isfinite(out):
+        return None
+    return out
+
+
+def _router_clean_text(value: Any, max_chars: int = 500) -> str:
+    text_value = str(value or "").strip()
+    if len(text_value) <= max_chars:
+        return text_value
+    return text_value[:max_chars].rstrip()
+
+
+def _canonical_valuation_method_name(value: Any) -> Optional[str]:
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    for method_name in VALUATION_METHOD_ORDER:
+        if raw.lower() == method_name.lower():
+            return method_name
+    return VALUATION_METHOD_ALIASES.get(raw.lower())
+
+
+def _canonical_dream_persona_name(value: Any, available_personas: Iterable[str]) -> Optional[str]:
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    for persona in available_personas:
+        if raw.lower() == str(persona).lower():
+            return str(persona)
+    return None
+
+
+def _router_items(value: Any, *, name_keys: Tuple[str, ...]) -> List[Dict[str, Any]]:
+    if isinstance(value, dict):
+        rows: List[Dict[str, Any]] = []
+        for name, weight in value.items():
+            if isinstance(weight, dict):
+                row = dict(weight)
+                row.setdefault("name", name)
+                rows.append(row)
+            else:
+                rows.append({"name": name, "weight_pct": weight})
+        return rows
+    if isinstance(value, list):
+        rows = []
+        for item in value:
+            if isinstance(item, dict):
+                row = dict(item)
+                if "name" not in row:
+                    for key in name_keys:
+                        if key in row:
+                            row["name"] = row.get(key)
+                            break
+                rows.append(row)
+            elif isinstance(item, str):
+                rows.append({"name": item})
+        return rows
+    return []
+
+
+def _extract_router_weight(row: Dict[str, Any]) -> Optional[float]:
+    for key in ("weight_pct", "weight_percent", "weight", "allocation_pct", "allocation_percent"):
+        if key not in row:
+            continue
+        val = _router_float(row.get(key))
+        if val is not None:
+            return max(0.0, float(val))
+    return None
+
+
+def _normalize_weights(
+    rows: List[Dict[str, Any]],
+    *,
+    name_key: str = "name",
+    min_weight_by_name: Optional[Dict[str, float]] = None,
+) -> List[Dict[str, Any]]:
+    if not rows:
+        return []
+    weights = []
+    for row in rows:
+        weight = _router_float(row.get("weight_pct"))
+        weights.append(max(0.0, float(weight)) if weight is not None else 0.0)
+
+    total = sum(weights)
+    if total <= 1e-9:
+        weights = [100.0 / len(rows)] * len(rows)
+    else:
+        weights = [(w / total) * 100.0 for w in weights]
+
+    min_map = min_weight_by_name or {}
+    for required_name, min_weight in min_map.items():
+        required_idx = None
+        for idx, row in enumerate(rows):
+            if str(row.get(name_key, "")).strip() == required_name:
+                required_idx = idx
+                break
+        if required_idx is None:
+            continue
+        min_weight = max(0.0, min(100.0, float(min_weight)))
+        if weights[required_idx] >= min_weight:
+            continue
+        remaining_total = sum(w for idx, w in enumerate(weights) if idx != required_idx)
+        weights[required_idx] = min_weight
+        remaining_budget = max(0.0, 100.0 - min_weight)
+        if remaining_total <= 1e-9:
+            other_count = max(1, len(rows) - 1)
+            for idx in range(len(weights)):
+                if idx != required_idx:
+                    weights[idx] = remaining_budget / other_count
+        else:
+            for idx, weight in enumerate(weights):
+                if idx != required_idx:
+                    weights[idx] = (weight / remaining_total) * remaining_budget
+
+    total = sum(weights)
+    if total > 1e-9:
+        weights = [(w / total) * 100.0 for w in weights]
+
+    normalized: List[Dict[str, Any]] = []
+    for row, weight in zip(rows, weights):
+        next_row = dict(row)
+        next_row["weight_pct"] = float(weight)
+        normalized.append(next_row)
+    return normalized
+
+
+def _valuation_method_catalog_text() -> str:
+    lines = []
+    for method_name in VALUATION_METHOD_ORDER:
+        lines.append(f"- {method_name}: {VALUATION_METHOD_DESCRIPTIONS[method_name]}")
+    return "\n".join(lines)
+
+
+def _dream_team_catalog_text(personas: Iterable[str]) -> str:
+    blocks = []
+    for persona in personas:
+        desc = _dream_team_description_for(str(persona))
+        blocks.append(
+            f"### {persona}\n{desc if desc else 'No additional profile file was available for this persona.'}"
+        )
+    return "\n\n".join(blocks)
+
+
+def _router_json_dumps(value: Any, max_chars: int = 20000) -> str:
+    try:
+        raw = json.dumps(value, ensure_ascii=False, default=str)
+    except Exception:
+        raw = str(value)
+    if len(raw) <= max_chars:
+        return raw
+    return raw[:max_chars].rstrip() + "...[truncated]"
+
+
+def build_valuation_router_prompt(
+    *,
+    ticker: str,
+    info_dict: Dict[str, Any],
+    financial_dict: Dict[str, Any],
+    variables_dict: Dict[str, Any],
+    analysis_text: str,
+    dream_team_personas: Iterable[str],
+) -> str:
+    company_name = ""
+    if isinstance(info_dict, dict):
+        company_name = str(
+            info_dict.get("short_name")
+            or (info_dict.get("info", {}) if isinstance(info_dict.get("info"), dict) else {}).get("shortName")
+            or ticker
+        )
+    financial_snapshot = {}
+    if isinstance(financial_dict, dict):
+        for key in ("currency_statement", "info", "info_financials", "rate"):
+            if key in financial_dict:
+                financial_snapshot[key] = financial_dict.get(key)
+
+    output_schema = """
+{
+  "rationale": "string explaining which valuation evidence matters most",
+  "selected_models": [
+    {
+      "name": "one exact model name from the catalog",
+      "weight_pct": number,
+      "rationale": "string"
+    }
+  ],
+  "dream_team": {
+    "rationale": "string",
+    "selected_valuators": [
+      {
+        "name": "one exact Dream Team persona name from the catalog",
+        "weight_pct": number,
+        "rationale": "string"
+      }
+    ]
+  }
+}
+""".strip()
+
+    return f"""
+You are the valuation-routing agent for {ticker} ({company_name}).
+
+Your job is to choose the right valuation models and Dream Team investor personas before the valuation agents run.
+Use the full company analysis context, financial context, and the model/persona catalogs below.
+
+Hard requirements:
+1) Choose at least {VALUATION_ROUTER_MIN_METHODS} valuation models in total.
+2) One selected model must be exactly "Dream Team".
+3) The "Dream Team" model weight must be at least {VALUATION_ROUTER_MIN_DREAM_WEIGHT_PCT:.0f}%.
+4) Choose at least {VALUATION_ROUTER_MIN_DREAM_PERSONAS} Dream Team personas.
+5) Model weights must sum to 100.
+6) Dream Team persona weights must sum to 100.
+7) Use only exact names from the catalogs.
+8) Return raw JSON only.
+
+Valuation model catalog:
+<valuation_models>
+{_valuation_method_catalog_text()}
+</valuation_models>
+
+Dream Team persona catalog:
+<dream_team_personas>
+{_dream_team_catalog_text(dream_team_personas)}
+</dream_team_personas>
+
+Structured company context:
+<structured_context>
+Ticker: {ticker}
+Company: {company_name}
+Variables: {_router_json_dumps(variables_dict)}
+Info: {_router_json_dumps(info_dict, max_chars=12000)}
+Financial snapshot: {_router_json_dumps(financial_snapshot, max_chars=20000)}
+</structured_context>
+
+Full analysis context:
+<analysis_context>
+{analysis_text}
+</analysis_context>
+
+Return this JSON shape exactly:
+{output_schema}
+""".strip()
+
+
+def _normalize_valuation_router_plan(
+    raw_plan: Dict[str, Any],
+    *,
+    available_methods: Iterable[str],
+    available_personas: Iterable[str],
+) -> Optional[Dict[str, Any]]:
+    if not isinstance(raw_plan, dict):
+        return None
+
+    available_method_set = set(str(m) for m in available_methods)
+    available_persona_list = [str(p) for p in available_personas]
+
+    raw_model_items = _router_items(
+        raw_plan.get("selected_models")
+        or raw_plan.get("models")
+        or raw_plan.get("valuation_models")
+        or raw_plan.get("selected_methods"),
+        name_keys=("name", "model", "method"),
+    )
+    model_rows: List[Dict[str, Any]] = []
+    seen_methods: Set[str] = set()
+    for row in raw_model_items:
+        method_name = _canonical_valuation_method_name(
+            row.get("name") or row.get("model") or row.get("method")
+        )
+        if not method_name or method_name not in available_method_set or method_name in seen_methods:
+            continue
+        seen_methods.add(method_name)
+        model_rows.append(
+            {
+                "name": method_name,
+                "weight_pct": _extract_router_weight(row),
+                "rationale": _router_clean_text(
+                    row.get("rationale")
+                    or row.get("reason")
+                    or row.get("why")
+                    or raw_plan.get("rationale")
+                ),
+            }
+        )
+
+    if "Dream Team" not in seen_methods:
+        return None
+    if len(model_rows) < VALUATION_ROUTER_MIN_METHODS:
+        return None
+
+    raw_dream = raw_plan.get("dream_team") if isinstance(raw_plan.get("dream_team"), dict) else {}
+    raw_persona_items = _router_items(
+        raw_dream.get("selected_valuators")
+        or raw_dream.get("valuators")
+        or raw_dream.get("selected_personas")
+        or raw_plan.get("selected_valuators")
+        or raw_plan.get("selected_personas")
+        or raw_plan.get("dream_team_personas"),
+        name_keys=("name", "persona", "valuator"),
+    )
+    persona_rows: List[Dict[str, Any]] = []
+    seen_personas: Set[str] = set()
+    for row in raw_persona_items:
+        persona_name = _canonical_dream_persona_name(
+            row.get("name") or row.get("persona") or row.get("valuator"),
+            available_persona_list,
+        )
+        if not persona_name or persona_name in seen_personas:
+            continue
+        seen_personas.add(persona_name)
+        persona_rows.append(
+            {
+                "name": persona_name,
+                "weight_pct": _extract_router_weight(row),
+                "rationale": _router_clean_text(
+                    row.get("rationale")
+                    or row.get("reason")
+                    or row.get("why")
+                    or raw_dream.get("rationale")
+                ),
+            }
+        )
+
+    if len(persona_rows) < VALUATION_ROUTER_MIN_DREAM_PERSONAS:
+        return None
+
+    model_rows = _normalize_weights(
+        model_rows,
+        min_weight_by_name={"Dream Team": VALUATION_ROUTER_MIN_DREAM_WEIGHT_PCT},
+    )
+    persona_rows = _normalize_weights(persona_rows)
+
+    method_weights = {row["name"]: float(row["weight_pct"]) for row in model_rows}
+    persona_weights = {row["name"]: float(row["weight_pct"]) for row in persona_rows}
+
+    return {
+        "status": "success",
+        "mode": "weighted_router",
+        "rationale": _router_clean_text(raw_plan.get("rationale"), max_chars=1200),
+        "selected_methods": model_rows,
+        "selected_personas": persona_rows,
+        "method_weights": method_weights,
+        "persona_weights": persona_weights,
+        "constraints": {
+            "min_methods_including_dream_team": VALUATION_ROUTER_MIN_METHODS,
+            "min_dream_team_personas": VALUATION_ROUTER_MIN_DREAM_PERSONAS,
+            "min_dream_team_weight_pct": VALUATION_ROUTER_MIN_DREAM_WEIGHT_PCT,
+        },
+    }
+
+
+def _fallback_valuation_router_plan(reason: str, *, raw_response: Optional[str] = None) -> Dict[str, Any]:
+    method_weight = 100.0 / len(VALUATION_METHOD_ORDER)
+    persona_weight = 100.0 / len(DEFAULT_DREAM_TEAM_VALUATORS)
+    payload = {
+        "status": "fallback",
+        "mode": "simple_all",
+        "reason": _router_clean_text(reason, max_chars=800),
+        "selected_methods": [
+            {"name": method_name, "weight_pct": method_weight, "rationale": "Fallback all-model simple mean."}
+            for method_name in VALUATION_METHOD_ORDER
+        ],
+        "selected_personas": [
+            {"name": persona, "weight_pct": persona_weight, "rationale": "Fallback full Dream Team."}
+            for persona in DEFAULT_DREAM_TEAM_VALUATORS
+        ],
+        "method_weights": {method_name: method_weight for method_name in VALUATION_METHOD_ORDER},
+        "persona_weights": {persona: persona_weight for persona in DEFAULT_DREAM_TEAM_VALUATORS},
+    }
+    if raw_response:
+        payload["raw_response"] = _router_clean_text(raw_response, max_chars=2000)
+    return payload
+
+
+def resolve_valuation_router_plan(
+    *,
+    ticker: str,
+    info_dict: Dict[str, Any],
+    financial_dict: Dict[str, Any],
+    variables_dict: Dict[str, Any],
+    analysis_text: str,
+    dream_team_personas: Iterable[str],
+) -> Dict[str, Any]:
+    api_key = os.getenv("DEEPSEEK_API_KEY", "").strip() or globals().get("DEEPSEEK_API_KEY", "")
+    if not api_key:
+        return _fallback_valuation_router_plan("DEEPSEEK_API_KEY is not configured.")
+
+    prompt = build_valuation_router_prompt(
+        ticker=ticker,
+        info_dict=info_dict if isinstance(info_dict, dict) else {},
+        financial_dict=financial_dict if isinstance(financial_dict, dict) else {},
+        variables_dict=variables_dict if isinstance(variables_dict, dict) else {},
+        analysis_text=str(analysis_text or ""),
+        dream_team_personas=dream_team_personas,
+    )
+    raw_response = ""
+    try:
+        with _obs_llm_context(stage="valuation.router"):
+            raw_response = deepseek_simple_text(
+                api_key=str(api_key),
+                prompt=prompt,
+                model="deepseek-reasoner",
+                temperature=0.0,
+                short_answer=False,
+            )
+        parsed = _extract_raw_json_dict(raw_response)
+        plan = _normalize_valuation_router_plan(
+            parsed,
+            available_methods=VALUATION_METHOD_ORDER,
+            available_personas=dream_team_personas,
+        )
+        if plan is None:
+            return _fallback_valuation_router_plan(
+                "Valuation router returned an invalid plan.",
+                raw_response=raw_response,
+            )
+        plan["raw_json"] = parsed
+        return plan
+    except Exception as exc:
+        return _fallback_valuation_router_plan(
+            f"Valuation router failed: {exc}",
+            raw_response=raw_response,
+        )
+
+
+def _mean_or_none(values: Iterable[float]) -> Optional[float]:
+    cleaned = []
+    for value in values:
+        val = _router_float(value)
+        if val is not None:
+            cleaned.append(float(val))
+    if not cleaned:
+        return None
+    return float(sum(cleaned) / len(cleaned))
+
+
+def _weighted_mean_from_map(values: Dict[str, Optional[float]], weights: Dict[str, float]) -> Optional[float]:
+    weighted_sum = 0.0
+    total_weight = 0.0
+    for key, raw_value in values.items():
+        value = _router_float(raw_value)
+        weight = _router_float(weights.get(key))
+        if value is None or weight is None or weight <= 0:
+            continue
+        weighted_sum += float(value) * float(weight)
+        total_weight += float(weight)
+    if total_weight <= 1e-9:
+        return None
+    return float(weighted_sum / total_weight)
+
+
+def _weighted_item_mean(
+    items: List[Dict[str, Any]],
+    *,
+    name_key: str,
+    value_key: str,
+    weights: Dict[str, float],
+) -> Optional[float]:
+    grouped: Dict[str, List[float]] = {}
+    iterable_items = items if isinstance(items, list) else []
+    for item in iterable_items:
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get(name_key, "") or "").strip()
+        value = _router_float(item.get(value_key))
+        if not name or value is None:
+            continue
+        grouped.setdefault(name, []).append(float(value))
+    values = {
+        name: _mean_or_none(vals)
+        for name, vals in grouped.items()
+        if name in weights and vals
+    }
+    return _weighted_mean_from_map(values, weights)
+
+
+def _redistribute_weights_to_successful(
+    requested_weights: Dict[str, float],
+    successful_names: Iterable[str],
+) -> Dict[str, float]:
+    successful = [str(name) for name in successful_names if str(name) in requested_weights]
+    if not successful:
+        return {}
+    total = sum(max(0.0, float(requested_weights.get(name, 0.0) or 0.0)) for name in successful)
+    if total <= 1e-9:
+        equal = 100.0 / len(successful)
+        return {name: equal for name in successful}
+    return {
+        name: (max(0.0, float(requested_weights.get(name, 0.0) or 0.0)) / total) * 100.0
+        for name in successful
+    }
+
+
+def make_weighted_short_list_prices(
+    list_of_all_results,
+    price_currency,
+    requested_method_weights: Dict[str, float],
+):
+    final_list, price_dict = make_short_list_prices(list_of_all_results, price_currency)
+    method_means = {
+        name: float(price_dict[name][0])
+        for _, name in list_of_all_results
+        if name in price_dict
+        and isinstance(price_dict.get(name), (list, tuple))
+        and len(price_dict[name]) >= 1
+        and _router_float(price_dict[name][0]) is not None
+    }
+    if not method_means:
+        return final_list, price_dict, {}, list(requested_method_weights.keys()), None
+
+    final_weights = _redistribute_weights_to_successful(requested_method_weights, method_means.keys())
+    weighted_mean = _weighted_mean_from_map(method_means, final_weights)
+    simple_mean = _mean_or_none(method_means.values())
+    method_values = list(method_means.values())
+    p25, p75 = np.quantile(np.asarray(method_values, dtype=float), [0.25, 0.75])
+    if weighted_mean is not None:
+        weighted_triplet = [float(weighted_mean), float(p25), float(p75)]
+        price_dict["Overall"] = weighted_triplet
+        price_dict["Weighted Overall"] = weighted_triplet
+    if simple_mean is not None:
+        price_dict["Simple Mean"] = [float(simple_mean), float(p25), float(p75)]
+    price_dict["Method Weights"] = final_weights
+    failed_methods = [name for name in requested_method_weights if name not in method_means]
+    return final_list, price_dict, final_weights, failed_methods, simple_mean
+
+
 # ---------------------------------------------------------------------
 # 4) Run ALL valuation blocks together in parallel
 #    - Collect their results + summary text
@@ -5369,32 +5985,14 @@ def run_valuations(
         text_input=text,
     )
 
-    dream_valuation_team = [
-    "Warren Buffett",
-    "Aswath Damodaran",
-    "Charlie Munger",
-    "Peter Lynch",
-    "Peter Thiel",
-    "Howard Marks",
-    "Bill Ackman",
-    "Cathie Wood",
-    "Ray Dalio",
-    "Stanley Druckenmiller",
-    ]
+    dream_valuation_team = list(DEFAULT_DREAM_TEAM_VALUATORS)
 
     price_currency = variables_dict.get("price_currency", 1)
     financial_currency = variables_dict.get("financial_currency", 1)
     collect_explain = isinstance(explain_collector, dict)
     collect_details_for_metrics = True
-    method_details = {
-        "Scenario DCF": [],
-        "Target Scenario": [],
-        "Earnings Scenario": [],
-        "Revenue Scenario": [],
-        "Composite Scenario": [],
-        "SOTP Scenario": [],
-        "Dream Team": [],
-    }
+    method_order = list(VALUATION_METHOD_ORDER)
+    method_details = {method_name: [] for method_name in method_order}
     def _collect_investment_values(items):
         out = []
         if not isinstance(items, list):
@@ -5426,6 +6024,61 @@ def run_valuations(
     context_model_schedule = ["deepseek-reasoner"] * len(context_schedule)
     print("valuation context passes:", len(context_schedule))
     print("valuation models per pass:", context_model_schedule)
+    valuation_router_plan = resolve_valuation_router_plan(
+        ticker=ticker,
+        info_dict=info_dict if isinstance(info_dict, dict) else {},
+        financial_dict=financial_dict if isinstance(financial_dict, dict) else {},
+        variables_dict=variables_dict if isinstance(variables_dict, dict) else {},
+        analysis_text=context_schedule[-1] if context_schedule else str(text or ""),
+        dream_team_personas=dream_valuation_team,
+    )
+    router_active = valuation_router_plan.get("mode") == "weighted_router"
+    selected_method_names = [
+        str(row.get("name", "")).strip()
+        for row in valuation_router_plan.get("selected_methods", [])
+        if isinstance(row, dict) and str(row.get("name", "")).strip() in method_order
+    ]
+    if not router_active:
+        selected_method_names = list(method_order)
+    selected_method_names = [name for name in method_order if name in set(selected_method_names)]
+    if not selected_method_names:
+        selected_method_names = list(method_order)
+        router_active = False
+    method_weight_pct_requested = (
+        {
+            str(name): float(weight)
+            for name, weight in (valuation_router_plan.get("method_weights") or {}).items()
+            if str(name) in selected_method_names and _router_float(weight) is not None
+        }
+        if router_active
+        else {}
+    )
+    selected_dream_personas = [
+        str(row.get("name", "")).strip()
+        for row in valuation_router_plan.get("selected_personas", [])
+        if isinstance(row, dict) and str(row.get("name", "")).strip() in dream_valuation_team
+    ]
+    if not router_active:
+        selected_dream_personas = list(dream_valuation_team)
+    if "Dream Team" in selected_method_names and len(selected_dream_personas) < VALUATION_ROUTER_MIN_DREAM_PERSONAS:
+        selected_dream_personas = list(dream_valuation_team)
+        router_active = False
+        valuation_router_plan = _fallback_valuation_router_plan("Router did not select enough Dream Team personas.")
+        selected_method_names = list(method_order)
+        method_weight_pct_requested = {}
+    dream_persona_weight_pct_requested = (
+        {
+            str(name): float(weight)
+            for name, weight in (valuation_router_plan.get("persona_weights") or {}).items()
+            if str(name) in selected_dream_personas and _router_float(weight) is not None
+        }
+        if router_active
+        else {}
+    )
+    print("valuation router mode:", valuation_router_plan.get("mode"))
+    print("valuation selected methods:", selected_method_names)
+    if "Dream Team" in selected_method_names:
+        print("valuation selected Dream Team personas:", selected_dream_personas)
     current_price = variables_dict["price"]
     current_revenue = variables_dict["revenue"]
     current_ni = variables_dict["net_income"]
@@ -5643,7 +6296,7 @@ def run_valuations(
                     ctx_results, ctx_summary, ctx_details = dream_valuation_full(
                         financial_dict,
                         ctx_text,
-                        dream_valuation_team,
+                        selected_dream_personas,
                         llm_workers=llm_workers_each_block,
                         model=model_name,
                         runtime_context=runtime_context,
@@ -5654,19 +6307,61 @@ def run_valuations(
                     ctx_results, ctx_summary = dream_valuation_full(
                         financial_dict,
                         ctx_text,
-                        dream_valuation_team,
+                        selected_dream_personas,
                         llm_workers=llm_workers_each_block,
                         model=model_name,
                         runtime_context=runtime_context,
                     )
                 all_results.extend(ctx_results)
                 summary_name = ctx_summary[1]
-        if all_results:
+        persona_final_weights: Dict[str, float] = {}
+        persona_failed: List[str] = []
+        if router_active and dream_persona_weight_pct_requested and details:
+            persona_targets: Dict[str, Optional[float]] = {}
+            for persona_name in selected_dream_personas:
+                vals = [
+                    float(item.get("target_price"))
+                    for item in details
+                    if isinstance(item, dict)
+                    and str(item.get("persona", "") or "").strip() == persona_name
+                    and _router_float(item.get("target_price")) is not None
+                ]
+                persona_targets[persona_name] = _mean_or_none(vals)
+            successful_personas = [
+                name for name, value in persona_targets.items() if _router_float(value) is not None
+            ]
+            persona_final_weights = _redistribute_weights_to_successful(
+                dream_persona_weight_pct_requested,
+                successful_personas,
+            )
+            persona_failed = [name for name in selected_dream_personas if name not in successful_personas]
+            weighted_dream_target = _weighted_mean_from_map(persona_targets, persona_final_weights)
+            if weighted_dream_target is not None:
+                all_results_mean = [float(weighted_dream_target)]
+            elif all_results:
+                all_results_mean = [sum(all_results) / len(all_results)]
+            else:
+                all_results_mean = []
+        elif all_results:
             all_results_mean = [sum(all_results) / len(all_results)]
         else:
             all_results_mean = []
-            
-        return all_results_mean, _plot_summary_or_empty(all_results_mean, summary_name), details
+
+        if persona_final_weights:
+            for item in details:
+                if not isinstance(item, dict):
+                    continue
+                persona_name = str(item.get("persona", "") or "").strip()
+                if persona_name in persona_final_weights:
+                    item["weight_pct"] = float(persona_final_weights[persona_name])
+
+        return (
+            all_results_mean,
+            _plot_summary_or_empty(all_results_mean, summary_name),
+            details,
+            persona_final_weights,
+            persona_failed,
+        )
 
     def _safe_future_result(fut, fallback, block_name):
         try:
@@ -5698,86 +6393,114 @@ def run_valuations(
             print(f"[INFO] {block_name} retry succeeded with valid JSON output.")
         return retried
 
-    # Launch all blocks in parallel
-    with ThreadPoolExecutor(max_workers=blocks_workers) as ex:
-        fut_dcf = ex.submit(_run_dcf_mixed)
-        fut_target_scenario = ex.submit(_run_target_scenario_mixed)
-        fut_earnings_scenario = ex.submit(_run_earnings_scenario_mixed)
-        fut_revenue_scenario = ex.submit(_run_revenue_scenario_mixed)
-        fut_composite_scenario = ex.submit(_run_composite_scenario_mixed)
-        fut_sotp_scenario = ex.submit(_run_sotp_scenario_mixed)
-        fut_dream = ex.submit(_run_dream_mixed)
+    all_results_dcf, text_dcf, details_dcf = [], ("\nNo results\n\n", "Scenario DCF Price Valuation"), []
+    all_results_target_scenario, text_target_scenario, details_target_scenario = [], ("\nNo results\n\n", "Target Scenario Valuation"), []
+    (
+        all_results_earnings_scenario,
+        ni_results_earnings_scenario,
+        pe_results_earnings_scenario,
+        text_earnings_scenario,
+        details_earnings_scenario,
+    ) = ([], [], [], ("\nNo results\n\n", "Earnings Scenario Valuation"), [])
+    (
+        all_results_revenue_scenario,
+        ps_results_revenue_scenario,
+        revenue_results_revenue_scenario,
+        text_revenue_scenario,
+        details_revenue_scenario,
+    ) = ([], [], [], ("\nNo results\n\n", "Revenue Scenario Valuation"), [])
+    (
+        all_results_composite_scenario,
+        revenue_results_composite_scenario,
+        ni_results_composite_scenario,
+        pe_results_composite_scenario,
+        text_composite_scenario,
+        details_composite_scenario,
+    ) = ([], [], [], [], ("\nNo results\n\n", "Composite Scenario Valuation"), [])
+    all_results_sotp_scenario, text_sotp_scenario, details_sotp_scenario = [], ("\nNo results\n\n", "SOTP Scenario Valuation"), []
+    (
+        all_results_dream,
+        text_dream,
+        details_dream,
+        dream_persona_weight_pct_final,
+        dream_failed_personas,
+    ) = ([], ("\nNo results\n\n", "Dream Team Target Price Valuation"), [], {}, [])
 
-        dcf_result = _safe_future_result(
-            fut_dcf,
+    runner_specs = {
+        "Scenario DCF": (
+            _run_dcf_mixed,
             ([], ("\nNo results\n\n", "Scenario DCF Price Valuation"), []),
             "Scenario DCF block",
-        )
-        dcf_result = _retry_block_once_if_empty(dcf_result, _run_dcf_mixed, "Scenario DCF block")
-        all_results_dcf, text_dcf, details_dcf = dcf_result
-
-        target_result = _safe_future_result(
-            fut_target_scenario,
+        ),
+        "Target Scenario": (
+            _run_target_scenario_mixed,
             ([], ("\nNo results\n\n", "Target Scenario Valuation"), []),
             "Target Scenario block",
-        )
-        target_result = _retry_block_once_if_empty(target_result, _run_target_scenario_mixed, "Target Scenario block")
-        all_results_target_scenario, text_target_scenario, details_target_scenario = target_result
-
-        earnings_result = _safe_future_result(
-            fut_earnings_scenario,
+        ),
+        "Earnings Scenario": (
+            _run_earnings_scenario_mixed,
             ([], [], [], ("\nNo results\n\n", "Earnings Scenario Valuation"), []),
             "Earnings Scenario block",
-        )
-        earnings_result = _retry_block_once_if_empty(
-            earnings_result,
-            _run_earnings_scenario_mixed,
-            "Earnings Scenario block",
-        )
+        ),
+        "Revenue Scenario": (
+            _run_revenue_scenario_mixed,
+            ([], [], [], ("\nNo results\n\n", "Revenue Scenario Valuation"), []),
+            "Revenue Scenario block",
+        ),
+        "Composite Scenario": (
+            _run_composite_scenario_mixed,
+            ([], [], [], [], ("\nNo results\n\n", "Composite Scenario Valuation"), []),
+            "Composite Scenario block",
+        ),
+        "SOTP Scenario": (
+            _run_sotp_scenario_mixed,
+            ([], ("\nNo results\n\n", "SOTP Scenario Valuation"), []),
+            "SOTP Scenario block",
+        ),
+        "Dream Team": (
+            _run_dream_mixed,
+            ([], ("\nNo results\n\n", "Dream Team Target Price Valuation"), [], {}, []),
+            "Dream Team block",
+        ),
+    }
+
+    max_block_workers = max(1, min(int(blocks_workers or 1), len(selected_method_names)))
+    with ThreadPoolExecutor(max_workers=max_block_workers) as ex:
+        futures = {
+            method_name: ex.submit(runner_specs[method_name][0])
+            for method_name in selected_method_names
+            if method_name in runner_specs
+        }
+        block_results = {}
+        for method_name in selected_method_names:
+            if method_name not in futures:
+                continue
+            rerun_fn, fallback, block_name = runner_specs[method_name]
+            result = _safe_future_result(futures[method_name], fallback, block_name)
+            result = _retry_block_once_if_empty(result, rerun_fn, block_name)
+            block_results[method_name] = result
+
+    if "Scenario DCF" in block_results:
+        all_results_dcf, text_dcf, details_dcf = block_results["Scenario DCF"]
+    if "Target Scenario" in block_results:
+        all_results_target_scenario, text_target_scenario, details_target_scenario = block_results["Target Scenario"]
+    if "Earnings Scenario" in block_results:
         (
             all_results_earnings_scenario,
             ni_results_earnings_scenario,
             pe_results_earnings_scenario,
             text_earnings_scenario,
             details_earnings_scenario,
-        ) = earnings_result
-
-        revenue_result = _safe_future_result(
-            fut_revenue_scenario,
-            ([], [], [], ("\nNo results\n\n", "Revenue Scenario Valuation"), []),
-            "Revenue Scenario block",
-        )
-        revenue_result = _retry_block_once_if_empty(
-            revenue_result,
-            _run_revenue_scenario_mixed,
-            "Revenue Scenario block",
-        )
+        ) = block_results["Earnings Scenario"]
+    if "Revenue Scenario" in block_results:
         (
             all_results_revenue_scenario,
             ps_results_revenue_scenario,
             revenue_results_revenue_scenario,
             text_revenue_scenario,
             details_revenue_scenario,
-        ) = revenue_result
-
-        dream_result = _safe_future_result(
-            fut_dream,
-            ([], ("\nNo results\n\n", "Dream Team Target Price Valuation"), []),
-            "Dream Team block",
-        )
-        dream_result = _retry_block_once_if_empty(dream_result, _run_dream_mixed, "Dream Team block")
-        all_results_dream, text_dream, details_dream = dream_result
-
-        composite_result = _safe_future_result(
-            fut_composite_scenario,
-            ([], [], [], [], ("\nNo results\n\n", "Composite Scenario Valuation"), []),
-            "Composite Scenario block",
-        )
-        composite_result = _retry_block_once_if_empty(
-            composite_result,
-            _run_composite_scenario_mixed,
-            "Composite Scenario block",
-        )
+        ) = block_results["Revenue Scenario"]
+    if "Composite Scenario" in block_results:
         (
             all_results_composite_scenario,
             revenue_results_composite_scenario,
@@ -5785,15 +6508,17 @@ def run_valuations(
             pe_results_composite_scenario,
             text_composite_scenario,
             details_composite_scenario,
-        ) = composite_result
-
-        sotp_result = _safe_future_result(
-            fut_sotp_scenario,
-            ([], ("\nNo results\n\n", "SOTP Scenario Valuation"), []),
-            "SOTP Scenario block",
-        )
-        sotp_result = _retry_block_once_if_empty(sotp_result, _run_sotp_scenario_mixed, "SOTP Scenario block")
-        all_results_sotp_scenario, text_sotp_scenario, details_sotp_scenario = sotp_result
+        ) = block_results["Composite Scenario"]
+    if "SOTP Scenario" in block_results:
+        all_results_sotp_scenario, text_sotp_scenario, details_sotp_scenario = block_results["SOTP Scenario"]
+    if "Dream Team" in block_results:
+        (
+            all_results_dream,
+            text_dream,
+            details_dream,
+            dream_persona_weight_pct_final,
+            dream_failed_personas,
+        ) = block_results["Dream Team"]
 
     method_details["Scenario DCF"] = details_dcf
     method_details["Target Scenario"] = details_target_scenario
@@ -5803,25 +6528,94 @@ def run_valuations(
     method_details["SOTP Scenario"] = details_sotp_scenario
     method_details["Dream Team"] = details_dream
 
+    all_results_list_all = [
+        (all_results_dcf, "Scenario DCF"),
+        (all_results_target_scenario, "Target Scenario"),
+        (all_results_earnings_scenario, "Earnings Scenario"),
+        (all_results_revenue_scenario, "Revenue Scenario"),
+        (all_results_composite_scenario, "Composite Scenario"),
+        (all_results_sotp_scenario, "SOTP Scenario"),
+        (all_results_dream, "Dream Team"),
+    ]
+    all_results_list = [
+        (results, method_name)
+        for results, method_name in all_results_list_all
+        if method_name in selected_method_names
+    ]
+
+    if router_active:
+        (
+            all_results_currency,
+            dict_of_prices,
+            method_weight_pct_final,
+            failed_methods,
+            simple_mean_price,
+        ) = make_weighted_short_list_prices(
+            all_results_list,
+            price_currency,
+            method_weight_pct_requested,
+        )
+        if "Overall" not in dict_of_prices:
+            all_results_currency, dict_of_prices = make_short_list_prices(all_results_list, price_currency)
+            method_weight_pct_final = {}
+            failed_methods = [
+                method_name for _, method_name in all_results_list if method_name not in dict_of_prices
+            ]
+            simple_mean_price = (
+                float(dict_of_prices["Overall"][0])
+                if isinstance(dict_of_prices.get("Overall"), (list, tuple)) and dict_of_prices["Overall"]
+                else None
+            )
+            valuation_router_plan = _fallback_valuation_router_plan(
+                "No selected valuation model produced a valid target after retry."
+            )
+            router_active = False
+    else:
+        all_results_currency, dict_of_prices = make_short_list_prices(all_results_list, price_currency)
+        method_weight_pct_final = {}
+        failed_methods = []
+        simple_mean_price = (
+            float(dict_of_prices["Overall"][0])
+            if isinstance(dict_of_prices.get("Overall"), (list, tuple)) and dict_of_prices["Overall"]
+            else None
+        )
+
+    if "Overall" not in dict_of_prices:
+        fallback_price = float(current_price * price_currency)
+        dict_of_prices["Overall"] = [fallback_price, fallback_price, fallback_price]
+        dict_of_prices["STD"] = 0.0
+    dict_of_prices["Current"] = current_price * price_currency
+    if "STD" not in dict_of_prices:
+        dict_of_prices["STD"] = 0.0
+    mean_overall = dict_of_prices["Overall"][0]
+    dict_of_prices["CV"] = (
+        dict_of_prices["STD"] / ((dict_of_prices["Current"] + mean_overall) / 2)
+        if abs((dict_of_prices["Current"] + mean_overall) / 2) > 1e-9
+        else 0.0
+    )
+    if router_active and simple_mean_price is not None:
+        dict_of_prices["Simple Mean"] = dict_of_prices.get("Simple Mean") or [
+            float(simple_mean_price),
+            float(simple_mean_price),
+            float(simple_mean_price),
+        ]
+        dict_of_prices["Weighted Overall"] = dict_of_prices.get("Weighted Overall") or dict_of_prices["Overall"]
+        dict_of_prices["Requested Method Weights"] = method_weight_pct_requested
+        dict_of_prices["Final Method Weights"] = method_weight_pct_final
+        dict_of_prices["Failed Methods"] = failed_methods
+
+    if method_weight_pct_final:
+        for method_name, items in method_details.items():
+            if not isinstance(items, list):
+                continue
+            for item in items:
+                if isinstance(item, dict) and method_name in method_weight_pct_final:
+                    item["method_weight_pct"] = float(method_weight_pct_final[method_name])
+
     all_investment_values = []
     for method_name, items in method_details.items():
         _ = method_name
         all_investment_values.extend(_collect_investment_values(items))
-
-    if all_investment_values:
-        inv_arr = np.asarray(all_investment_values, dtype=float)
-        mean_investment = float(inv_arr.mean())
-        std_investment = float(inv_arr.std())
-    else:
-        mean_investment = 0.0
-        std_investment = 0.0
-
-    mean_investment_percent = (mean_investment / 100000.0) * 100.0
-    if abs(mean_investment) > 1e-9:
-        investment_cv = float(std_investment / mean_investment)
-    else:
-        investment_cv = 0.0
-    lmil = [mean_investment_percent, investment_cv]
 
     aggregate_investments = {
         "Scenario DCF": _mean_investment_for_method(method_details["Scenario DCF"]),
@@ -5830,8 +6624,42 @@ def run_valuations(
         "Revenue Scenario": _mean_investment_for_method(method_details["Revenue Scenario"]),
         "Composite Scenario": _mean_investment_for_method(method_details["Composite Scenario"]),
         "SOTP Scenario": _mean_investment_for_method(method_details["SOTP Scenario"]),
-        "Dream Team": _mean_investment_for_method(method_details["Dream Team"]),
+        "Dream Team": (
+            _weighted_item_mean(
+                method_details["Dream Team"],
+                name_key="persona",
+                value_key="investment_amount",
+                weights=dream_persona_weight_pct_final,
+            )
+            if router_active and dream_persona_weight_pct_final
+            else _mean_investment_for_method(method_details["Dream Team"])
+        ),
     }
+
+    if all_investment_values:
+        inv_arr = np.asarray(all_investment_values, dtype=float)
+        std_investment = float(inv_arr.std())
+    else:
+        std_investment = 0.0
+    weighted_investment = (
+        _weighted_mean_from_map(aggregate_investments, method_weight_pct_final)
+        if router_active and method_weight_pct_final
+        else None
+    )
+    if weighted_investment is not None:
+        mean_investment = float(weighted_investment)
+    elif all_investment_values:
+        mean_investment = float(np.asarray(all_investment_values, dtype=float).mean())
+    else:
+        mean_investment = 0.0
+
+    mean_investment_percent = (mean_investment / 100000.0) * 100.0
+    if abs(mean_investment) > 1e-9:
+        investment_cv = float(std_investment / mean_investment)
+    else:
+        investment_cv = 0.0
+    lmil = [mean_investment_percent, investment_cv]
+
     aggregate_investment_percents = {
         method_name: (
             (float(amount) / 100000.0) * 100.0
@@ -5841,21 +6669,6 @@ def run_valuations(
         for method_name, amount in aggregate_investments.items()
     }
 
-    # Build final_dict (same logic as your original)
-    all_results_list = [
-        (all_results_dcf, "Scenario DCF"),
-        (all_results_target_scenario, "Target Scenario"),
-        (all_results_earnings_scenario, "Earnings Scenario"),
-        (all_results_revenue_scenario, "Revenue Scenario"),
-        (all_results_composite_scenario, "Composite Scenario"),
-        (all_results_sotp_scenario, "SOTP Scenario"),
-        (all_results_dream, "Dream Team"),
-    ]
-
-    all_results_currency, dict_of_prices = make_short_list_prices(all_results_list, price_currency)
-    dict_of_prices["Current"] = current_price * price_currency
-    mean_overall = dict_of_prices["Overall"][0]
-    dict_of_prices["CV"] = dict_of_prices["STD"] / ((dict_of_prices["Current"] + mean_overall) / 2)
     dict_of_prices["LMIL"] = lmil
     dict_of_prices["LMIL Mean Investment"] = mean_investment
     dict_of_prices["LMIL Investment STD"] = std_investment
@@ -5895,40 +6708,72 @@ def run_valuations(
       append_text_to_file(text="", header="Our Analysts Price Valuations", two_rows_n=False)
       append_text_to_file(text=f"Current Price: ${current_price}", two_rows_n=False)
 
-      append_text_to_file(text = text_dcf[0], header = text_dcf[1])
-      append_text_to_file(text = text_target_scenario[0], header = text_target_scenario[1])
-      append_text_to_file(text = text_earnings_scenario[0], header = text_earnings_scenario[1])
-      append_text_to_file(text = text_revenue_scenario[0], header = text_revenue_scenario[1])
-      append_text_to_file(text = text_composite_scenario[0], header = text_composite_scenario[1])
-      append_text_to_file(text = text_sotp_scenario[0], header = text_sotp_scenario[1])
-      append_text_to_file(text = text_dream[0], header = text_dream[1])
+      text_by_method = {
+          "Scenario DCF": text_dcf,
+          "Target Scenario": text_target_scenario,
+          "Earnings Scenario": text_earnings_scenario,
+          "Revenue Scenario": text_revenue_scenario,
+          "Composite Scenario": text_composite_scenario,
+          "SOTP Scenario": text_sotp_scenario,
+          "Dream Team": text_dream,
+      }
+      for method_name in method_order:
+          if method_name not in selected_method_names:
+              continue
+          method_text = text_by_method.get(method_name)
+          if isinstance(method_text, (list, tuple)) and len(method_text) >= 2:
+              append_text_to_file(text=method_text[0], header=method_text[1])
 
       # If you still want the "overall_valuation" sections written to file, keep it here (sequential)
       all_results = [x / price_currency for x in all_results_currency]
       overall_valuation(all_results, revenue_results, ni_results, pe_results, variables_dict)
 
     if collect_explain:
+      aggregate_targets = {
+          "Scenario DCF": float(all_results_dcf[0]) if all_results_dcf else None,
+          "Target Scenario": float(all_results_target_scenario[0]) if all_results_target_scenario else None,
+          "Earnings Scenario": float(all_results_earnings_scenario[0]) if all_results_earnings_scenario else None,
+          "Revenue Scenario": float(all_results_revenue_scenario[0]) if all_results_revenue_scenario else None,
+          "Composite Scenario": float(all_results_composite_scenario[0]) if all_results_composite_scenario else None,
+          "SOTP Scenario": float(all_results_sotp_scenario[0]) if all_results_sotp_scenario else None,
+          "Dream Team": float(all_results_dream[0]) if all_results_dream else None,
+      }
+      router_payload = dict(valuation_router_plan) if isinstance(valuation_router_plan, dict) else {}
+      router_payload["active"] = bool(router_active)
+      router_payload["selected_method_names"] = list(selected_method_names)
+      router_payload["selected_dream_personas"] = list(selected_dream_personas)
+      router_payload["requested_method_weights"] = method_weight_pct_requested
+      router_payload["final_method_weights"] = method_weight_pct_final
+      router_payload["requested_persona_weights"] = dream_persona_weight_pct_requested
+      router_payload["final_persona_weights"] = dream_persona_weight_pct_final
+      router_payload["failed_methods_after_retry"] = failed_methods
+      router_payload["failed_personas_after_retry"] = dream_failed_personas
       explain_collector.clear()
       explain_collector.update(
           {
               "ticker": ticker,
               "current_price": current_price * price_currency,
+              "valuation_router": router_payload,
               "methods": method_details,
               "all_investments": all_investment_values,
               "mean_investment": mean_investment,
               "investment_std": std_investment,
               "lmil": lmil,
-              "aggregate_targets": {
-                  "Scenario DCF": float(all_results_dcf[0]) if all_results_dcf else None,
-                  "Target Scenario": float(all_results_target_scenario[0]) if all_results_target_scenario else None,
-                  "Earnings Scenario": float(all_results_earnings_scenario[0]) if all_results_earnings_scenario else None,
-                  "Revenue Scenario": float(all_results_revenue_scenario[0]) if all_results_revenue_scenario else None,
-                  "Composite Scenario": float(all_results_composite_scenario[0]) if all_results_composite_scenario else None,
-                  "SOTP Scenario": float(all_results_sotp_scenario[0]) if all_results_sotp_scenario else None,
-                  "Dream Team": float(all_results_dream[0]) if all_results_dream else None,
-              },
+              "weighted_mean_target_price": (
+                  float(dict_of_prices["Overall"][0])
+                  if isinstance(dict_of_prices.get("Overall"), (list, tuple)) and dict_of_prices["Overall"]
+                  else None
+              ),
+              "simple_mean_target_price": (
+                  float(dict_of_prices["Simple Mean"][0])
+                  if isinstance(dict_of_prices.get("Simple Mean"), (list, tuple)) and dict_of_prices["Simple Mean"]
+                  else None
+              ),
+              "aggregate_targets": aggregate_targets,
               "aggregate_investments": aggregate_investments,
               "aggregate_investment_percents": aggregate_investment_percents,
+              "method_weight_pct": method_weight_pct_final,
+              "persona_weight_pct": dream_persona_weight_pct_final,
           }
       )
 

--- a/tests/test_valuation_scenarios.py
+++ b/tests/test_valuation_scenarios.py
@@ -65,6 +65,133 @@ def test_extract_sotp_scenario_json_parses_nested_activities():
     assert abs(parsed["scenarios"]["bear"]["probability"] - 0.2) < 1e-9
 
 
+def test_valuation_router_plan_normalizes_weights_and_constraints():
+    raw = {
+        "rationale": "Use cash-flow and earnings evidence with a Dream Team cross-check.",
+        "selected_models": [
+            {"name": "Scenario DCF", "weight_pct": 45},
+            {"name": "Target Scenario", "weight_pct": 50},
+            {"name": "Dream Team", "weight_pct": 5},
+        ],
+        "dream_team": {
+            "selected_valuators": [
+                {"name": "Warren Buffett", "weight_pct": 1},
+                {"name": "Peter Lynch", "weight_pct": 1},
+                {"name": "Howard Marks", "weight_pct": 2},
+            ],
+        },
+    }
+
+    plan = lp._normalize_valuation_router_plan(
+        raw,
+        available_methods=lp.VALUATION_METHOD_ORDER,
+        available_personas=lp.DEFAULT_DREAM_TEAM_VALUATORS,
+    )
+
+    assert plan is not None
+    assert plan["mode"] == "weighted_router"
+    assert len(plan["selected_methods"]) == 3
+    assert plan["method_weights"]["Dream Team"] >= 10
+    assert abs(sum(plan["method_weights"].values()) - 100) < 1e-9
+    assert len(plan["selected_personas"]) == 3
+    assert abs(sum(plan["persona_weights"].values()) - 100) < 1e-9
+
+
+def test_run_valuations_uses_router_selected_models_and_weighted_mean(monkeypatch):
+    calls = []
+
+    def _plan(**kwargs):
+        return {
+            "status": "success",
+            "mode": "weighted_router",
+            "rationale": "Use three models.",
+            "selected_methods": [
+                {"name": "Scenario DCF", "weight_pct": 20, "rationale": "Cash-flow anchor."},
+                {"name": "Target Scenario", "weight_pct": 30, "rationale": "Scenario target."},
+                {"name": "Dream Team", "weight_pct": 50, "rationale": "Investor blend."},
+            ],
+            "selected_personas": [
+                {"name": "Warren Buffett", "weight_pct": 50, "rationale": "Quality."},
+                {"name": "Peter Lynch", "weight_pct": 30, "rationale": "Growth."},
+                {"name": "Howard Marks", "weight_pct": 20, "rationale": "Risk."},
+            ],
+            "method_weights": {"Scenario DCF": 20, "Target Scenario": 30, "Dream Team": 50},
+            "persona_weights": {"Warren Buffett": 50, "Peter Lynch": 30, "Howard Marks": 20},
+        }
+
+    def _dcf(*args, **kwargs):
+        calls.append("Scenario DCF")
+        return [100.0], ("txt", "Scenario DCF Valuation"), [
+            {"target_price": 100.0, "investment_amount": 1000, "raw_json": {"target_market_cap": 100000000}}
+        ]
+
+    def _target(*args, **kwargs):
+        calls.append("Target Scenario")
+        return [200.0], ("txt", "Target Scenario Valuation"), [
+            {"target_price": 200.0, "investment_amount": 2000, "raw_json": {"target_market_cap": 200000000}}
+        ]
+
+    def _dream(financial_dict, text, names_list, *args, **kwargs):
+        calls.append("Dream Team")
+        assert names_list == ["Warren Buffett", "Peter Lynch", "Howard Marks"]
+        return [300.0, 100.0, 200.0], ("txt", "Dream Team Target Price Valuation"), [
+            {"persona": "Warren Buffett", "target_price": 300.0, "investment_amount": 3000, "raw_json": {"target_market_cap": 300000000}},
+            {"persona": "Peter Lynch", "target_price": 100.0, "investment_amount": 1000, "raw_json": {"target_market_cap": 100000000}},
+            {"persona": "Howard Marks", "target_price": 200.0, "investment_amount": 2000, "raw_json": {"target_market_cap": 200000000}},
+        ]
+
+    def _unselected(name):
+        def _raise(*args, **kwargs):
+            raise AssertionError(f"{name} should not run")
+        return _raise
+
+    monkeypatch.setattr(lp, "resolve_valuation_router_plan", _plan)
+    monkeypatch.setattr(lp, "scenario_dcf_full", _dcf)
+    monkeypatch.setattr(lp, "bbb_tp_full", _target)
+    monkeypatch.setattr(lp, "dream_valuation_full", _dream)
+    monkeypatch.setattr(lp, "bbb_ni_pe_full", _unselected("Earnings Scenario"))
+    monkeypatch.setattr(lp, "revenue_scenario_full", _unselected("Revenue Scenario"))
+    monkeypatch.setattr(lp, "composite_scenario_full", _unselected("Composite Scenario"))
+    monkeypatch.setattr(lp, "sotp_scenario_full", _unselected("SOTP Scenario"))
+
+    explain = {}
+    final_dict = lp.run_valuations(
+        ticker="TEST",
+        info_dict={"short_name": "Test Co"},
+        financial_dict={},
+        variables_dict={
+            "price_currency": 1.0,
+            "financial_currency": 1.0,
+            "price": 100.0,
+            "revenue": 50000000.0,
+            "net_income": 5000000.0,
+            "market_cap": 100000000.0,
+            "shares_outstanding": 1000000.0,
+            "ev": 120000000.0,
+        },
+        text="analysis",
+        add_text=False,
+        explain_collector=explain,
+    )
+
+    assert sorted(calls) == ["Dream Team", "Scenario DCF", "Target Scenario"]
+    assert abs(final_dict["Prices"]["Overall"][0] - 190.0) < 1e-9
+    assert abs(final_dict["Prices"]["Weighted Overall"][0] - 190.0) < 1e-9
+    assert abs(final_dict["Prices"]["Simple Mean"][0] - ((100.0 + 200.0 + 220.0) / 3)) < 1e-9
+    assert explain["aggregate_targets"]["Dream Team"] == 220.0
+    assert explain["valuation_router"]["active"] is True
+    assert explain["valuation_router"]["final_method_weights"] == {
+        "Scenario DCF": 20.0,
+        "Target Scenario": 30.0,
+        "Dream Team": 50.0,
+    }
+    assert explain["valuation_router"]["final_persona_weights"] == {
+        "Warren Buffett": 50.0,
+        "Peter Lynch": 30.0,
+        "Howard Marks": 20.0,
+    }
+
+
 def test_run_valuations_uses_scenario_only_method_set(monkeypatch):
     def _dcf(*args, **kwargs):
         return [110.0], ("txt", "Scenario DCF Valuation"), [


### PR DESCRIPTION
## Summary

- Adds a valuation router agent that selects valuation models and Dream Team personas before valuation runs.
- Uses weighted consensus for new router-backed reports, keeps Simple Mean alongside it for comparison, and falls back to the old all-model simple mean when routing fails.
- Surfaces model/persona weights in the dashboard and adds Simple Mean comparison rows for Discovery and Hit Rate testing.

## Preview

URL: https://pr-119-hedge-in-a-box-site.fly.dev

Verified preview routes:
- `/discovery` returned HTTP 200
- `/api/discovery` returned HTTP 200
- `/hit-rate` returned HTTP 200
- `/api/hit-rate` returned HTTP 200

## Test plan

- [x] `$env:PYTHONPATH='src'; pytest -q tests\test_valuation_scenarios.py --basetemp .pytest-tmp-router`
- [x] `python -m py_compile src\ai_hedge\dashboard.py src\ai_hedge\legacy_port.py`
- [x] `npm exec tsc -- --noEmit`
- [x] `npm run lint -- src/lib/dashboard-types.ts src/lib/ticker-summary-aggregate.ts src/lib/hit-rate-aggregate.ts src/app/api/discovery/route.ts src/components/target-price-chart.tsx src/lib/dashboard-fallback.ts src/lib/ticker-summary-aggregate.test.ts src/lib/hit-rate-aggregate.test.ts`
- [x] `npm run build`

## Notes for reviewer

- Full lint including `hedge-dashboard.tsx` and `discovery/page.tsx` still hits existing React Compiler baseline rules around setState-in-effect and manual memoization; TypeScript and production build pass.
- `npm run build` passes with existing Next/Turbopack warnings for deprecated middleware naming and an NFT tracing warning through `next.config.ts`.