### PR TITLE
Refine market charts and financials prompt

### DIFF
--- a/frontend/src/app/(app)/compare/page.tsx
+++ b/frontend/src/app/(app)/compare/page.tsx
@@ -527,7 +527,14 @@ export default function ComparePage() {
                   tickFormatter={(value) => formatReturn(Number(value))}
                 />
                 <Tooltip content={<ChartTooltip />} wrapperStyle={{ outline: "none" }} />
-                <ReferenceLine y={0} stroke={tokens["--chart-current"]} strokeWidth={2.4} ifOverflow="extendDomain" />
+                <ReferenceLine
+                  y={0}
+                  stroke={tokens["--chart-axis"]}
+                  strokeWidth={2.8}
+                  strokeDasharray="1 6"
+                  strokeLinecap="round"
+                  ifOverflow="extendDomain"
+                />
                 {comparison.series.map((item, idx) => (
                   <Line
                     key={item.ticker}

--- a/frontend/src/app/(app)/dashboard/[ticker]/financials/financials-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/financials/financials-client.tsx
@@ -39,6 +39,7 @@ const BALANCE_METRICS = new Set([
   "Customers / Accounts Receivable",
   "Inventory",
   "Liquid Assets: Cash, Cash Equivalents, and Short-Term Investments",
+  "Working Capital",
   "Total Liabilities",
   "Total Shareholders' Equity",
   "Total Debt: Short-Term and Long-Term",

--- a/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
@@ -530,7 +530,14 @@ function MarketReturnComparison({ market, ticker }: { market: MarketReviewPayloa
                   tickFormatter={(value) => formatReturn(Number(value))}
                 />
                 <Tooltip content={<ReturnTooltip />} wrapperStyle={{ outline: "none" }} />
-                <ReferenceLine y={0} stroke={tokens["--chart-current"]} strokeWidth={2.4} ifOverflow="extendDomain" />
+                <ReferenceLine
+                  y={0}
+                  stroke={tokens["--chart-axis"]}
+                  strokeWidth={2.8}
+                  strokeDasharray="1 6"
+                  strokeLinecap="round"
+                  ifOverflow="extendDomain"
+                />
                 {comparison.activeSeries.map((item, idx) => (
                   <Line
                     key={item.ticker}

--- a/src/ai_hedge/financials_agent.py
+++ b/src/ai_hedge/financials_agent.py
@@ -37,6 +37,7 @@ REQUIRED_METRICS = [
     "Customers / Accounts Receivable",
     "Inventory",
     "Liquid Assets: Cash, Cash Equivalents, and Short-Term Investments",
+    "Working Capital",
     "Total Liabilities",
     "Total Shareholders' Equity",
     "Total Debt: Short-Term and Long-Term",
@@ -284,6 +285,7 @@ Non-GAAP logic:
 Balance sheet and market-value logic:
 - Total Assets, receivables, inventory, liquid assets, liabilities, equity, debt, and net liquidity should come from the balance sheet whenever available.
 - Liquid Assets means cash + cash equivalents + short-term investments / marketable securities. If yfinance reports only cash and equivalents, use that and say so in the note.
+- Working Capital = Total Current Assets - Total Current Liabilities. Use reported current asset/current liability lines from the balance sheet. If either side is unavailable, use null and explain which side is missing.
 - Total Debt means short-term debt plus long-term debt. If only total debt is available from quote info, use it only where period-specific statement debt is missing and mark the row "derived" or "mixed".
 - Net Liquidity = Liquid Assets - Total Debt.
 - Equity-to-Assets Ratio = Total Shareholders' Equity / Total Assets. It is a ratio decimal, not a percent string.
@@ -368,6 +370,14 @@ def _default_kind_for_metric(metric: str) -> str:
 
 def _metric_key(metric: str) -> str:
     return re.sub(r"\s+", " ", str(metric or "").replace("’", "'").replace("`", "'").strip().lower())
+
+
+FINANCIAL_METRIC_ALIASES = {
+    _metric_key("Net Working Capital"): "Working Capital",
+    _metric_key("Current Assets Less Current Liabilities"): "Working Capital",
+    _metric_key("Working Capital: Current Assets Less Current Liabilities"): "Working Capital",
+    _metric_key("Working Capital (Current Assets Less Current Liabilities)"): "Working Capital",
+}
 
 
 def _normalize_quality(value: Any) -> str:
@@ -547,6 +557,7 @@ def normalize_financials_analysis(raw: Dict[str, Any], *, ticker: str, currency:
 
     ordered_rows: List[Dict[str, Any]] = []
     required_by_key = {_metric_key(metric): metric for metric in REQUIRED_METRICS}
+    required_by_key.update(FINANCIAL_METRIC_ALIASES)
     by_metric = {}
     for row in rows:
         raw_metric = str(row.get("metric") or "")

--- a/src/ai_hedge/legacy_port.py
+++ b/src/ai_hedge/legacy_port.py
@@ -2475,6 +2475,7 @@ def swot_analysis(ticker):
   Focus on factors such as:
 
   * Structural moat or lack thereof
+  * Whether the product or service is a must-have or merely a nice-to-have for customers
   * Pricing power, differentiation, or cost advantages
   * Quality of revenue and customer base
   * Technology, IP, scale, or ecosystem advantages

--- a/tests/test_financials_agent.py
+++ b/tests/test_financials_agent.py
@@ -111,6 +111,7 @@ def test_normalize_financials_analysis_preserves_required_order_and_caps_added_r
     tax_rate = next(row for row in normalized["rows"] if row["metric"] == "Tax Rate")
     capex = next(row for row in normalized["rows"] if row["metric"] == "Capital Expenditures (Capex)")
     capex_ratio = next(row for row in normalized["rows"] if row["metric"] == "Capex / Revenue")
+    working_capital = next(row for row in normalized["rows"] if row["metric"] == "Working Capital")
     ebitda = next(row for row in normalized["rows"] if row["metric"] == "EBITDA")
     ebitda_margin = next(row for row in normalized["rows"] if row["metric"] == "EBITDA Margin")
     sbc_ratio = next(row for row in normalized["rows"] if row["metric"] == "SBC / Revenue")
@@ -124,6 +125,7 @@ def test_normalize_financials_analysis_preserves_required_order_and_caps_added_r
     assert ebitda_margin["kind"] == "percent"
     assert capex["kind"] == "currency"
     assert capex_ratio["kind"] == "percent"
+    assert working_capital["kind"] == "currency"
     assert sbc_ratio["kind"] == "percent"
 
 
@@ -147,6 +149,29 @@ def test_normalize_financials_analysis_canonicalizes_curly_shareholders_equity()
 
     row = next(row for row in normalized["rows"] if row["metric"] == "Total Shareholders' Equity")
     assert row["values"]["2024-12-31_A"] == 500
+
+
+def test_normalize_financials_analysis_canonicalizes_working_capital_alias():
+    normalized = normalize_financials_analysis(
+        {
+            "periods": [{"key": "2024-12-31_A", "label": "FY 2024", "date": "2024-12-31", "period_type": "annual"}],
+            "rows": [
+                {
+                    "metric": "Net Working Capital",
+                    "kind": "currency",
+                    "values": {"2024-12-31_A": 250},
+                    "quality": "derived",
+                    "note": "Current assets less current liabilities.",
+                }
+            ],
+        },
+        ticker="TEST",
+        currency="USD",
+    )
+
+    row = next(row for row in normalized["rows"] if row["metric"] == "Working Capital")
+    assert row["values"]["2024-12-31_A"] == 250
+    assert row["quality"] == "derived"
 
 
 def test_financials_markdown_includes_currency_and_table():


### PR DESCRIPTION
﻿## Summary

- Adds the SWOT prompt factor for must-have versus nice-to-have customer value.
- Changes the 0% return reference line in both Market and Compare charts from orange to a bold gray dotted line.
- Adds Working Capital to the Financials balance-sheet contract, canonicalizes common aliases, and includes it in the Balance Sheet table.

## Preview

URL: https://pr-121-hedge-in-a-box-site.fly.dev

## Test plan

- [x] `$env:PYTHONPATH='src'; python -m pytest tests/test_financials_agent.py --basetemp .tmp\pytest-financials-working-capital` - 9 passed
- [x] `npx eslint "src/app/(app)/dashboard/[ticker]/market/market-client.tsx" "src/app/(app)/compare/page.tsx" "src/app/(app)/dashboard/[ticker]/financials/financials-client.tsx"` from `frontend/`
- [x] `npm run build` from `frontend/`
- [x] Preview deploy passed.
- [x] Preview HTTP checks passed for `/api/health`, `/compare`, `/dashboard/AAPL/market`, `/dashboard/AAPL/financials`, and `/api/dashboard/AAPL`.
- [x] Preview JS chunk check found the new `strokeDasharray:"1 6"` chart styling in the Compare and Market chunks and `Working Capital` in the Financials chunk.

## Notes for reviewer

Working Capital is calculated by the Financials agent as Total Current Assets minus Total Current Liabilities when both balance-sheet lines are available. If either side is missing, the prompt requires null with a note instead of inventing a value.
