### PR TITLE
Quarantine unreliable INFO financial metrics

### DIFF
--- a/frontend/src/app/(app)/dashboard/[ticker]/info/info-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/info/info-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Activity, BadgeDollarSign, CalendarDays, Gauge, History, Info, RefreshCw, ShieldCheck, TrendingUp } from "lucide-react";
+import { Activity, BadgeDollarSign, CalendarDays, Gauge, History, Info, RefreshCw, TrendingUp } from "lucide-react";
 
 import { ReportChipRow } from "@/components/dashboard-chrome";
 import type { ReportListItem } from "@/lib/dashboard-types";
@@ -43,23 +43,10 @@ const LIVE_QUOTE_MULTIPLE_KEYS: Record<string, string> = {
   EnterpriseValue: "enterpriseValue",
 };
 
-const FINANCIAL_CARD_MAP: MetricCard[] = [
-  { label: "Current Price", value: "currentPrice", kind: "currency" },
+const ANALYST_CARD_MAP: MetricCard[] = [
   { label: "Target Mean", value: "targetMeanPrice", kind: "currency" },
   { label: "Target Median", value: "targetMedianPrice", kind: "currency" },
   { label: "Analysts", value: "numberOfAnalystOpinions", kind: "plain" },
-  { label: "Revenue Growth", value: "revenueGrowth", kind: "percent" },
-  { label: "Earnings Growth", value: "earningsGrowth", kind: "percent" },
-  { label: "Gross Margin", value: "grossMargins", kind: "percent" },
-  { label: "EBITDA Margin", value: "ebitdaMargins", kind: "percent" },
-  { label: "Operating Margin", value: "operatingMargins", kind: "percent" },
-  { label: "Profit Margin", value: "profitMargins", kind: "percent" },
-  { label: "ROA", value: "returnOnAssets", kind: "percent" },
-  { label: "ROE", value: "returnOnEquity", kind: "percent" },
-  { label: "Cash", value: "totalCash", kind: "currency" },
-  { label: "Debt", value: "totalDebt", kind: "currency" },
-  { label: "Current Ratio", value: "currentRatio", kind: "ratio" },
-  { label: "Debt / Equity", value: "debtToEquity", kind: "ratio" },
 ];
 
 function num(value: unknown): number | null {
@@ -122,7 +109,7 @@ function latestMultiple(info: YahooqueryInfo): Record<string, unknown> {
   return info.valuation_measures?.latest || {};
 }
 
-function financialData(info: YahooqueryInfo): Record<string, unknown> {
+function analystData(info: YahooqueryInfo): Record<string, unknown> {
   return info.financial_data || {};
 }
 
@@ -185,12 +172,12 @@ export function InfoClient({
 }: InfoClientProps) {
   const rows = rowsFromInfo(info);
   const latest = latestMultiple(info);
-  const finance = financialData(info);
+  const analyst = analystData(info);
   const quote = liveQuote(info);
   const currency = String(
-    quote.financialCurrency || finance.financialCurrency || (ticker.endsWith(".TA") ? "ILS" : "USD"),
+    quote.currency || quote.financialCurrency || analyst.financialCurrency || (ticker.endsWith(".TA") ? "ILS" : "USD"),
   ).toUpperCase();
-  const recommendation = String(finance.recommendationKey || "none").replace(/_/g, " ");
+  const recommendation = String(analyst.recommendationKey || "none").replace(/_/g, " ");
   const status = String(info.status || "").toLowerCase();
   const multipleCards = MULTIPLE_MAP.map((item) => {
     const liveKey = LIVE_QUOTE_MULTIPLE_KEYS[item.key];
@@ -206,9 +193,9 @@ export function InfoClient({
           : undefined,
     };
   });
-  const financeCards = FINANCIAL_CARD_MAP.map((item) => ({
+  const analystCards = ANALYST_CARD_MAP.map((item) => ({
     label: item.label,
-    value: finance[String(item.value)],
+    value: analyst[String(item.value)],
     kind: item.kind,
   }));
 
@@ -224,11 +211,11 @@ export function InfoClient({
               Information
             </h1>
             <p className="text-xs uppercase tracking-[0.18em] text-[color:var(--text-muted)]">
-              {ticker} - live yahooquery profile, multiples, and market context
+              {ticker} - live market data and provider-reported valuation multiples
             </p>
           </div>
           <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-            <MetricTile card={{ label: "Live Price", value: liveCurrentPrice ?? finance.currentPrice, kind: "currency" }} currency={currency} />
+            <MetricTile card={{ label: "Live Price", value: liveCurrentPrice ?? quote.currentPrice ?? quote.regularMarketPrice, kind: "currency" }} currency={currency} />
             <MetricTile card={{ label: "Currency", value: currency, kind: "plain" }} currency={currency} />
             <MetricTile card={{ label: "Recommendation", value: recommendation, kind: "plain" }} currency={currency} />
             <MetricTile card={{ label: "Data Rows", value: rows.length, kind: "plain" }} currency={currency} />
@@ -254,6 +241,9 @@ export function InfoClient({
               <p className="mt-1 text-sm text-[color:var(--text-muted)]">
                 Latest preferred row: {dateLabel(latest.asOfDate)} / {String(latest.periodType || "N/A")}
               </p>
+              <p className="mt-1 text-xs text-[color:var(--text-muted)]">
+                Provider-reported snapshot; compare like-for-like periods and treat unavailable or non-positive values as N/A.
+              </p>
             </div>
             <RefreshCw size={15} className="text-[color:var(--text-muted)]" />
           </div>
@@ -267,25 +257,16 @@ export function InfoClient({
         <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
           <h2 className="inline-flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.16em] text-[color:var(--text-secondary)]">
             <Gauge size={15} />
-            Quality Snapshot
+            Analyst Snapshot
           </h2>
+          <p className="mt-1 text-sm text-[color:var(--text-muted)]">
+            Consensus targets and coverage only. Operating metrics belong in the Financials tab.
+          </p>
           <div className="mt-3 grid gap-3 sm:grid-cols-2">
-            {financeCards.slice(4, 12).map((card) => (
+            {analystCards.map((card) => (
               <MetricTile key={card.label} card={card} currency={currency} />
             ))}
           </div>
-        </div>
-      </section>
-
-      <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
-        <h2 className="inline-flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.16em] text-[color:var(--text-secondary)]">
-          <ShieldCheck size={15} />
-          Financial Data
-        </h2>
-        <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-          {financeCards.map((card) => (
-            <MetricTile key={card.label} card={card} currency={currency} />
-          ))}
         </div>
       </section>
 
@@ -300,7 +281,7 @@ export function InfoClient({
           </div>
           <p className="inline-flex items-center gap-1 text-xs text-[color:var(--text-muted)]">
             <CalendarDays size={13} />
-            {info.generated_at ? `Updated ${dateLabel(info.generated_at)}` : "Live fetch"}
+            {info.generated_at ? `Fetched ${dateLabel(info.generated_at)}` : "Live fetch"}
           </p>
         </div>
         <div className="overflow-auto rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)]">

--- a/frontend/src/app/(app)/dashboard/[ticker]/info/info-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/info/info-client.tsx
@@ -177,7 +177,9 @@ export function InfoClient({
   const currency = String(
     quote.currency || quote.financialCurrency || analyst.financialCurrency || (ticker.endsWith(".TA") ? "ILS" : "USD"),
   ).toUpperCase();
-  const recommendation = String(analyst.recommendationKey || "none").replace(/_/g, " ");
+  const recommendation = analyst.recommendationKey
+    ? String(analyst.recommendationKey).replace(/_/g, " ")
+    : "N/A";
   const status = String(info.status || "").toLowerCase();
   const multipleCards = MULTIPLE_MAP.map((item) => {
     const liveKey = LIVE_QUOTE_MULTIPLE_KEYS[item.key];
@@ -217,7 +219,7 @@ export function InfoClient({
           <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
             <MetricTile card={{ label: "Live Price", value: liveCurrentPrice ?? quote.currentPrice ?? quote.regularMarketPrice, kind: "currency" }} currency={currency} />
             <MetricTile card={{ label: "Currency", value: currency, kind: "plain" }} currency={currency} />
-            <MetricTile card={{ label: "Recommendation", value: recommendation, kind: "plain" }} currency={currency} />
+            <MetricTile card={{ label: "Wall St. Consensus", value: recommendation, kind: "plain" }} currency={currency} />
             <MetricTile card={{ label: "Data Rows", value: rows.length, kind: "plain" }} currency={currency} />
           </div>
         </div>

--- a/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/market/market-client.tsx
@@ -67,23 +67,6 @@ function numeric(value: unknown): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
-function formatLarge(value: unknown): string {
-  const n = numeric(value);
-  if (n === null) return "-";
-  const abs = Math.abs(n);
-  if (abs >= 1_000_000_000_000) return `${(n / 1_000_000_000_000).toFixed(1)}T`;
-  if (abs >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`;
-  if (abs >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  return n.toLocaleString(undefined, { maximumFractionDigits: 0 });
-}
-
-function formatPercent(value: unknown): string {
-  const n = numeric(value);
-  if (n === null) return "-";
-  const pct = Math.abs(n) <= 1 ? n * 100 : n;
-  return `${pct.toFixed(1)}%`;
-}
-
 function formatMultiple(value: unknown): string {
   const n = numeric(value);
   if (n === null || n <= 0) return "-";
@@ -742,7 +725,7 @@ function ProductOverlapTable({ market }: { market: MarketReviewPayload }) {
   );
 }
 
-function FinancialScaleTable({ market, ticker }: { market: MarketReviewPayload; ticker: string }) {
+function EquityMultiplesTable({ market, ticker }: { market: MarketReviewPayload; ticker: string }) {
   const rows = buildComparisonRows(market, ticker);
   if (!rows.length || rows.every((row) => !Object.keys(row.info).length)) return null;
 
@@ -754,10 +737,10 @@ function FinancialScaleTable({ market, ticker }: { market: MarketReviewPayload; 
         </div>
         <div className="min-w-0">
           <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[color:var(--text-muted)]">
-            Financial Scale
+            Provider-Reported Multiples
           </p>
           <h2 className="break-words font-display text-lg text-[color:var(--text-primary)]">
-            Size And Growth
+            Equity Multiples
           </h2>
         </div>
       </div>
@@ -768,10 +751,11 @@ function FinancialScaleTable({ market, ticker }: { market: MarketReviewPayload; 
             <tr>
               <th className="hib-market-table-head">Rank</th>
               <th className="hib-market-table-head">Company</th>
-              <th className="hib-market-table-head">Market Cap</th>
-              <th className="hib-market-table-head">EV</th>
-              <th className="hib-market-table-head">Revenue (TTM)</th>
-              <th className="hib-market-table-head">Rev Growth</th>
+              <th className="hib-market-table-head">P/E (TTM)</th>
+              <th className="hib-market-table-head">Forward P/E</th>
+              <th className="hib-market-table-head">PEG</th>
+              <th className="hib-market-table-head">P/S</th>
+              <th className="hib-market-table-head">P/B</th>
             </tr>
           </thead>
           <tbody>
@@ -781,10 +765,11 @@ function FinancialScaleTable({ market, ticker }: { market: MarketReviewPayload; 
                 <tr key={`${row.ticker || row.company_name}-${idx}`}>
                   <td className="hib-market-table-cell font-mono text-xs">{row.rank}</td>
                   <CompanyCell row={row} />
-                  <td className="hib-market-table-cell font-mono">{formatLarge(info.marketCap)}</td>
-                  <td className="hib-market-table-cell font-mono">{formatLarge(info.enterpriseValue)}</td>
-                  <td className="hib-market-table-cell font-mono">{formatLarge(info.totalRevenue)}</td>
-                  <td className="hib-market-table-cell font-mono">{formatPercent(info.revenueGrowth)}</td>
+                  <td className="hib-market-table-cell font-mono">{formatMultiple(info.trailingPE)}</td>
+                  <td className="hib-market-table-cell font-mono">{formatMultiple(info.forwardPE)}</td>
+                  <td className="hib-market-table-cell font-mono">{formatMultiple(info.pegRatio)}</td>
+                  <td className="hib-market-table-cell font-mono">{formatMultiple(info.priceToSalesTrailing12Months)}</td>
+                  <td className="hib-market-table-cell font-mono">{formatMultiple(info.priceToBook)}</td>
                 </tr>
               );
             })}
@@ -795,7 +780,7 @@ function FinancialScaleTable({ market, ticker }: { market: MarketReviewPayload; 
   );
 }
 
-function MarginValuationTable({ market, ticker }: { market: MarketReviewPayload; ticker: string }) {
+function EnterpriseMultiplesTable({ market, ticker }: { market: MarketReviewPayload; ticker: string }) {
   const rows = buildComparisonRows(market, ticker);
   if (!rows.length || rows.every((row) => !Object.keys(row.info).length)) return null;
 
@@ -807,10 +792,10 @@ function MarginValuationTable({ market, ticker }: { market: MarketReviewPayload;
         </div>
         <div className="min-w-0">
           <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-[color:var(--text-muted)]">
-            Profitability And Multiples
+            Provider-Reported Multiples
           </p>
           <h2 className="break-words font-display text-lg text-[color:var(--text-primary)]">
-            Margins And Valuation
+            Enterprise Multiples
           </h2>
         </div>
       </div>
@@ -821,11 +806,8 @@ function MarginValuationTable({ market, ticker }: { market: MarketReviewPayload;
             <tr>
               <th className="hib-market-table-head">Rank</th>
               <th className="hib-market-table-head">Company</th>
-              <th className="hib-market-table-head">Gross Margin (TTM)</th>
-              <th className="hib-market-table-head">EBITDA Margin (TTM)</th>
-              <th className="hib-market-table-head">Net Margin (TTM)</th>
-              <th className="hib-market-table-head">P/E (TTM)</th>
               <th className="hib-market-table-head">EV/Revenue (TTM)</th>
+              <th className="hib-market-table-head">EV/EBITDA (TTM)</th>
             </tr>
           </thead>
           <tbody>
@@ -835,11 +817,8 @@ function MarginValuationTable({ market, ticker }: { market: MarketReviewPayload;
                 <tr key={`${row.ticker || row.company_name}-${idx}`}>
                   <td className="hib-market-table-cell font-mono text-xs">{row.rank}</td>
                   <CompanyCell row={row} />
-                  <td className="hib-market-table-cell font-mono">{formatPercent(info.grossMargins)}</td>
-                  <td className="hib-market-table-cell font-mono">{formatPercent(info.ebitdaMargins)}</td>
-                  <td className="hib-market-table-cell font-mono">{formatPercent(info.profitMargins)}</td>
-                  <td className="hib-market-table-cell font-mono">{formatMultiple(info.trailingPE)}</td>
                   <td className="hib-market-table-cell font-mono">{formatMultiple(info.enterpriseToRevenue)}</td>
+                  <td className="hib-market-table-cell font-mono">{formatMultiple(info.enterpriseToEbitda)}</td>
                 </tr>
               );
             })}
@@ -895,8 +874,8 @@ export function MarketClient({ ticker, data, reportsForTicker, resolvedReportId 
         <MarketReturnComparison market={market} ticker={ticker} />
         <PeerStrategyTable market={market} ticker={ticker} />
         <ProductOverlapTable market={market} />
-        <FinancialScaleTable market={market} ticker={ticker} />
-        <MarginValuationTable market={market} ticker={ticker} />
+        <EquityMultiplesTable market={market} ticker={ticker} />
+        <EnterpriseMultiplesTable market={market} ticker={ticker} />
       </div>
     </div>
   );

--- a/frontend/src/app/(app)/reports/page.tsx
+++ b/frontend/src/app/(app)/reports/page.tsx
@@ -89,7 +89,14 @@ async function CommunityTabContent({
     return <EmptyState tab="community" signedIn={signedIn} hasQuery={Boolean(query)} />;
   }
 
-  return <CommunityList initialRows={rows} initialHasMore={hasMore} query={query} />;
+  return (
+    <CommunityList
+      key={query.trim().toLowerCase() || "all-reports"}
+      initialRows={rows}
+      initialHasMore={hasMore}
+      query={query}
+    />
+  );
 }
 
 async function MineTabContent({

--- a/frontend/src/app/(app)/screeners/page.tsx
+++ b/frontend/src/app/(app)/screeners/page.tsx
@@ -107,9 +107,10 @@ function csvEscape(value: unknown): string {
   return /[",\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
 }
 
-function downloadCsv(rows: ScreenerRow[], filename: string) {
+function downloadCsv(rows: ScreenerRow[], filename: string, positionByRow: ReadonlyMap<ScreenerRow, number>) {
   const header = [
     "Rank",
+    "Size Rank",
     "Ticker",
     "Company",
     "Valuation Score",
@@ -122,6 +123,7 @@ function downloadCsv(rows: ScreenerRow[], filename: string) {
     "Industry",
   ];
   const body = rows.map((row) => [
+    positionByRow.get(row) ?? "",
     row.rank,
     row.ticker,
     row.company_name,
@@ -359,9 +361,9 @@ export default function ScreenersPage() {
       return sectorMatch && industryMatch && queryMatch;
     });
   }, [industry, query, rows, sector]);
-  const sortedRows = useMemo(() => {
+  const sortedUniverseRows = useMemo(() => {
     const direction = sortDirection === "asc" ? 1 : -1;
-    return [...filteredRows].sort((left, right) => {
+    return [...rows].sort((left, right) => {
       const leftValue = sortValue(left, sortKey);
       const rightValue = sortValue(right, sortKey);
       const leftMissing = leftValue === null || leftValue === "";
@@ -376,7 +378,15 @@ export default function ScreenersPage() {
       const diff = String(leftValue).localeCompare(String(rightValue), undefined, { sensitivity: "base", numeric: true });
       return diff === 0 ? left.rank - right.rank : diff * direction;
     });
-  }, [filteredRows, sortDirection, sortKey]);
+  }, [rows, sortDirection, sortKey]);
+  const positionByRow = useMemo(
+    () => new Map(sortedUniverseRows.map((row, index) => [row, index + 1])),
+    [sortedUniverseRows],
+  );
+  const sortedRows = useMemo(() => {
+    const visibleRows = new Set(filteredRows);
+    return sortedUniverseRows.filter((row) => visibleRows.has(row));
+  }, [filteredRows, sortedUniverseRows]);
 
   const sectorCount = sectors.length > 0 ? sectors.length - 1 : 0;
   const industryCount = useMemo(
@@ -539,7 +549,7 @@ export default function ScreenersPage() {
             </button>
             <button
               type="button"
-              onClick={() => downloadCsv(sortedRows, `${activeScreener}-screener.csv`)}
+              onClick={() => downloadCsv(sortedRows, `${activeScreener}-screener.csv`, positionByRow)}
               disabled={!sortedRows.length}
               className="inline-flex items-center gap-2 rounded-lg border border-emerald-400/60 bg-emerald-500/20 px-3 py-2 text-sm font-semibold text-emerald-100 transition hover:bg-emerald-500/30 disabled:cursor-not-allowed disabled:text-[color:var(--text-disabled)] disabled:opacity-60"
             >
@@ -584,10 +594,17 @@ export default function ScreenersPage() {
           </div>
         ) : (
           <div className="hib-market-table-wrap m-0 max-h-[72vh]">
-            <table className="hib-market-table min-w-[104rem] table-fixed">
+            <table className="hib-market-table min-w-[109rem] table-fixed">
               <thead>
                 <tr>
-                  <SortHeader id="rank" label="Rank" sortKey={sortKey} sortDirection={sortDirection} onSort={toggleSort} className="w-20" />
+                  <th
+                    scope="col"
+                    title="Position in the full screener under the current sort"
+                    className="hib-market-table-head w-20"
+                  >
+                    Rank
+                  </th>
+                  <SortHeader id="rank" label="Size Rank" sortKey={sortKey} sortDirection={sortDirection} onSort={toggleSort} className="w-28" />
                   <SortHeader id="ticker" label="Ticker" sortKey={sortKey} sortDirection={sortDirection} onSort={toggleSort} className="w-28" />
                   <SortHeader
                     id="company_name"
@@ -653,6 +670,9 @@ export default function ScreenersPage() {
                 {sortedRows.length ? (
                   sortedRows.map((row) => (
                     <tr key={`${row.rank}-${row.ticker}`}>
+                      <td className="hib-market-table-cell font-mono text-xs font-semibold text-[color:var(--text-primary)]">
+                        #{positionByRow.get(row) ?? "-"}
+                      </td>
                       <td className="hib-market-table-cell font-mono text-xs text-[color:var(--text-muted)]">#{row.rank}</td>
                       <td className="hib-market-table-cell">
                         <button
@@ -699,7 +719,7 @@ export default function ScreenersPage() {
                   ))
                 ) : (
                   <tr>
-                    <td colSpan={11} className="hib-market-table-cell py-14 text-center text-[color:var(--text-muted)]">
+                    <td colSpan={12} className="hib-market-table-cell py-14 text-center text-[color:var(--text-muted)]">
                       No companies match this filter.
                     </td>
                   </tr>

--- a/frontend/src/app/api/dashboard/[ticker]/dream-team/chat/route.ts
+++ b/frontend/src/app/api/dashboard/[ticker]/dream-team/chat/route.ts
@@ -115,7 +115,7 @@ function normalizeFinancial(value: Partial<FinancialContext> | null | undefined)
     all_reports: String(value?.all_reports || ""),
     info: value?.info ?? {},
     currency_statement: String(value?.currency_statement || ""),
-    info_financials: value?.info_financials ?? {},
+    info_financials: {},
     rate: value?.rate ?? 0,
   };
 }
@@ -194,7 +194,7 @@ function toContextBlocks(args: {
     financial_info: args.financial.info ?? {},
     currency_statement: trimText(args.financial.currency_statement, 8000),
     today_date: new Date().toISOString().slice(0, 10),
-    info_financials: args.financial.info_financials ?? {},
+    info_financials: {},
     rate: args.financial.rate ?? 0,
     persona_prior_text: trimText(args.personaPlainText, 35000),
     annual_report_text: trimText(args.annualText, 50000),

--- a/frontend/src/components/hedge-dashboard.tsx
+++ b/frontend/src/components/hedge-dashboard.tsx
@@ -29,6 +29,7 @@ export type CurrencyContext = {
   financialCode: string;
   financialSymbol: string;
   isIsraeli: boolean;
+  priceUnitNote?: string;
   priceUsdToDisplay: number;
   financialUsdToDisplay: number;
 };
@@ -174,6 +175,7 @@ export function buildCurrencyContext(data: DashboardPayload | null): CurrencyCon
     financialCode,
     financialSymbol: currencySymbol(financialCode),
     isIsraeli,
+    priceUnitNote: String(data?.header?.price_unit_note || "").trim() || undefined,
     // Dashboard numeric values are already emitted in display scale.
     // Do not apply an extra multiplier in the UI.
     priceUsdToDisplay: 1,
@@ -645,7 +647,13 @@ function splitMarkdownHeadingBlocks(title: string, text: string): Array<{ title:
   return blocks.map((block) => ({ title: block.title, text: block.lines.join("\n").trim() }));
 }
 
-function TradingAgentsPanel({ payload }: { payload?: DashboardPayload["trading_agents"] }) {
+function TradingAgentsPanel({
+  payload,
+  currencyContext,
+}: {
+  payload?: DashboardPayload["trading_agents"];
+  currencyContext: CurrencyContext;
+}) {
   if (!payload || !Object.keys(payload).length) {
     return <p className="mt-3 text-sm text-zinc-500">No TradingAgents lens was stored for this report.</p>;
   }
@@ -679,6 +687,12 @@ function TradingAgentsPanel({ payload }: { payload?: DashboardPayload["trading_a
       : decisionTone === "down"
         ? "border-red-500/45 bg-red-500/10"
         : "border-white/10 bg-black/30";
+  const tacticalPriceTarget =
+    typeof payload.price_target === "number" && Number.isFinite(payload.price_target) && payload.price_target > 0
+      ? payload.price_target
+      : null;
+  const timeHorizon = String(payload.time_horizon || "").trim();
+  const hasTacticalDecisionMetadata = tacticalPriceTarget !== null || timeHorizon.length > 0;
 
   return (
     <div className="mt-3 space-y-3">
@@ -691,13 +705,43 @@ function TradingAgentsPanel({ payload }: { payload?: DashboardPayload["trading_a
         </div>
         <p className="mt-2 text-xs leading-relaxed text-zinc-400">
           This is a separate research memo from a small agent team. It reads the business, recent news, and market
-          sentiment, then stages bull, bear, and risk debates before a final committee view. The memo itself does not
-          set the target price or score.
+          sentiment, then stages bull, bear, and risk debates before a final committee view. Its tactical decision is
+          kept separate from the AI Hedge valuation target and score.
         </p>
         {status !== "success" && payload.error ? (
           <p className="mt-2 text-xs text-zinc-400">Reason: {payload.error}</p>
         ) : null}
       </div>
+
+      {hasTacticalDecisionMetadata ? (
+        <section className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--text-secondary)]">
+            TradingAgents Final Decision
+          </p>
+          <div className="mt-2 grid gap-2 sm:grid-cols-2">
+            {tacticalPriceTarget !== null ? (
+              <div className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-3">
+                <p className="text-xs text-[color:var(--text-secondary)]">
+                  Tactical Price Target{currencyContext.priceUnitNote ? ` (${currencyContext.priceUnitNote})` : ""}
+                </p>
+                <p className="mt-1 text-lg font-semibold text-[color:var(--text-primary)]">
+                  {fmtMoney(tacticalPriceTarget, currencyContext, "price")}
+                </p>
+              </div>
+            ) : null}
+            {timeHorizon ? (
+              <div className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-3">
+                <p className="text-xs text-[color:var(--text-secondary)]">Time Horizon</p>
+                <p className="mt-1 text-lg font-semibold text-[color:var(--text-primary)]">{timeHorizon}</p>
+              </div>
+            ) : null}
+          </div>
+          <p className="mt-2 text-xs leading-relaxed text-[color:var(--text-muted)]">
+            Independent tactical output. It is excluded from AI Hedge valuation prompts, model target-price
+            calculations, and consensus target aggregation to preserve an unanchored fundamental valuation process.
+          </p>
+        </section>
+      ) : null}
 
       {renderedSections.map((section, index) => {
         const isDecision = section.title.toLowerCase() === "final committee decision";
@@ -2083,7 +2127,7 @@ export function HedgeDashboard({
                     ) : null}
                   </div>
                 ) : valuationTab === "trading-agents" ? (
-                  <TradingAgentsPanel payload={tradingAgentsPayload} />
+                  <TradingAgentsPanel payload={tradingAgentsPayload} currencyContext={currencyContext} />
                 ) : activeMethod ? (
                   <div className="mt-3 grid gap-3 xl:grid-cols-[1fr_1.2fr]">
                     <article className="rounded-xl border border-white/10 bg-black/35 p-3">

--- a/frontend/src/components/reports/reports-tabs.tsx
+++ b/frontend/src/components/reports/reports-tabs.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import { Loader2, Search, X } from "lucide-react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useState } from "react";
+import type { FormEvent } from "react";
+import { useCallback, useEffect, useState, useTransition } from "react";
 
 export type ReportsTabKey = "mine" | "community";
 
@@ -23,23 +25,45 @@ export function ReportsTabs({
   const router = useRouter();
   const search = useSearchParams();
   const [query, setQuery] = useState(initialQuery);
+  const [isPending, startTransition] = useTransition();
+  const currentQuery = String(search?.get("q") || "").trim();
+  const searchString = search?.toString() || "";
+
+  const navigateToQuery = useCallback((value: string) => {
+    const normalized = value.trim();
+    if (normalized === currentQuery) return;
+
+    const params = new URLSearchParams(searchString);
+    if (normalized) params.set("q", normalized);
+    else params.delete("q");
+    const qs = params.toString();
+    startTransition(() => {
+      router.replace(qs ? `/reports?${qs}` : "/reports", { scroll: false });
+    });
+  }, [currentQuery, router, searchString]);
 
   useEffect(() => {
     const handle = window.setTimeout(() => {
-      const params = new URLSearchParams(search?.toString() || "");
-      if (query) params.set("q", query);
-      else params.delete("q");
-      const qs = params.toString();
-      router.replace(qs ? `/reports?${qs}` : `/reports`);
-    }, 200);
+      navigateToQuery(query);
+    }, 400);
     return () => window.clearTimeout(handle);
-  }, [query, router, search]);
+  }, [navigateToQuery, query]);
+
+  function submitSearch(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    navigateToQuery(query);
+  }
+
+  function clearSearch() {
+    setQuery("");
+    navigateToQuery("");
+  }
 
   return (
-    <div className="mb-6 flex flex-wrap items-center gap-3">
-      <nav className="inline-flex rounded-xl border border-white/10 bg-zinc-950/70 p-1">
+    <div className="mb-6 grid gap-3 sm:grid-cols-[auto_minmax(0,1fr)] sm:items-center">
+      <nav className="flex w-full rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-1 sm:w-auto">
         {TAB_ORDER.map((t) => {
-          const params = new URLSearchParams(search?.toString() || "");
+          const params = new URLSearchParams(searchString);
           params.set("tab", t.key);
           const isActive = t.key === active;
           const disabled = t.key === "mine" && !signedIn;
@@ -47,7 +71,7 @@ export function ReportsTabs({
             return (
               <span
                 key={t.key}
-                className="cursor-not-allowed rounded-lg px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.14em] text-zinc-600"
+                className="flex-1 cursor-not-allowed rounded-lg px-3 py-1.5 text-center text-xs font-semibold uppercase tracking-[0.14em] text-[color:var(--text-disabled)] sm:flex-none"
                 title="Sign in to see your reports"
               >
                 {t.label}
@@ -58,10 +82,11 @@ export function ReportsTabs({
             <Link
               key={t.key}
               href={`/reports?${params.toString()}`}
-              className={`rounded-lg px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.14em] transition ${
+              scroll={false}
+              className={`flex-1 rounded-lg px-3 py-1.5 text-center text-xs font-semibold uppercase tracking-[0.14em] transition sm:flex-none ${
                 isActive
-                  ? "bg-emerald-500/20 text-emerald-100"
-                  : "text-zinc-400 hover:text-zinc-100"
+                  ? "bg-[color:var(--accent)] text-[color:var(--text-on-accent)]"
+                  : "text-[color:var(--text-muted)] hover:text-[color:var(--text-primary)]"
               }`}
             >
               {t.label}
@@ -69,12 +94,53 @@ export function ReportsTabs({
           );
         })}
       </nav>
-      <input
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
-        placeholder="Search ticker or company"
-        className="min-w-[220px] flex-1 rounded-lg border border-white/10 bg-zinc-950/70 px-3 py-2 text-base text-zinc-100 placeholder:text-zinc-500 focus:border-emerald-400/60 focus:outline-none sm:text-sm"
-      />
+
+      <form
+        role="search"
+        aria-label="Search reports"
+        aria-busy={isPending}
+        onSubmit={submitSearch}
+        className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] gap-2"
+      >
+        <div className="relative min-w-0">
+          <Search
+            aria-hidden="true"
+            size={16}
+            className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-[color:var(--text-muted)]"
+          />
+          <input
+            type="search"
+            enterKeyHint="search"
+            autoComplete="off"
+            aria-label="Search ticker or company"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search ticker or company"
+            className="w-full min-w-0 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] py-2 pl-10 pr-10 text-base text-[color:var(--text-primary)] outline-none transition placeholder:text-[color:var(--text-muted)] focus:border-[color:var(--accent)] sm:text-sm"
+          />
+          <div className="absolute right-3 top-1/2 flex -translate-y-1/2 items-center">
+            {isPending ? (
+              <Loader2 aria-label="Searching reports" size={16} className="animate-spin text-[color:var(--accent)]" />
+            ) : query ? (
+              <button
+                type="button"
+                onClick={clearSearch}
+                aria-label="Clear report search"
+                className="rounded text-[color:var(--text-muted)] transition hover:text-[color:var(--text-primary)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent)]"
+              >
+                <X size={16} />
+              </button>
+            ) : null}
+          </div>
+        </div>
+        <button
+          type="submit"
+          disabled={isPending || query.trim() === currentQuery}
+          className="rounded-lg bg-[color:var(--accent)] px-3 py-2 text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--text-on-accent)] transition hover:bg-[color:var(--accent-hover)] disabled:cursor-not-allowed disabled:text-[color:var(--text-disabled)] disabled:opacity-60"
+        >
+          Search
+        </button>
+      </form>
     </div>
   );
 }

--- a/frontend/src/lib/dashboard-server.ts
+++ b/frontend/src/lib/dashboard-server.ts
@@ -67,6 +67,33 @@ export type YahooqueryInfo = {
   financial_data?: Record<string, unknown>;
 };
 
+const SAFE_ANALYST_CONTEXT_KEYS = [
+  "financialCurrency",
+  "recommendationKey",
+  "targetMeanPrice",
+  "targetMedianPrice",
+  "numberOfAnalystOpinions",
+] as const;
+
+function infoTabYahooqueryPayload(value: YahooqueryInfo, ticker: string): YahooqueryInfo {
+  const rawAnalyst = value?.financial_data;
+  const analystContext: Record<string, unknown> = {};
+  if (rawAnalyst && typeof rawAnalyst === "object" && !Array.isArray(rawAnalyst)) {
+    for (const key of SAFE_ANALYST_CONTEXT_KEYS) {
+      if (key in rawAnalyst) analystContext[key] = rawAnalyst[key];
+    }
+  }
+  return {
+    status: value?.status,
+    ticker: String(value?.ticker || ticker).toUpperCase(),
+    generated_at: value?.generated_at,
+    error: value?.error,
+    valuation_measures: value?.valuation_measures,
+    live_quote: value?.live_quote,
+    financial_data: analystContext,
+  };
+}
+
 async function loadReportsList(): Promise<ReportListItem[]> {
   const merged = new Map<string, ReportListItem>();
   const deletedFilter = await getDeletedReportFilter();
@@ -483,10 +510,7 @@ export const getLiveYahooqueryInfo = unstable_cache(
     const tk = ticker.toUpperCase();
     try {
       const result = await runLiveYahooqueryInfoScript(tk);
-      return {
-        ...result,
-        ticker: String(result?.ticker || tk).toUpperCase(),
-      };
+      return infoTabYahooqueryPayload(result, tk);
     } catch (err) {
       return {
         status: "error",

--- a/frontend/src/lib/dashboard-types.ts
+++ b/frontend/src/lib/dashboard-types.ts
@@ -59,6 +59,10 @@ export type TradingAgentsPayload = {
   bull_bear_debate?: string;
   risk_debate?: string;
   final_committee_view?: string;
+  rating?: string;
+  price_target?: number | null;
+  time_horizon?: string;
+  valuation_prompt_excluded_fields?: string[];
   artifact_json?: string;
   artifact_txt?: string;
 };

--- a/scripts/dream_team_context.py
+++ b/scripts/dream_team_context.py
@@ -184,7 +184,6 @@ def main() -> int:
         "currency_statement": str(financial_dict.get("currency_statement") or ""),
         "info_financials": _to_jsonable(financial_dict.get("info_financials", {})),
         "rate": financial_dict.get("rate", 0),
-        "ticker_info": _to_jsonable((info_dict or {}).get("info", {})),
     }
 
     rows = _extract_filing_entries(files_dict)

--- a/src/ai_hedge/competitor_market_review.py
+++ b/src/ai_hedge/competitor_market_review.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 import json
 import os
 import re
+from copy import deepcopy
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import yfinance as yf
+
+from .provider_data_policy import safe_company_profile
 
 
 CONTEXT_HEADER = "Competitor Market Review"
@@ -130,41 +133,11 @@ def normalize_competitors(
 
 
 def _compact_info_for_llm(info: Dict[str, Any]) -> Dict[str, Any]:
-    keys = [
-        "shortName",
-        "longName",
-        "symbol",
-        "quoteType",
-        "industry",
-        "sector",
-        "country",
-        "currency",
-        "financialCurrency",
-        "original_price_currency",
-        "original_financial_currency",
-        "marketCap",
-        "enterpriseValue",
-        "totalRevenue",
-        "revenueGrowth",
-        "grossMargins",
-        "operatingMargins",
-        "profitMargins",
-        "ebitdaMargins",
-        "netIncomeToCommon",
-        "trailingPE",
-        "forwardPE",
-        "priceToSalesTrailing12Months",
-        "enterpriseToRevenue",
-        "enterpriseToEbitda",
-        "returnOnAssets",
-        "returnOnEquity",
-        "totalDebt",
-        "totalCash",
-        "fullTimeEmployees",
-        "website",
-        "longBusinessSummary",
-    ]
-    return {key: info.get(key) for key in keys if key in info}
+    return safe_company_profile(
+        info,
+        include_market_context=True,
+        include_valuation_context=True,
+    )
 
 
 def _clean_price_history_frame(df: Any) -> List[Dict[str, Any]]:
@@ -406,7 +379,8 @@ def build_original_company_context(
 
 
 def build_discovery_prompt(ticker: str, info: Dict[str, Any]) -> str:
-    original_country = str(info.get("country") or "").strip()
+    profile = safe_company_profile(info)
+    original_country = str(profile.get("country") or "").strip()
     suffix_guidance = COUNTRY_SUFFIX_GUIDANCE.get(_country_key(original_country))
     local_guidance = ""
     if original_country and _country_key(original_country) not in {"united states", "usa", "us"}:
@@ -435,8 +409,8 @@ Think in two passes before producing the JSON:
 
 Original ticker: {ticker}
 Original country: {original_country or "Unknown"}
-Original company info_dict["info"]:
-{json.dumps(info, ensure_ascii=False, default=str)}
+Original company profile (business identity and description only):
+{json.dumps(profile, ensure_ascii=False, default=str)}
 
 Return ONLY valid JSON with this exact shape:
 {{
@@ -550,20 +524,29 @@ def collect_competitor_context(
 
 
 def build_review_prompt(payload: Dict[str, Any]) -> str:
+    clean_payload = deepcopy(payload) if isinstance(payload, dict) else {}
+    original_company = clean_payload.get("original_company")
+    if isinstance(original_company, dict):
+        original_company["info"] = _compact_info_for_llm(original_company.get("info", {}))
+    competitors = clean_payload.get("competitors")
+    if isinstance(competitors, list):
+        for competitor in competitors:
+            if isinstance(competitor, dict):
+                competitor["info"] = _compact_info_for_llm(competitor.get("info", {}))
     return f"""
 You are a senior buy-side market analyst writing a dashboard-ready market review.
 
 You receive:
 - the original ticker
 - the market name
-- original company info_dict["info"]
+- original company profile and provider-reported valuation context
 - original company annual income-statement table
 - ranked public competitors
-- normalized competitor info produced by the same info engine used for the original company
+- normalized competitor profiles and provider-reported valuation context
 - competitor annual income-statement tables produced by the same financial table engine
 
 Payload:
-{json.dumps(payload, ensure_ascii=False, default=str)}
+{json.dumps(clean_payload, ensure_ascii=False, default=str)}
 
 Write a comprehensive market review in Markdown for a tab called "Market".
 
@@ -580,9 +563,11 @@ Rules:
 - Focus on what matters to investors and valuation.
 - Include the original company in the financial and strategic comparison wherever the payload provides data.
 - Use the original company and competitor annual income-statement data when available; explicitly say when data is unavailable.
+- Derive operating growth, profitability, margins, cash flow, and balance-sheet claims only from the supplied financial statement tables. The company profile fields are not an operating-financial source.
+- Treat provider-reported multiples as a separate valuation snapshot. Compare only like-for-like multiples and period types, and do not reverse-engineer operating claims from them.
 - Compare business model, scale, profitability, growth, pricing power, cyclicality, and competitive intensity.
 - Prefer Markdown tables for ranked competitors, financial comparison, product/customer overlap, and any exact-data comparison.
-- Make tables compact and directly useful: include tickers, latest available annual figures, growth or margin cues when present, and clear "-" cells when data is missing.
+- Make tables compact and directly useful: include tickers, latest available annual figures, statement-derived growth or margin cues when present, provider-reported multiples in a separate valuation comparison, and clear "-" cells when data is missing.
 - Ground every material claim in the payload. Use only:
   1. original company info,
   2. original annual income-statement table,

--- a/src/ai_hedge/dashboard.py
+++ b/src/ai_hedge/dashboard.py
@@ -1490,7 +1490,7 @@ def _build_current_assumption_values(
     earnings = _safe_float(variables_dict.get("net_income"))
     ev = _safe_float(variables_dict.get("ev"))
     market_cap = _safe_float(variables_dict.get("market_cap"))
-    fcf = _safe_float(info.get("freeCashflow"))
+    fcf = _safe_float(variables_dict.get("free_cashflow"))
 
     def _scaled_financial(value: Optional[float]) -> Optional[float]:
         if value is None:

--- a/src/ai_hedge/financials_agent.py
+++ b/src/ai_hedge/financials_agent.py
@@ -9,6 +9,8 @@ import numpy as np
 import pandas as pd
 import yfinance as yf
 
+from .provider_data_policy import valuation_only_yahooquery
+
 
 REQUIRED_METRICS = [
     "Revenue",
@@ -172,20 +174,19 @@ def build_raw_financials_payload(ticker: str, info_dict: Dict[str, Any]) -> Dict
     yahooquery = info_dict.get("yahooquery") if isinstance(info_dict, dict) else {}
     if not isinstance(yahooquery, dict):
         yahooquery = {}
-    financial_data = _yahooquery_section(yahooquery, "financial_data")
-    key_stats = _yahooquery_section(yahooquery, "key_stats")
-    summary_detail = _yahooquery_section(yahooquery, "summary_detail")
+    yahooquery = valuation_only_yahooquery(yahooquery)
+    live_quote = _yahooquery_section(yahooquery, "live_quote")
     valuation_latest = _latest_valuation_measures(yahooquery)
     financial_currency = (
         provider_info.get("financialCurrency")
-        or financial_data.get("financialCurrency")
+        or live_quote.get("financialCurrency")
         or info.get("original_financial_currency")
         or info.get("financial_currency")
         or "USD"
     )
     price_currency = (
         provider_info.get("currency")
-        or summary_detail.get("currency")
+        or live_quote.get("currency")
         or info.get("original_price_currency")
         or None
     )
@@ -206,20 +207,17 @@ def build_raw_financials_payload(ticker: str, info_dict: Dict[str, Any]) -> Dict
         "financial_currency": financial_currency,
         "original_price_currency": price_currency,
         "currency_policy": "original_provider_currency_only",
-        "current_price": _first_present(provider_info.get("currentPrice"), provider_info.get("regularMarketPrice"), financial_data.get("currentPrice")),
-        "shares_outstanding": _first_present(provider_info.get("sharesOutstanding"), provider_info.get("impliedSharesOutstanding"), key_stats.get("sharesOutstanding")),
-        "market_cap": _first_present(provider_info.get("marketCap"), valuation_latest.get("MarketCap"), summary_detail.get("marketCap")),
-        "enterprise_value": _first_present(provider_info.get("enterpriseValue"), valuation_latest.get("EnterpriseValue"), key_stats.get("enterpriseValue")),
-        "price_to_book": _first_present(provider_info.get("priceToBook"), key_stats.get("priceToBook")),
-        "price_to_earnings": _first_present(provider_info.get("trailingPE"), summary_detail.get("trailingPE")),
-        "forward_price_to_earnings": _first_present(provider_info.get("forwardPE"), summary_detail.get("forwardPE")),
-        "price_to_sales": _first_present(provider_info.get("priceToSalesTrailing12Months"), key_stats.get("priceToSalesTrailing12Months")),
-        "enterprise_to_revenue": _first_present(provider_info.get("enterpriseToRevenue"), key_stats.get("enterpriseToRevenue")),
-        "enterprise_to_ebitda": _first_present(provider_info.get("enterpriseToEbitda"), key_stats.get("enterpriseToEbitda")),
-        "peg_ratio": _first_present(provider_info.get("pegRatio"), key_stats.get("pegRatio")),
-        "total_debt": _first_present(provider_info.get("totalDebt"), financial_data.get("totalDebt")),
-        "total_cash": _first_present(provider_info.get("totalCash"), financial_data.get("totalCash")),
-        "total_revenue": _first_present(provider_info.get("totalRevenue"), financial_data.get("totalRevenue")),
+        "current_price": _first_present(provider_info.get("currentPrice"), provider_info.get("regularMarketPrice"), live_quote.get("currentPrice"), live_quote.get("regularMarketPrice")),
+        "shares_outstanding": _first_present(provider_info.get("sharesOutstanding"), provider_info.get("impliedSharesOutstanding"), live_quote.get("sharesOutstanding"), live_quote.get("impliedSharesOutstanding")),
+        "market_cap": _first_present(provider_info.get("marketCap"), live_quote.get("marketCap"), valuation_latest.get("MarketCap")),
+        "enterprise_value": _first_present(provider_info.get("enterpriseValue"), live_quote.get("enterpriseValue"), valuation_latest.get("EnterpriseValue")),
+        "price_to_book": _first_present(provider_info.get("priceToBook"), valuation_latest.get("PbRatio")),
+        "price_to_earnings": _first_present(provider_info.get("trailingPE"), valuation_latest.get("PeRatio")),
+        "forward_price_to_earnings": _first_present(provider_info.get("forwardPE"), valuation_latest.get("ForwardPeRatio")),
+        "price_to_sales": _first_present(provider_info.get("priceToSalesTrailing12Months"), valuation_latest.get("PsRatio")),
+        "enterprise_to_revenue": _first_present(provider_info.get("enterpriseToRevenue"), valuation_latest.get("EnterprisesValueRevenueRatio")),
+        "enterprise_to_ebitda": _first_present(provider_info.get("enterpriseToEbitda"), valuation_latest.get("EnterprisesValueEBITDARatio")),
+        "peg_ratio": _first_present(provider_info.get("pegRatio"), valuation_latest.get("PegRatio")),
     }
     return {
         "ticker": str(ticker).upper(),
@@ -262,14 +260,14 @@ Use Deep Reasoning:
 - Keep values in the original financial currency. Ratios and margins should be decimals, not strings.
 - Keep currency/count numeric values as raw statement values. Do not rescale to thousands, millions, or billions; the dashboard will handle display formatting.
 - Treat this payload as original-provider-currency-only. Do not convert any value to USD, do not infer USD values, and do not mix USD-normalized legacy values with original financial statements.
-- Current quote snapshot fields in payload.info, including market_cap, enterprise_value, debt, cash, revenue, and valuation multiples, are selected from original provider data for this Financials tab. Use them as-is and preserve the payload currency.
+- Current quote snapshot fields in payload.info are limited to price, shares, market capitalization, enterprise value, and provider-reported valuation multiples. Operating financial metrics must come from the statement tables.
 - If the price currency differs from the financial currency, use provider market_cap and enterprise_value for currency metrics rather than multiplying price by shares. Some exchanges quote price units differently from financial statement currency.
 - Make the table simple enough for a dashboard but deep enough to explain the economics.
 
 Mandatory rows, in this exact order:
 {required}
 
-Current market snapshot fields, outside the period table. Use the yahooquery valuation_measures and financial_data payload as the preferred source for these current multiple boxes, especially P/S, EV/Revenue, EV/EBITDA, PEG, and Forward P/E. If multiple period rows exist, prefer the latest TTM row; if TTM is missing, use the latest available row and state that in the note. The recent_average object may be used as context in the note, not as a replacement for the current latest value unless the latest value is missing:
+Current market snapshot fields, outside the period table. Use only the yahooquery valuation_measures payload and the allowlisted quote fields as the source for these current multiple boxes. If multiple period rows exist, prefer the latest TTM row; if TTM is missing, use the latest available row and state that in the note. The recent_average object may be used as context in the note, not as a replacement for the current latest value unless the latest value is missing:
 {snapshot}
 
 Optional rows:
@@ -286,7 +284,7 @@ Balance sheet and market-value logic:
 - Total Assets, receivables, inventory, liquid assets, liabilities, equity, debt, and net liquidity should come from the balance sheet whenever available.
 - Liquid Assets means cash + cash equivalents + short-term investments / marketable securities. If yfinance reports only cash and equivalents, use that and say so in the note.
 - Working Capital = Total Current Assets - Total Current Liabilities. Use reported current asset/current liability lines from the balance sheet. If either side is unavailable, use null and explain which side is missing.
-- Total Debt means short-term debt plus long-term debt. If only total debt is available from quote info, use it only where period-specific statement debt is missing and mark the row "derived" or "mixed".
+- Total Debt means short-term debt plus long-term debt and must come from the period-specific statement. If it is unavailable, use null.
 - Net Liquidity = Liquid Assets - Total Debt.
 - Equity-to-Assets Ratio = Total Shareholders' Equity / Total Assets. It is a ratio decimal, not a percent string.
 - Tax Rate = tax provision / pretax income when both are available. If either line is missing, use null.
@@ -295,7 +293,7 @@ Balance sheet and market-value logic:
 - Capital Expenditures (Capex) should come from the cash flow statement when available. Use the absolute cash outflow amount as a positive currency value even if the statement reports capex as negative.
 - Capex / Revenue = Capital Expenditures (Capex) / Revenue when both are available. It is a ratio decimal, not a percent string.
 - SBC / Revenue = Stock-Based Compensation / Revenue when both are available. If SBC is not disclosed separately, use null.
-- Market Capitalization, Enterprise Value (EV), Price-to-Book Ratio (P/B), Price-to-Earnings Ratio (P/E), Forward P/E, Price-to-Sales, EV/Revenue, EV/EBITDA, and PEG are current quote/multiple snapshot fields, not period-table rows. Put them in current_metrics only when available from quote info, yahooquery valuation_measures, yahooquery financial_data, or defensible from quote info plus latest statements. Do not invent historical values for them.
+- Market Capitalization, Enterprise Value (EV), Price-to-Book Ratio (P/B), Price-to-Earnings Ratio (P/E), Forward P/E, Price-to-Sales, EV/Revenue, EV/EBITDA, and PEG are current quote/multiple snapshot fields, not period-table rows. Put them in current_metrics only when available from the allowlisted quote info or yahooquery valuation_measures. Do not invent historical values for them.
 
 Return ONLY valid JSON with this exact shape:
 {{

--- a/src/ai_hedge/legacy_port.py
+++ b/src/ai_hedge/legacy_port.py
@@ -35,6 +35,11 @@ def get_10_day_avg_risk_free_rate():
 from typing import Any, Dict, Optional
 import pandas as pd
 
+from .provider_data_policy import (
+    safe_company_profile,
+    valuation_only_yahooquery,
+)
+
 def _df_to_table_payload(
     df: pd.DataFrame,
     scale_abs_gt: float = 1,
@@ -398,76 +403,19 @@ def find_currency(curr):
 
 def recalculate_derived_metrics(info: Dict[str, Any]) -> Dict[str, Any]:
     """
-    Recalculates ratios like PE, PriceToBook, EV, etc. based on the
-    unifed USD values of price and financials.
+    Normalize market capitalization after quote-currency conversion.
+
+    Provider financial-summary fields are not a trusted basis for deriving
+    valuation multiples. Preserve the provider's directly reported multiples
+    instead of rebuilding P/E, P/B, P/S, EV, or EV ratios from those fields.
     """
-    # 1. Ensure basic values exist
     price = info.get("currentPrice")
     shares = _select_shares_outstanding(info, default=None)
 
     if not price or not shares:
         return info
 
-    # 2. Recalculate Market Cap (Must be accurate for other calcs)
-    market_cap = price * shares
-    info["marketCap"] = market_cap
-
-    # 3. Recalculate EPS (Net Income / Shares)
-    # YFinance often reports EPS in ILS even if financials are USD.
-    # Best to recalc from Net Income which is reliable.
-    net_income = info.get("netIncomeToCommon")
-    if _is_number(net_income):
-        info["trailingEps"] = net_income / shares
-        # Now Recalculate PE
-        if info["trailingEps"] > 0:
-            info["trailingPE"] = price / info["trailingEps"]
-        else:
-            info["trailingPE"] = None
-
-    # 4. Recalculate Price to Book
-    book_value = info.get("bookValue") # Assumed to be in USD after conversion
-    if _is_number(book_value) and book_value != 0:
-        info["priceToBook"] = price / book_value
-
-    # 5. Recalculate Enterprise Value (EV)
-    # EV = Market Cap + Total Debt - Total Cash
-    total_debt = info.get("totalDebt")
-    total_cash = info.get("totalCash")
-
-    if _is_number(total_debt) and _is_number(total_cash):
-        ev = market_cap + total_debt - total_cash
-        info["enterpriseValue"] = ev
-
-    # 6. EV based ratios
-        ebitda = info.get("ebitda")
-        if _is_number(ebitda) and ebitda != 0:
-            info["enterpriseToEbitda"] = ev / ebitda
-
-        revenue = info.get("totalRevenue")
-        if _is_number(revenue) and revenue != 0:
-            info["enterpriseToRevenue"] = ev / revenue
-
-    # 7. Dividend ratios - FIXED
-    yield_val = info.get("dividendYield")
-
-    if _is_number(price) and _is_number(yield_val):
-        if yield_val > 0.5:
-            yield_decimal = yield_val / 100.0
-        else:
-            yield_decimal = yield_val
-
-        calculated_rate = price * yield_decimal
-
-        info["dividendRate"] = calculated_rate
-
-    else:
-        info.pop("dividendRate", None)
-        info.pop("trailingAnnualDividendRate", None)
-
-    # 8. Recalculate Price to Sales (P/S)
-    revenue = info.get("totalRevenue")
-    if _is_number(revenue) and revenue > 0:
-        info["priceToSalesTrailing12Months"] = market_cap / revenue
+    info["marketCap"] = price * shares
 
     return info
 
@@ -1067,15 +1015,246 @@ warnings.filterwarnings('ignore')
 #  'price_currency_to_USD': 3.1077,
 #  'financial_currency_to_USD': 3.1077
 
+def _safe_ticker_frame(ticker_obj: Any, attribute: str) -> pd.DataFrame:
+    try:
+        frame = getattr(ticker_obj, attribute)
+    except Exception:
+        return pd.DataFrame()
+    return frame if isinstance(frame, pd.DataFrame) else pd.DataFrame()
+
+
+def _ordered_statement_columns(df: pd.DataFrame) -> List[Any]:
+    columns = list(getattr(df, "columns", []))
+    try:
+        return sorted(columns, key=lambda value: pd.Timestamp(value), reverse=True)
+    except Exception:
+        return columns
+
+
+def _statement_series(df: pd.DataFrame, aliases: Iterable[str]) -> Optional[pd.Series]:
+    if df is None or getattr(df, "empty", True):
+        return None
+    for alias in aliases:
+        if alias not in df.index:
+            continue
+        row = df.loc[alias]
+        if isinstance(row, pd.DataFrame):
+            row = row.iloc[0]
+        if isinstance(row, pd.Series):
+            return row
+    return None
+
+
+def _statement_value(
+    df: pd.DataFrame,
+    aliases: Iterable[str],
+) -> Tuple[Optional[float], Optional[str]]:
+    row = _statement_series(df, aliases)
+    if row is None:
+        return None, None
+    for column in _ordered_statement_columns(df):
+        try:
+            value = float(row[column])
+        except (TypeError, ValueError, KeyError):
+            continue
+        if pd.notna(value):
+            return value, str(column)
+    return None, None
+
+
+def _statement_ttm_value(
+    quarterly_df: pd.DataFrame,
+    aliases: Iterable[str],
+) -> Tuple[Optional[float], Optional[str]]:
+    row = _statement_series(quarterly_df, aliases)
+    if row is None:
+        return None, None
+    values: List[float] = []
+    newest_period: Optional[str] = None
+    for column in _ordered_statement_columns(quarterly_df):
+        try:
+            value = float(row[column])
+        except (TypeError, ValueError, KeyError):
+            continue
+        if pd.isna(value):
+            continue
+        if newest_period is None:
+            newest_period = str(column)
+        values.append(value)
+        if len(values) == 4:
+            return sum(values), newest_period
+    return None, None
+
+
+def _scaled_statement_amount(value: Optional[float], currency_rate: Any) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        divisor = float(currency_rate)
+    except (TypeError, ValueError):
+        divisor = 1.0
+    if divisor <= 0:
+        divisor = 1.0
+    return float(value) / divisor
+
+
+def _build_statement_metrics(
+    *,
+    financials_annual: pd.DataFrame,
+    financials_quarterly: pd.DataFrame,
+    balance_sheet_annual: pd.DataFrame,
+    balance_sheet_quarterly: pd.DataFrame,
+    cashflow_annual: pd.DataFrame,
+    cashflow_quarterly: pd.DataFrame,
+    currency_rate: Any,
+) -> Dict[str, Any]:
+    revenue, income_period = _statement_ttm_value(
+        financials_quarterly,
+        ("Total Revenue", "Operating Revenue"),
+    )
+    if revenue is None:
+        revenue, income_period = _statement_value(
+            financials_annual,
+            ("Total Revenue", "Operating Revenue"),
+        )
+
+    net_income, net_income_period = _statement_ttm_value(
+        financials_quarterly,
+        (
+            "Net Income Common Stockholders",
+            "Net Income",
+            "Net Income Continuous Operations",
+        ),
+    )
+    if net_income is None:
+        net_income, net_income_period = _statement_value(
+            financials_annual,
+            (
+                "Net Income Common Stockholders",
+                "Net Income",
+                "Net Income Continuous Operations",
+            ),
+        )
+    income_period = income_period or net_income_period
+
+    balance_sheet = balance_sheet_quarterly
+    if balance_sheet is None or getattr(balance_sheet, "empty", True):
+        balance_sheet = balance_sheet_annual
+
+    total_cash, balance_period = _statement_value(
+        balance_sheet,
+        (
+            "Cash Cash Equivalents And Short Term Investments",
+            "Cash And Cash Equivalents",
+            "Cash Financial",
+        ),
+    )
+    total_debt, debt_period = _statement_value(balance_sheet, ("Total Debt",))
+    if total_debt is None:
+        current_debt, current_debt_period = _statement_value(
+            balance_sheet,
+            ("Current Debt And Capital Lease Obligation", "Current Debt"),
+        )
+        long_debt, long_debt_period = _statement_value(
+            balance_sheet,
+            ("Long Term Debt And Capital Lease Obligation", "Long Term Debt"),
+        )
+        if current_debt is not None or long_debt is not None:
+            total_debt = float(current_debt or 0) + float(long_debt or 0)
+            debt_period = current_debt_period or long_debt_period
+
+    total_equity, equity_period = _statement_value(
+        balance_sheet,
+        ("Stockholders Equity", "Total Equity Gross Minority Interest"),
+    )
+    total_assets, assets_period = _statement_value(balance_sheet, ("Total Assets",))
+    current_assets, current_assets_period = _statement_value(
+        balance_sheet,
+        ("Current Assets", "Total Current Assets"),
+    )
+    current_liabilities, current_liabilities_period = _statement_value(
+        balance_sheet,
+        ("Current Liabilities", "Total Current Liabilities"),
+    )
+    balance_period = (
+        balance_period
+        or debt_period
+        or equity_period
+        or assets_period
+        or current_assets_period
+        or current_liabilities_period
+    )
+
+    free_cashflow, cashflow_period = _statement_ttm_value(
+        cashflow_quarterly,
+        ("Free Cash Flow",),
+    )
+    if free_cashflow is None:
+        operating_cashflow, operating_period = _statement_ttm_value(
+            cashflow_quarterly,
+            ("Operating Cash Flow", "Total Cash From Operating Activities"),
+        )
+        capital_expenditure, capex_period = _statement_ttm_value(
+            cashflow_quarterly,
+            ("Capital Expenditure", "Capital Expenditures"),
+        )
+        if operating_cashflow is not None and capital_expenditure is not None:
+            free_cashflow = operating_cashflow - abs(capital_expenditure)
+            cashflow_period = operating_period or capex_period
+    if free_cashflow is None:
+        free_cashflow, cashflow_period = _statement_value(cashflow_annual, ("Free Cash Flow",))
+
+    current_ratio = None
+    if current_assets is not None and current_liabilities not in (None, 0):
+        current_ratio = float(current_assets) / float(current_liabilities)
+
+    equity_to_assets = None
+    if total_equity is not None and total_assets not in (None, 0):
+        equity_to_assets = float(total_equity) / float(total_assets)
+
+    return {
+        "source": "yfinance_statement_tables",
+        "income_period_end": income_period,
+        "balance_sheet_period_end": balance_period,
+        "cashflow_period_end": cashflow_period,
+        "revenue": _scaled_statement_amount(revenue, currency_rate),
+        "net_income": _scaled_statement_amount(net_income, currency_rate),
+        "free_cashflow": _scaled_statement_amount(free_cashflow, currency_rate),
+        "total_cash": _scaled_statement_amount(total_cash, currency_rate),
+        "total_debt": _scaled_statement_amount(total_debt, currency_rate),
+        "total_equity": _scaled_statement_amount(total_equity, currency_rate),
+        "total_assets": _scaled_statement_amount(total_assets, currency_rate),
+        "current_ratio": current_ratio,
+        "equity_to_assets": equity_to_assets,
+    }
+
+
 def get_financial_data(ticker: str, info_dict: dict, info_financials: dict) -> dict:
     financial_dict = {}
     ticker_obj = yf.Ticker(ticker)
 
-    # 1. Maintain original metadata keys
-    financial_dict["info"] = info_dict
+    # Provider financial summaries stay available in info_dict for diagnostics,
+    # but never cross an analysis/chat boundary.
+    financial_dict["info"] = safe_company_profile(info_dict, include_market_context=True)
     financial_currency_rate = info_dict.get("financial_currency_to_USD", 1)
     financial_dict["currency_statement"] = "Financial data is in USD"
-    financial_dict["info_financials"] = info_financials
+    financial_dict["info_financials"] = {}
+
+    financials_annual = _safe_ticker_frame(ticker_obj, "financials")
+    financials_quarterly = _safe_ticker_frame(ticker_obj, "quarterly_financials")
+    balance_sheet_annual = _safe_ticker_frame(ticker_obj, "balance_sheet")
+    balance_sheet_quarterly = _safe_ticker_frame(ticker_obj, "quarterly_balance_sheet")
+    cashflow_annual = _safe_ticker_frame(ticker_obj, "cashflow")
+    cashflow_quarterly = _safe_ticker_frame(ticker_obj, "quarterly_cashflow")
+    financial_dict["statement_metrics"] = _build_statement_metrics(
+        financials_annual=financials_annual,
+        financials_quarterly=financials_quarterly,
+        balance_sheet_annual=balance_sheet_annual,
+        balance_sheet_quarterly=balance_sheet_quarterly,
+        cashflow_annual=cashflow_annual,
+        cashflow_quarterly=cashflow_quarterly,
+        currency_rate=financial_currency_rate,
+    )
 
     # Helper to wrap the original df_to_llm_csv with a name
     def get_named_table(df, title):
@@ -1093,16 +1272,16 @@ def get_financial_data(ticker: str, info_dict: dict, info_financials: dict) -> d
             return f"### {title}\nNot available\n\n"
 
     # --- 2. Financials (Income Statement) ---
-    financial_dict["financials_annual"] = get_named_table(ticker_obj.financials, "Annual Income Statement")
-    financial_dict["financials_quarterly"] = get_named_table(ticker_obj.quarterly_financials, "Quarterly Income Statement")
+    financial_dict["financials_annual"] = get_named_table(financials_annual, "Annual Income Statement")
+    financial_dict["financials_quarterly"] = get_named_table(financials_quarterly, "Quarterly Income Statement")
 
     # --- 3. Balance Sheet ---
-    financial_dict["balance_sheet_annual"] = get_named_table(ticker_obj.balance_sheet, "Annual Balance Sheet")
-    financial_dict["balance_sheet_quarterly"] = get_named_table(ticker_obj.quarterly_balance_sheet, "Quarterly Balance Sheet")
+    financial_dict["balance_sheet_annual"] = get_named_table(balance_sheet_annual, "Annual Balance Sheet")
+    financial_dict["balance_sheet_quarterly"] = get_named_table(balance_sheet_quarterly, "Quarterly Balance Sheet")
 
     # --- 4. Cash Flow ---
-    financial_dict["cashflow_annual"] = get_named_table(ticker_obj.cashflow, "Annual Cash Flow Statement")
-    financial_dict["cashflow_quarterly"] = get_named_table(ticker_obj.quarterly_cashflow, "Quarterly Cash Flow Statement")
+    financial_dict["cashflow_annual"] = get_named_table(cashflow_annual, "Annual Cash Flow Statement")
+    financial_dict["cashflow_quarterly"] = get_named_table(cashflow_quarterly, "Quarterly Cash Flow Statement")
 
     # --- 5. Aggregates (Built as structured strings instead of raw tuples) ---
     try:
@@ -1170,8 +1349,15 @@ warnings.filterwarnings('ignore')
 #  'price_currency_to_USD': 3.1077,
 #  'financial_currency_to_USD': 3.1077
 
-def get_variables(ticker: str, info_dict: dict, financial_dict_quarter_bs, financial_dict_annual_finance, info_financials: dict) -> dict:
+def get_variables(
+    ticker: str,
+    info_dict: dict,
+    statement_metrics: dict,
+    financial_dict_annual_finance=None,
+    info_financials: Optional[dict] = None,
+) -> dict:
     variables_dict = {}
+    statement_metrics = statement_metrics if isinstance(statement_metrics, dict) else {}
     variables_dict["shares_outstanding"] = _select_shares_outstanding(info_dict, default=1)
     price = info_dict.get("currentPrice", 0)
     variables_dict["price"] = price if _is_number(price) else 0
@@ -1184,39 +1370,29 @@ def get_variables(ticker: str, info_dict: dict, financial_dict_quarter_bs, finan
         variables_dict["market_cap"] = 0
     variables_dict["price_currency"] = info_dict.get("price_currency_to_USD", 1)
     variables_dict["financial_currency"] = info_dict.get("financial_currency_to_USD", 1)
-    total_debt = info_dict.get("totalDebt")
-    total_cash = info_dict.get("totalCash")
-    enterprise_value = info_dict.get("enterpriseValue")
+    total_debt = statement_metrics.get("total_debt")
+    total_cash = statement_metrics.get("total_cash")
 
-    # Keep EV/Market Cap bridge consistent across currencies.
-    # Prefer EV rebuilt from debt/cash when available in normalized info.
+    # The EV/equity bridge uses dated balance-sheet rows, never opaque INFO
+    # debt/cash fields. If statement net debt is unavailable, retain the
+    # existing neutral fallback and make its provenance explicit.
     if _is_number(total_debt) and _is_number(total_cash):
       variables_dict["ev"] = variables_dict["market_cap"] + total_debt - total_cash
-    elif _is_number(enterprise_value):
-      variables_dict["ev"] = enterprise_value
+      variables_dict["ev_source"] = "statement_net_debt"
     else:
       variables_dict["ev"] = variables_dict["market_cap"]
+      variables_dict["ev_source"] = "market_cap_fallback_missing_statement_net_debt"
     variables_dict["differnce"] = variables_dict["ev"] - variables_dict["market_cap"]
-    book_value = info_dict.get("bookValue", 0)
-    variables_dict["Equity"] = book_value * variables_dict["shares_outstanding"]
-    variables_dict["current_ratio"] = info_dict.get("currentRatio", 0)
-    try:
-        bs = financial_dict_quarter_bs
-        variables_dict["Total_assets"] = bs["values"][bs["index"].index("Total Assets")][0]
-    except:
-        variables_dict["Total_assets"] = 1
-    try:
-        variables_dict["Equity_to_assets"] = variables_dict["Equity"] / variables_dict["Total_assets"]
-    except:
-        variables_dict["Equity_to_assets"] = 0
-    try:
-        variables_dict["revenue"] = info_financials.get("totalRevenue", 1)
-    except:
-        variables_dict["revenue"] = 1
-    try:
-        variables_dict["net_income"] = info_financials.get("netIncomeToCommon", 1)
-    except:
-        variables_dict["net_income"] = 1
+    variables_dict["Equity"] = statement_metrics.get("total_equity")
+    variables_dict["Total_assets"] = statement_metrics.get("total_assets")
+    variables_dict["current_ratio"] = statement_metrics.get("current_ratio")
+    variables_dict["Equity_to_assets"] = statement_metrics.get("equity_to_assets")
+    variables_dict["revenue"] = statement_metrics.get("revenue")
+    variables_dict["net_income"] = statement_metrics.get("net_income")
+    variables_dict["free_cashflow"] = statement_metrics.get("free_cashflow")
+    variables_dict["statement_metrics_source"] = statement_metrics.get("source")
+    variables_dict["statement_income_period_end"] = statement_metrics.get("income_period_end")
+    variables_dict["statement_balance_sheet_period_end"] = statement_metrics.get("balance_sheet_period_end")
 
     print(f"Downloaded variables for {ticker}")
     return variables_dict
@@ -1231,7 +1407,11 @@ def get_dicts(ticker):
     info_payload = info_dict.get("info") if isinstance(info_dict, dict) else {}
     files_dict = latest_filing_full_text(ticker, company_info=info_payload if isinstance(info_payload, dict) else {})
     financial_dict = get_financial_data(ticker, info_dict["info"], info_dict["financials"])
-    variables_dict = get_variables(ticker, info_dict["info"], financial_dict["balance_sheet_quarterly"], financial_dict["financials_annual"], info_dict["financials"])
+    variables_dict = get_variables(
+        ticker,
+        info_dict["info"],
+        financial_dict.get("statement_metrics", {}),
+    )
     return info_dict, files_dict, financial_dict, variables_dict
 
 
@@ -1507,12 +1687,13 @@ def what_it_does_insights_result(info_dict) -> Tuple[str, str]:
     """
 
     header = "What the company is doing"
+    profile = safe_company_profile(info_dict.get("info") if isinstance(info_dict, dict) else {})
 
     prompt = f"""
 You are a sharp equity analyst.
 
-Here is raw company information data:
-{info_dict["info"]}
+Here is an allowlisted company profile containing business-description and identity fields only:
+{json.dumps(profile, ensure_ascii=False, default=str)}
 
 Your task:
 Explain, in clear and simple language, what this company actually does in practice.
@@ -1560,16 +1741,19 @@ def info_insights_result(info_dict) -> Tuple[str, str]:
     """
 
     header = "General Information Insights"
+    profile = safe_company_profile(
+        info_dict.get("info") if isinstance(info_dict, dict) else {},
+        include_market_context=True,
+    )
 
     prompt = f"""
 You are a world-class equity analyst, long-term investor, and strategic thinker.
 
-You are given a single Python dictionary called info_dict["info"], extracted from a financial API.
-This dictionary contains company profile data, governance indicators, market data, valuation metrics,
-growth rates, profitability ratios, balance sheet strength, ownership structure, analyst expectations,
-and operational details.
+You are given an allowlisted company profile containing business-description,
+identity, geography, and limited current market-context fields. Opaque provider
+financial statistics have intentionally been excluded.
 
-Your task is to extract the deepest, smartest, and most non-obvious insights possible from this data.
+Your task is to extract useful strategic and business-model insights from this limited profile.
 
 Rules:
 - Think like a buy-side analyst managing concentrated capital.
@@ -1580,9 +1764,9 @@ Rules:
 - Be explicit about what truly matters and what is misleading.
 - If something looks extraordinary, explain why.
 - If something looks risky or unsustainable, explain the mechanism.
-- If valuation implies extreme expectations, articulate them clearly.
-- If governance, ownership, margins, growth, or capital structure stand out, explain the consequences.
-- Connect business model, financials, and market expectations into a single coherent story.
+- Do not infer revenue growth, profitability, balance-sheet strength, or accounting quality from absent data.
+- Treat price, shares, and market capitalization only as market context, not evidence of operating quality.
+- Focus on business model, customers, geography, scale, and strategic positioning supported by the profile.
 
 {ANALYSIS_CALIBRATION_RULES}
 
@@ -1593,7 +1777,7 @@ Output format:
 - No filler or repetition.
 
 Here is the data:
-{info_dict["info"]}
+{json.dumps(profile, ensure_ascii=False, default=str)}
 
 Now extract the smartest possible insights.
 """.strip()
@@ -1919,26 +2103,35 @@ def multiple_insights_result(info_dict) -> Tuple[str, str]:
     """
 
     header = "Multiple Analysis"
-    yq = info_dict.get("yahooquery") if isinstance(info_dict, dict) else {}
+    yq = valuation_only_yahooquery(
+        info_dict.get("yahooquery") if isinstance(info_dict, dict) else {}
+    )
     if not isinstance(yq, dict) or yq.get("status") != "success":
         error = yq.get("error") if isinstance(yq, dict) else "No yahooquery payload found."
         return header, f"Yahooquery valuation measures are not available. {error or ''}".strip()
+    profile = safe_company_profile(
+        info_dict.get("info") if isinstance(info_dict, dict) else {},
+        include_market_context=True,
+    )
 
     prompt = f"""
 You are a senior equity analyst writing the valuation-multiple context chapter for a company analysis.
 
 You are given:
 1) yahooquery valuation_measures, including historical rows of market cap, enterprise value, P/E, forward P/E, PEG, P/B, P/S, EV/Revenue, and EV/EBITDA.
-2) yahooquery financial_data with current financial, margin, analyst, liquidity, and leverage fields.
-3) The existing info_dict["info"] company context from the product pipeline.
+2) An allowlisted company profile with identity, business, currency, and limited market context.
 
 Objective:
-Extract the important valuation information from the multiple data and explain what it says about how the market currently prices the company.
+Compare like-for-like valuation multiples across the supplied dates and period types, and explain what the history says about how the market prices the company.
 
 Rules:
 - Use only the supplied data.
 - This is company context, not a buy/sell recommendation.
-- Highlight current valuation level, historical movement in multiples, growth expectations embedded in PEG/forward P/E, balance-sheet effects in EV multiples, and margin/ROE context from financial_data.
+- Keep TTM, annual, and other period types distinct. Do not compare unlike periods as if they were identical.
+- Highlight current valuation level, historical movement in multiples, differences between trailing and forward P/E, and balance-sheet effects visible in EV-based versus equity-based multiples.
+- Provider-reported multiples are comparison inputs, not audited accounting facts.
+- Do not infer revenue growth, margins, ROA, ROE, liquidity, or financial quality; those fields are intentionally absent.
+- Treat missing, zero-placeholder, negative-denominator, or economically inapplicable multiples as unavailable rather than forcing an interpretation.
 - When data is missing or mixed by period, say so plainly.
 - For non-USD or .TA tickers, do not assume USD; use the currency fields as context.
 - Keep it concise and user-friendly.
@@ -1950,8 +2143,8 @@ Rules:
 yahooquery payload:
 {json.dumps(yq, ensure_ascii=False)[:90000]}
 
-info_dict["info"]:
-{json.dumps(info_dict.get("info", {}), ensure_ascii=False)[:60000]}
+Company profile:
+{json.dumps(profile, ensure_ascii=False, default=str)[:30000]}
 
 Now write the valuation-multiple context chapter.
 """.strip()
@@ -3998,10 +4191,12 @@ import datetime as dt
 
 def build_prompt(ticker, financial_dict, instruction, text):
   financial_data = financial_dict["All Reports"]
-  info = financial_dict["info"]
+  info = safe_company_profile(
+      financial_dict.get("info"),
+      include_market_context=True,
+  )
   currency_statement = financial_dict["currency_statement"]
   today_date = dt.date.today().strftime("%Y-%m-%d")
-  additional_data = financial_dict["info_financials"]
   rate = financial_dict.get("rate", 0)
   if rate > 0:
     rate_statement = f"The 10-Day Average Risk-Free Rate (USA 10Y Treasury) is: {rate:.4f}%"
@@ -4016,7 +4211,7 @@ def build_prompt(ticker, financial_dict, instruction, text):
   You are given:
   1) - Prepared analysis document (raw text)
   2) - Financial data (structured)
-  3) - Company Profile Stats (structured)
+  3) - Company profile and current market context (structured)
   4) - Explicit output instructions (strict JSON schema)
 
   Treat the prepared analysis as a very professional analyst opinion - very strong and high quality - but not the truth itself.
@@ -4036,10 +4231,6 @@ def build_prompt(ticker, financial_dict, instruction, text):
   Company Profile Stats:
   <Company_Profile_Stats>
   {info}
-
-  Relevant financial data from the Company Profile Stats:
-  {additional_data}
-  {currency_statement}
   </Company_Profile_Stats>
 
   <Internal_Thinking_Process>
@@ -6009,7 +6200,10 @@ def extract_gaap_sbc_non_recurring_json(text: str, variables_dict: Dict[str, Any
 
 def _run_sicum_once(ticker, text, financial_dict, as_of_date, n, variables_dict):
   financial_reports = financial_dict["All Reports"]
-  info = financial_dict["info"]
+  info = safe_company_profile(
+      financial_dict.get("info"),
+      include_market_context=True,
+  )
   currrency_statement = financial_dict["currency_statement"]
   prompt = f"""
 You are a senior buy-side equity analyst and forensic accountant.

--- a/src/ai_hedge/provider_data_policy.py
+++ b/src/ai_hedge/provider_data_policy.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Dict, Mapping
+
+
+# Provider company-info dictionaries mix durable profile fields, live market
+# fields, and opaque financial calculations. Only explicitly approved fields
+# may cross an LLM boundary.
+SAFE_COMPANY_PROFILE_KEYS = (
+    "shortName",
+    "longName",
+    "displayName",
+    "symbol",
+    "underlyingSymbol",
+    "quoteType",
+    "exchange",
+    "fullExchangeName",
+    "industry",
+    "sector",
+    "country",
+    "state",
+    "city",
+    "address1",
+    "website",
+    "longBusinessSummary",
+    "fullTimeEmployees",
+    "currency",
+    "financialCurrency",
+    "original_price_currency",
+    "original_financial_currency",
+)
+
+SAFE_MARKET_CONTEXT_KEYS = (
+    "currentPrice",
+    "regularMarketPrice",
+    "marketCap",
+    "sharesOutstanding",
+    "impliedSharesOutstanding",
+)
+
+# Multiples remain useful for like-for-like valuation comparisons. They are
+# intentionally isolated from operating claims such as growth and margins.
+SAFE_VALUATION_CONTEXT_KEYS = (
+    "trailingPE",
+    "forwardPE",
+    "pegRatio",
+    "priceToBook",
+    "priceToSalesTrailing12Months",
+    "enterpriseToRevenue",
+    "enterpriseToEbitda",
+)
+
+SAFE_LIVE_QUOTE_KEYS = (
+    "currentPrice",
+    "regularMarketPrice",
+    "marketCap",
+    "enterpriseValue",
+    "sharesOutstanding",
+    "impliedSharesOutstanding",
+    "currency",
+    "financialCurrency",
+)
+
+SAFE_VALUATION_MEASURE_KEYS = (
+    "asOfDate",
+    "periodType",
+    "MarketCap",
+    "EnterpriseValue",
+    "PeRatio",
+    "ForwardPeRatio",
+    "PegRatio",
+    "PbRatio",
+    "PsRatio",
+    "EnterprisesValueRevenueRatio",
+    "EnterprisesValueEBITDARatio",
+)
+
+# Kept as an explicit policy list for tests, reviews, and future provider
+# additions. The allowlists above remain the enforcement mechanism.
+QUARANTINED_FINANCIAL_INFO_KEYS = frozenset(
+    {
+        "totalRevenue",
+        "revenueGrowth",
+        "grossProfits",
+        "ebitda",
+        "netIncomeToCommon",
+        "totalCash",
+        "totalDebt",
+        "freeCashflow",
+        "operatingCashflow",
+        "earningsGrowth",
+        "earningsQuarterlyGrowth",
+        "grossMargins",
+        "operatingMargins",
+        "ebitdaMargins",
+        "profitMargins",
+        "returnOnEquity",
+        "returnOnAssets",
+        "trailingEps",
+        "forwardEps",
+        "bookValue",
+        "currentRatio",
+        "quickRatio",
+        "debtToEquity",
+    }
+)
+
+
+def _select(source: Mapping[str, Any], keys: tuple[str, ...]) -> Dict[str, Any]:
+    return {key: deepcopy(source[key]) for key in keys if key in source}
+
+
+def safe_company_profile(
+    info: Mapping[str, Any] | None,
+    *,
+    include_market_context: bool = False,
+    include_valuation_context: bool = False,
+) -> Dict[str, Any]:
+    """Return an allowlisted company profile safe to serialize into prompts."""
+
+    if not isinstance(info, Mapping):
+        return {}
+    keys = list(SAFE_COMPANY_PROFILE_KEYS)
+    if include_market_context:
+        keys.extend(SAFE_MARKET_CONTEXT_KEYS)
+    if include_valuation_context:
+        keys.extend(SAFE_VALUATION_CONTEXT_KEYS)
+    return _select(info, tuple(dict.fromkeys(keys)))
+
+
+def valuation_only_yahooquery(snapshot: Mapping[str, Any] | None) -> Dict[str, Any]:
+    """Keep Yahooquery valuation rows and safe quote metadata, never financial_data."""
+
+    if not isinstance(snapshot, Mapping):
+        return {}
+
+    result = _select(
+        snapshot,
+        ("status", "ticker", "generated_at", "report_date", "error"),
+    )
+    valuation = snapshot.get("valuation_measures")
+    if isinstance(valuation, Mapping):
+        clean_valuation: Dict[str, Any] = {}
+        rows = valuation.get("rows")
+        if isinstance(rows, list):
+            clean_valuation["rows"] = [
+                _select(row, SAFE_VALUATION_MEASURE_KEYS)
+                for row in rows
+                if isinstance(row, Mapping)
+            ]
+        columns = valuation.get("columns")
+        if isinstance(columns, list):
+            clean_valuation["columns"] = [
+                key for key in SAFE_VALUATION_MEASURE_KEYS if key in columns
+            ]
+        latest = valuation.get("latest")
+        if isinstance(latest, Mapping):
+            clean_valuation["latest"] = _select(latest, SAFE_VALUATION_MEASURE_KEYS)
+        latest_by_period = valuation.get("latest_by_period")
+        if isinstance(latest_by_period, Mapping):
+            clean_valuation["latest_by_period"] = {
+                str(period): _select(row, SAFE_VALUATION_MEASURE_KEYS)
+                for period, row in latest_by_period.items()
+                if isinstance(row, Mapping)
+            }
+        recent_average = valuation.get("recent_average")
+        if isinstance(recent_average, Mapping):
+            clean_valuation["recent_average"] = _select(
+                recent_average,
+                SAFE_VALUATION_MEASURE_KEYS,
+            )
+        result["valuation_measures"] = clean_valuation
+
+    live_quote = snapshot.get("live_quote")
+    if isinstance(live_quote, Mapping):
+        result["live_quote"] = _select(live_quote, SAFE_LIVE_QUOTE_KEYS)
+    return result

--- a/src/ai_hedge/runner.py
+++ b/src/ai_hedge/runner.py
@@ -585,6 +585,21 @@ def _upsert_markdown_block(text: str, marker: str, block: str) -> str:
     return f"{block_txt}\n"
 
 
+def _append_trading_agents_final_decision(text: str, payload: Dict[str, Any]) -> str:
+    """Append the display-only TradingAgents decision after valuation has completed."""
+
+    from .trading_agents_adapter import build_trading_agents_final_decision_body
+
+    decision_body = build_trading_agents_final_decision_body(payload)
+    if not decision_body:
+        return str(text or "").strip()
+    return _upsert_markdown_block(
+        text,
+        "## TradingAgents Final Decision",
+        f"## TradingAgents Final Decision\n\n{decision_body}",
+    )
+
+
 def _wall_st_synthesis_to_markdown(wall_st_payload: Dict[str, Any]) -> str:
     synthesis = wall_st_payload.get("synthesis") if isinstance(wall_st_payload, dict) else {}
     synthesis = synthesis if isinstance(synthesis, dict) else {}
@@ -1909,6 +1924,12 @@ def _run_ticker_valuation_impl(
                 "## Financials",
                 financials_markdown,
             )
+        # Deliberately append this only after run_valuations. The tactical target and
+        # horizon remain stored for transparency but never cross the valuation boundary.
+        merged_analysis_text = _append_trading_agents_final_decision(
+            merged_analysis_text,
+            trading_agents_payload,
+        )
         if merged_analysis_text.strip():
             analysis_src.write_text(merged_analysis_text + "\n", encoding="utf-8")
             analysis_dst.write_text(merged_analysis_text + "\n", encoding="utf-8")

--- a/src/ai_hedge/service.py
+++ b/src/ai_hedge/service.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from re import compile as re_compile
 from typing import Any, Dict, List, Tuple
 
+from .provider_data_policy import safe_company_profile
+
 TICKER_REGEX = re_compile(r"^[A-Z0-9\.\-]{1,10}$")
 
 
@@ -539,7 +541,13 @@ def _generate_sec_analysis_text(
         errors.append("No official filing text available in files_dict.")
         return "", errors
 
-    info_text = _truncate_text(json.dumps(info_dict.get("info", {}), ensure_ascii=False), 120_000)
+    info_text = _truncate_text(
+        json.dumps(
+            safe_company_profile(info_dict.get("info", {}), include_market_context=True),
+            ensure_ascii=False,
+        ),
+        120_000,
+    )
     reports_value = financial_dict.get("all_reports", financial_dict.get("All Reports", ""))
     all_reports_text = _truncate_text(reports_value, 160_000)
 
@@ -912,7 +920,7 @@ def _run_sec_analysis(
 
         header = (
             f"# {ticker_u} - {'SEC Summary' if short_mode else 'SEC Full'} Analysis\n\n"
-            "This report is based strictly on official filing text + info_dict['info'] + financial_dict['All Reports'].\n\n"
+            "This report is based strictly on official filing text + an allowlisted company profile + financial_dict['All Reports'].\n\n"
             "\n\n"
         )
         analysis_target.write_text(header + generated_text + "\n", encoding="utf-8")

--- a/src/ai_hedge/trading_agents_adapter.py
+++ b/src/ai_hedge/trading_agents_adapter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import math
 import os
+import re
 import shutil
 import inspect
 from datetime import datetime, timedelta, timezone
@@ -10,7 +11,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 
-ADAPTER_VERSION = "2026-05-27.v2"
+ADAPTER_VERSION = "2026-08-19.v3"
 CONFIG_VERSION = "deepseek-v0.2.4-fundamentals-news-social"
 REUSE_WINDOW_DAYS = 7
 SELECTED_ANALYSTS = ["fundamentals", "news", "social"]
@@ -21,6 +22,26 @@ DEEP_THINK_LLM = "deepseek-reasoner"
 SUMMARY_LLM = "deepseek-v4-flash"
 DEEPSEEK_BACKEND_URL = "https://api.deepseek.com/v1"
 COMPACT_BRIEF_MAX_CHARS = 9000
+
+FINAL_DECISION_INDEPENDENCE_NOTE = (
+    "This tactical output is preserved for transparency as an independent TradingAgents view. "
+    "Its price target and time horizon are excluded from AI Hedge valuation prompts, model target-price "
+    "calculations, and consensus target aggregation to avoid anchoring the fundamental valuation process."
+)
+
+_TACTICAL_CONTEXT_LINE_RE = re.compile(
+    r"\b(?:price[\s_-]*target|target[\s_-]*price|entry[\s_-]*price|stop[\s_-]*loss|"
+    r"time[\s_-]*horizon|holding[\s_-]*period)\b",
+    flags=re.IGNORECASE,
+)
+_PRICE_TARGET_RE = re.compile(
+    r"(?im)^\s*(?:[-*]\s*)?(?:\*\*)?(?:price\s*target|target\s*price)(?:\*\*)?\s*:\s*"
+    r"(?:[A-Z]{3}\s*)?(?:[$€£₪]\s*)?([+-]?\d[\d,]*(?:\.\d+)?)",
+)
+_TIME_HORIZON_RE = re.compile(
+    r"(?im)^\s*(?:[-*]\s*)?(?:\*\*)?(?:time\s*horizon|holding\s*period)(?:\*\*)?\s*:\s*(.+?)\s*$",
+)
+_RATING_RE = re.compile(r"(?im)^\s*(?:[-*]\s*)?(?:\*\*)?rating(?:\*\*)?\s*:\s*(.+?)\s*$")
 
 CONTEXT_HEADER = "Independent Multi-Agent Research Lens"
 CONTEXT_INTRO = (
@@ -84,6 +105,84 @@ def _trim_chars(value: str, limit: int) -> str:
     return text[: max(0, int(limit))].rstrip() + "\n\n[Truncated]"
 
 
+def _without_tactical_decision_lines(value: Any) -> str:
+    """Remove tactical price/holding lines before content crosses a valuation boundary."""
+
+    text = _text(value)
+    if not text:
+        return ""
+    lines = [line for line in text.splitlines() if not _TACTICAL_CONTEXT_LINE_RE.search(line)]
+    return re.sub(r"\n{3,}", "\n\n", "\n".join(lines)).strip()
+
+
+def _clean_markdown_value(value: Any) -> str:
+    return re.sub(r"\*+", "", _text(value)).strip()
+
+
+def _extract_final_decision_metadata(final_decision: Any, processed_decision: Any = None) -> Dict[str, Any]:
+    text = _text(final_decision)
+    price_target: Optional[float] = None
+    price_match = _PRICE_TARGET_RE.search(text)
+    if price_match:
+        try:
+            parsed = float(price_match.group(1).replace(",", ""))
+            if math.isfinite(parsed) and parsed > 0:
+                price_target = parsed
+        except Exception:
+            price_target = None
+
+    time_horizon = ""
+    horizon_match = _TIME_HORIZON_RE.search(text)
+    if horizon_match:
+        time_horizon = _clean_markdown_value(horizon_match.group(1))
+
+    rating = _clean_markdown_value(processed_decision)
+    if not rating:
+        rating_match = _RATING_RE.search(text)
+        if rating_match:
+            rating = _clean_markdown_value(rating_match.group(1))
+
+    return {
+        "rating": rating,
+        "price_target": price_target,
+        "time_horizon": time_horizon,
+    }
+
+
+def _format_tactical_price(value: Any) -> str:
+    try:
+        number = float(value)
+    except Exception:
+        return ""
+    if not math.isfinite(number) or number <= 0:
+        return ""
+    return f"{number:,.2f}".rstrip("0").rstrip(".")
+
+
+def build_trading_agents_final_decision_body(payload: Dict[str, Any]) -> str:
+    """Render display-only decision metadata; this body must be appended after valuation."""
+
+    if not isinstance(payload, dict) or payload.get("status") != "success":
+        return ""
+    final_view = _text(payload.get("final_committee_view"))
+    safe_final_view = _without_tactical_decision_lines(final_view)
+    price_target = _format_tactical_price(payload.get("price_target"))
+    time_horizon = _clean_markdown_value(payload.get("time_horizon"))
+
+    parts: List[str] = []
+    if safe_final_view:
+        parts.append(safe_final_view)
+    metadata: List[str] = []
+    if price_target:
+        metadata.append(f"**TradingAgents Tactical Price Target:** {price_target} (instrument quote currency)")
+    if time_horizon:
+        metadata.append(f"**Time Horizon:** {time_horizon}")
+    if metadata:
+        parts.append("\n\n".join(metadata))
+        parts.append(f"> **Independence note:** {FINAL_DECISION_INDEPENDENCE_NOTE}")
+    return "\n\n".join(part.strip() for part in parts if str(part or "").strip()).strip()
+
+
 def _section(title: str, body: Any) -> str:
     text = _text(body)
     if not text:
@@ -94,7 +193,7 @@ def _section(title: str, body: Any) -> str:
 def build_trading_agents_context(payload: Dict[str, Any]) -> str:
     if not isinstance(payload, dict) or payload.get("status") != "success":
         return ""
-    research_brief = _text(payload.get("research_brief"))
+    research_brief = _without_tactical_decision_lines(payload.get("research_brief"))
     if research_brief:
         sections = [
             CONTEXT_INTRO,
@@ -104,12 +203,12 @@ def build_trading_agents_context(payload: Dict[str, Any]) -> str:
 
     sections = [
         CONTEXT_INTRO,
-        _section("Fundamentals Report", payload.get("fundamentals_report")),
-        _section("News Report", payload.get("news_report")),
-        _section("Social / Sentiment Report", payload.get("sentiment_report")),
-        _section("Bull/Bear Debate", payload.get("bull_bear_debate")),
-        _section("Risk Debate", payload.get("risk_debate")),
-        _section("Final Committee View", payload.get("final_committee_view")),
+        _section("Fundamentals Report", _without_tactical_decision_lines(payload.get("fundamentals_report"))),
+        _section("News Report", _without_tactical_decision_lines(payload.get("news_report"))),
+        _section("Social / Sentiment Report", _without_tactical_decision_lines(payload.get("sentiment_report"))),
+        _section("Bull/Bear Debate", _without_tactical_decision_lines(payload.get("bull_bear_debate"))),
+        _section("Risk Debate", _without_tactical_decision_lines(payload.get("risk_debate"))),
+        _section("Final Committee View", _without_tactical_decision_lines(payload.get("final_committee_view"))),
     ]
     return "\n\n".join(part.strip() for part in sections if str(part or "").strip()).strip()
 
@@ -117,7 +216,11 @@ def build_trading_agents_context(payload: Dict[str, Any]) -> str:
 def build_trading_agents_artifact_text(payload: Dict[str, Any]) -> str:
     body = build_trading_agents_context(payload)
     if body:
-        return f"## {CONTEXT_HEADER}\n\n{body}\n"
+        parts = [f"## {CONTEXT_HEADER}\n\n{body}"]
+        final_decision = build_trading_agents_final_decision_body(payload)
+        if final_decision:
+            parts.append(f"## TradingAgents Final Decision\n\n{final_decision}")
+        return "\n\n".join(parts).strip() + "\n"
 
     status = str(payload.get("status") or "unavailable") if isinstance(payload, dict) else "unavailable"
     error = str(payload.get("error") or payload.get("message") or "") if isinstance(payload, dict) else ""
@@ -135,19 +238,19 @@ def build_trading_agents_artifact_text(payload: Dict[str, Any]) -> str:
 
 def _raw_trading_agents_bundle(payload: Dict[str, Any]) -> str:
     sections = [
-        _section("Final Committee View", payload.get("final_committee_view")),
-        _section("Fundamentals Report", payload.get("fundamentals_report")),
-        _section("News Report", payload.get("news_report")),
-        _section("Social / Sentiment Report", payload.get("sentiment_report")),
-        _section("Bull/Bear Debate", payload.get("bull_bear_debate")),
-        _section("Risk Debate", payload.get("risk_debate")),
+        _section("Final Committee View", _without_tactical_decision_lines(payload.get("final_committee_view"))),
+        _section("Fundamentals Report", _without_tactical_decision_lines(payload.get("fundamentals_report"))),
+        _section("News Report", _without_tactical_decision_lines(payload.get("news_report"))),
+        _section("Social / Sentiment Report", _without_tactical_decision_lines(payload.get("sentiment_report"))),
+        _section("Bull/Bear Debate", _without_tactical_decision_lines(payload.get("bull_bear_debate"))),
+        _section("Risk Debate", _without_tactical_decision_lines(payload.get("risk_debate"))),
     ]
     return "\n\n".join(part.strip() for part in sections if str(part or "").strip()).strip()
 
 
 def _fallback_compact_research_brief(payload: Dict[str, Any]) -> str:
     pieces = []
-    final_view = _text(payload.get("final_committee_view"))
+    final_view = _without_tactical_decision_lines(payload.get("final_committee_view"))
     if final_view:
         pieces.append(f"### Final Committee View\n{_trim_chars(final_view, 1200)}")
     for title, key in [
@@ -157,7 +260,7 @@ def _fallback_compact_research_brief(payload: Dict[str, Any]) -> str:
         ("Bull/Bear Debate", "bull_bear_debate"),
         ("Risk Debate", "risk_debate"),
     ]:
-        text = _text(payload.get(key))
+        text = _without_tactical_decision_lines(payload.get(key))
         if text:
             pieces.append(f"### {title}\n{_trim_chars(text, 1400)}")
     return _trim_chars("\n\n".join(pieces).strip(), COMPACT_BRIEF_MAX_CHARS)
@@ -193,7 +296,8 @@ Preserve:
 
 Rules:
 - Keep it useful for valuation work: business quality, growth durability, earnings quality, margin drivers, capital intensity, competitive position, key news, sentiment, bull case, bear case, risk debate, and any other points that are relevant to fundamental valuation.
-- Do not add a target price, score, instruction, or trading order.
+- Omit every TradingAgents price target, target price, entry price, stop-loss, time horizon, and holding period. These tactical fields are preserved separately and must never enter the valuation context.
+- Do not add a score, instruction, or trading order.
 - Do not include chart or technical-analysis claims.
 - Do not mention that you are summarizing.
 - If the transcript evidence is ordinary, mixed, or thin, say so plainly.
@@ -231,7 +335,7 @@ TradingAgents raw transcript:
         )
         summary = _text(summary)
         if summary:
-            return _trim_chars(summary, COMPACT_BRIEF_MAX_CHARS)
+            return _trim_chars(_without_tactical_decision_lines(summary), COMPACT_BRIEF_MAX_CHARS)
     except Exception:
         pass
     return _fallback_compact_research_brief(payload)
@@ -248,6 +352,15 @@ def compact_trading_agents_payload(payload: Dict[str, Any], *, api_key: str = ""
             "trade_date": payload.get("trade_date"),
             "research_brief": brief,
             "final_committee_view": _text(payload.get("final_committee_view")),
+            "rating": _text(payload.get("rating")),
+            "price_target": payload.get("price_target"),
+            "time_horizon": _text(payload.get("time_horizon")),
+            "valuation_prompt_excluded_fields": [
+                "price_target",
+                "time_horizon",
+                "entry_price",
+                "stop_loss",
+            ],
             "market_report_excluded": bool(payload.get("market_report_excluded")),
             "compacted": True,
             "summary_model": SUMMARY_LLM if str(api_key or "").strip() else "fallback",
@@ -351,6 +464,15 @@ def _base_payload(ticker: str, now: Optional[datetime] = None) -> Dict[str, Any]
         "excluded_analysts": list(EXCLUDED_ANALYSTS),
         "reuse_window_days": REUSE_WINDOW_DAYS,
         "reused": False,
+        "rating": "",
+        "price_target": None,
+        "time_horizon": "",
+        "valuation_prompt_excluded_fields": [
+            "price_target",
+            "time_horizon",
+            "entry_price",
+            "stop_loss",
+        ],
         "included_sections": [
             "fundamentals_report",
             "news_report",
@@ -385,6 +507,12 @@ def normalize_trading_agents_state(
     payload = _base_payload(ticker, now=now)
     investment_debate = state.get("investment_debate_state") if isinstance(state, dict) else {}
     risk_debate = state.get("risk_debate_state") if isinstance(state, dict) else {}
+    raw_final_decision = _text(
+        state.get("final_trade_decision")
+        or state.get("investment_plan")
+        or state.get("trader_investment_plan")
+    )
+    metadata = _extract_final_decision_metadata(raw_final_decision, decision)
     payload.update(
         {
             "status": "success",
@@ -399,12 +527,10 @@ def normalize_trading_agents_state(
                 risk_debate,
                 ["aggressive_history", "conservative_history", "neutral_history", "judge_decision", "history"],
             ),
-            "final_committee_view": _text(
-                decision
-                or state.get("final_trade_decision")
-                or state.get("investment_plan")
-                or state.get("trader_investment_plan")
-            ),
+            "final_committee_view": raw_final_decision or _text(decision),
+            "rating": metadata["rating"],
+            "price_target": metadata["price_target"],
+            "time_horizon": metadata["time_horizon"],
             "market_report_excluded": bool(_text(state.get("market_report"))),
         }
     )

--- a/tests/test_competitor_market_review.py
+++ b/tests/test_competitor_market_review.py
@@ -43,11 +43,21 @@ def test_normalize_competitors_keeps_more_than_five_and_adds_israeli_suffix():
 
 
 def test_discovery_prompt_allows_more_than_five_and_israeli_suffix():
-    prompt = cmr.build_discovery_prompt("TEST.TA", {"country": "Israel", "longBusinessSummary": "software"})
+    prompt = cmr.build_discovery_prompt(
+        "TEST.TA",
+        {
+            "country": "Israel",
+            "longBusinessSummary": "software",
+            "revenueGrowth": -0.128,
+            "grossMargins": 0.94763,
+        },
+    )
     assert "okay to return more than 5" in prompt
     assert "top 5 ranked companies" in prompt
     assert ".TA" in prompt
     assert "United States" in prompt
+    assert "revenueGrowth" not in prompt
+    assert "grossMargins" not in prompt
 
 
 def test_collect_competitor_context_caps_to_five_and_uses_info_engine():
@@ -68,6 +78,8 @@ def test_collect_competitor_context_caps_to_five_and_uses_info_engine():
                 "marketCap": 123,
                 "financial_currency_to_USD": 2,
                 "longBusinessSummary": "summary",
+                "revenueGrowth": -0.128,
+                "grossMargins": 0.94763,
             }
         }
 
@@ -86,6 +98,8 @@ def test_collect_competitor_context_caps_to_five_and_uses_info_engine():
     assert info_calls == ["T1", "T2", "T3", "T4", "T5"]
     assert annual_calls == [("T1", 2), ("T2", 2), ("T3", 2), ("T4", 2), ("T5", 2)]
     assert out[0]["info"]["marketCap"] == 123
+    assert "revenueGrowth" not in out[0]["info"]
+    assert "grossMargins" not in out[0]["info"]
 
 
 def test_collect_competitor_context_retries_invalid_ticker_then_skips():
@@ -168,6 +182,8 @@ def test_build_original_company_context_uses_info_and_annual_income_statement():
                 "marketCap": 123,
                 "financial_currency_to_USD": 1,
                 "longBusinessSummary": "Cybersecurity platform.",
+                "revenueGrowth": -0.128,
+                "grossMargins": 0.94763,
             }
         },
         annual_table_fetcher=fake_annual,
@@ -177,6 +193,8 @@ def test_build_original_company_context_uses_info_and_annual_income_statement():
     assert context["ticker"] == "CHKP"
     assert context["company_name"] == "Check Point"
     assert context["info"]["marketCap"] == 123
+    assert "revenueGrowth" not in context["info"]
+    assert "grossMargins" not in context["info"]
     assert "Revenue,Net Income" in context["annual_financials"]
 
 
@@ -259,25 +277,40 @@ def test_normalize_price_history_does_not_rescale_non_ta_ticker():
     assert normalized is rows
 
 
-def test_review_prompt_requires_original_company_financial_comparison():
+def test_review_prompt_requires_statement_financials_and_sanitizes_info():
     prompt = cmr.build_review_prompt(
         {
             "ticker": "CHKP",
             "name_of_market": "Enterprise Cybersecurity",
             "original_company": {
                 "ticker": "CHKP",
-                "info": {"shortName": "Check Point", "marketCap": 123},
+                "info": {
+                    "shortName": "Check Point",
+                    "marketCap": 123,
+                    "revenueGrowth": -0.128,
+                    "grossMargins": 0.94763,
+                },
                 "annual_financials": "### Annual Income Statement\n```csv\nRevenue\n```",
             },
-            "competitors": [{"ticker": "PANW", "annual_financials": "### Annual Income Statement\nNot available"}],
+            "competitors": [
+                {
+                    "ticker": "PANW",
+                    "info": {"profitMargins": 0.2},
+                    "annual_financials": "### Annual Income Statement\nNot available",
+                }
+            ],
         }
     )
 
-    assert 'original company info_dict["info"]' in prompt
+    assert "original company profile and provider-reported valuation context" in prompt
     assert "original company annual income-statement table" in prompt
     assert "Include the original company in the financial and strategic comparison" in prompt
     assert 'clear "-" cells when data is missing' in prompt
     assert '"original_company"' in prompt
+    assert "revenueGrowth" not in prompt
+    assert "grossMargins" not in prompt
+    assert "profitMargins" not in prompt
+    assert "statement-derived growth or margin cues" in prompt
 
 
 def test_run_competitor_market_review_includes_original_company_payload(monkeypatch):

--- a/tests/test_financials_agent.py
+++ b/tests/test_financials_agent.py
@@ -4,6 +4,7 @@ import pandas as pd
 
 from ai_hedge.financials_agent import (
     REQUIRED_METRICS,
+    build_financials_prompt,
     build_raw_financials_payload,
     financials_analysis_to_markdown,
     normalize_financials_analysis,
@@ -62,10 +63,34 @@ def test_build_raw_financials_payload_uses_original_provider_currency_quote_fiel
     assert payload["info"]["current_price"] == 724.6
     assert payload["info"]["market_cap"] == 132440792
     assert payload["info"]["enterprise_value"] == 110804120
-    assert payload["info"]["total_debt"] == 2710000
-    assert payload["info"]["total_cash"] == 24949000
-    assert payload["info"]["total_revenue"] == 17395000
+    assert "total_debt" not in payload["info"]
+    assert "total_cash" not in payload["info"]
+    assert "total_revenue" not in payload["info"]
     assert "financial_currency_to_USD" not in payload["info"]
+
+
+def test_build_raw_financials_payload_quarantines_yahooquery_financial_data():
+    info_dict = {
+        "info": {"symbol": "RIT1.TA", "original_financial_currency": "ILS"},
+        "yahooquery": {
+            "status": "success",
+            "ticker": "RIT1.TA",
+            "valuation_measures": {
+                "latest": {"periodType": "TTM", "PeRatio": 8.5, "PsRatio": 4.1}
+            },
+            "financial_data": {"revenueGrowth": -0.128, "grossMargins": 0.94763},
+        },
+    }
+
+    with patch("ai_hedge.financials_agent.yf.Ticker", return_value=EmptyTicker({})):
+        payload = build_raw_financials_payload("RIT1.TA", info_dict)
+
+    assert "financial_data" not in payload["yahooquery"]
+    assert payload["yahooquery"]["valuation_measures"]["latest"]["PeRatio"] == 8.5
+    prompt = build_financials_prompt("RIT1.TA", payload)
+    assert "revenueGrowth" not in prompt
+    assert "grossMargins" not in prompt
+    assert "yahooquery financial_data" not in prompt
 
 
 def test_normalize_financials_analysis_preserves_required_order_and_caps_added_rows():

--- a/tests/test_info_financial_quarantine.py
+++ b/tests/test_info_financial_quarantine.py
@@ -1,0 +1,178 @@
+import pandas as pd
+
+from ai_hedge import legacy_port
+from ai_hedge import service
+
+
+def _capture_prompt(monkeypatch):
+    captured = []
+
+    def fake_deepseek(**kwargs):
+        captured.append(kwargs["prompt"])
+        return "ok"
+
+    monkeypatch.setattr(legacy_port, "deepseek_simple_text", fake_deepseek)
+    return captured
+
+
+def test_profile_analysis_prompts_exclude_provider_financial_summary(monkeypatch):
+    captured = _capture_prompt(monkeypatch)
+    info_dict = {
+        "info": {
+            "shortName": "RIT 1",
+            "symbol": "RIT1.TA",
+            "longBusinessSummary": "Owns income-producing real estate.",
+            "marketCap": 2_500,
+            "revenueGrowth": -0.128,
+            "grossMargins": 0.94763,
+            "totalRevenue": 509_428_000,
+        }
+    }
+
+    legacy_port.what_it_does_insights_result(info_dict)
+    legacy_port.info_insights_result(info_dict)
+
+    prompt = "\n".join(captured)
+    assert "RIT 1" in prompt
+    assert "revenueGrowth" not in prompt
+    assert "grossMargins" not in prompt
+    assert "totalRevenue" not in prompt
+    assert "-0.128" not in prompt
+
+
+def test_multiple_prompt_keeps_valuation_and_drops_financial_data(monkeypatch):
+    captured = _capture_prompt(monkeypatch)
+    info_dict = {
+        "info": {"shortName": "RIT 1", "revenueGrowth": -0.128},
+        "yahooquery": {
+            "status": "success",
+            "ticker": "RIT1.TA",
+            "valuation_measures": {
+                "rows": [
+                    {
+                        "asOfDate": "2026-06-30",
+                        "periodType": "TTM",
+                        "PeRatio": 8.5,
+                        "PsRatio": 4.1,
+                        "grossMargins": 0.94763,
+                    }
+                ]
+            },
+            "financial_data": {"revenueGrowth": -0.128, "grossMargins": 0.94763},
+        },
+    }
+
+    header, result = legacy_port.multiple_insights_result(info_dict)
+
+    assert header == "Multiple Analysis"
+    assert result == "ok"
+    assert "PeRatio" in captured[0]
+    assert "PsRatio" in captured[0]
+    assert "financial_data" not in captured[0]
+    assert "revenueGrowth" not in captured[0]
+    assert "grossMargins" not in captured[0]
+    assert "-0.128" not in captured[0]
+
+
+def test_final_valuation_prompt_defensively_ignores_legacy_info_financials():
+    prompt = legacy_port.build_prompt(
+        "RIT1.TA",
+        {
+            "All Reports": "STATEMENT_REVENUE=100",
+            "info": {
+                "shortName": "RIT 1",
+                "marketCap": 2_500,
+                "revenueGrowth": -0.128,
+                "grossMargins": 0.94763,
+            },
+            "info_financials": {"revenueGrowth": -0.128, "grossMargins": 0.94763},
+            "currency_statement": "Financial data is in USD",
+            "rate": 4.2,
+        },
+        "Return JSON",
+        "Prepared analysis",
+    )
+
+    assert "STATEMENT_REVENUE=100" in prompt
+    assert "RIT 1" in prompt
+    assert "revenueGrowth" not in prompt
+    assert "grossMargins" not in prompt
+    assert "-0.128" not in prompt
+    assert "Relevant financial data from the Company Profile Stats" not in prompt
+
+
+def test_sec_analysis_prompt_uses_allowlisted_profile(monkeypatch):
+    captured = _capture_prompt(monkeypatch)
+
+    text, errors = service._generate_sec_analysis_text(
+        ticker="RIT1.TA",
+        info_dict={
+            "info": {
+                "shortName": "RIT 1",
+                "longBusinessSummary": "Owns income-producing real estate.",
+                "revenueGrowth": -0.128,
+                "grossMargins": 0.94763,
+            }
+        },
+        files_dict={"MAYA Annual": {"date": "2025-12-31", "text": "OFFICIAL FILING"}},
+        financial_dict={"All Reports": "STATEMENT_REVENUE=100"},
+        short_mode=False,
+    )
+
+    assert text == "ok\n\nok"
+    assert errors == []
+    prompt = "\n".join(captured)
+    assert "RIT 1" in prompt
+    assert "OFFICIAL FILING" in prompt
+    assert "STATEMENT_REVENUE=100" in prompt
+    assert "revenueGrowth" not in prompt
+    assert "grossMargins" not in prompt
+    assert "-0.128" not in prompt
+
+
+def test_statement_metrics_use_four_quarters_and_latest_balance_sheet():
+    columns = pd.to_datetime(["2025-12-31", "2025-09-30", "2025-06-30", "2025-03-31"])
+    quarterly_income = pd.DataFrame(
+        [[40, 30, 20, 10], [4, 3, 2, 1]],
+        index=["Total Revenue", "Net Income"],
+        columns=columns,
+    )
+    quarterly_balance = pd.DataFrame(
+        [[50, 40, 30, 20], [10, 9, 8, 7], [30, 29, 28, 27], [200, 190, 180, 170], [400, 390, 380, 370], [120, 110, 100, 90], [60, 55, 50, 45]],
+        index=[
+            "Cash Cash Equivalents And Short Term Investments",
+            "Current Debt",
+            "Long Term Debt",
+            "Stockholders Equity",
+            "Total Assets",
+            "Current Assets",
+            "Current Liabilities",
+        ],
+        columns=columns,
+    )
+    quarterly_cashflow = pd.DataFrame(
+        [[15, 14, 13, 12], [-5, -4, -3, -2]],
+        index=["Operating Cash Flow", "Capital Expenditure"],
+        columns=columns,
+    )
+
+    metrics = legacy_port._build_statement_metrics(
+        financials_annual=pd.DataFrame(),
+        financials_quarterly=quarterly_income,
+        balance_sheet_annual=pd.DataFrame(),
+        balance_sheet_quarterly=quarterly_balance,
+        cashflow_annual=pd.DataFrame(),
+        cashflow_quarterly=quarterly_cashflow,
+        currency_rate=2,
+    )
+
+    assert metrics["source"] == "yfinance_statement_tables"
+    assert metrics["revenue"] == 50
+    assert metrics["net_income"] == 5
+    assert metrics["free_cashflow"] == 20
+    assert metrics["total_cash"] == 25
+    assert metrics["total_debt"] == 20
+    assert metrics["total_equity"] == 100
+    assert metrics["total_assets"] == 200
+    assert metrics["current_ratio"] == 2
+    assert metrics["equity_to_assets"] == 0.5

--- a/tests/test_legacy_port_shares.py
+++ b/tests/test_legacy_port_shares.py
@@ -5,9 +5,18 @@ def _variables_for(info):
     return legacy_port.get_variables(
         "TEST",
         info,
-        {"index": ["Total Assets"], "values": [[1000]]},
-        {},
-        {"totalRevenue": 100, "netIncomeToCommon": 10},
+        {
+            "source": "yfinance_statement_tables",
+            "total_assets": 1000,
+            "total_equity": 400,
+            "total_cash": 20,
+            "total_debt": 30,
+            "current_ratio": 2,
+            "equity_to_assets": 0.4,
+            "revenue": 100,
+            "net_income": 10,
+            "free_cashflow": 8,
+        },
     )
 
 
@@ -52,3 +61,56 @@ def test_get_variables_derives_shares_from_market_cap_and_price():
     )
 
     assert variables["shares_outstanding"] == 100
+
+
+def test_get_variables_uses_statement_metrics_not_provider_financial_summary():
+    variables = _variables_for(
+        {
+            "sharesOutstanding": 100,
+            "currentPrice": 10,
+            "marketCap": 1000,
+            "totalCash": 900,
+            "totalDebt": 800,
+            "totalRevenue": 700,
+            "netIncomeToCommon": 600,
+            "freeCashflow": 500,
+            "bookValue": 400,
+            "currentRatio": 99,
+        }
+    )
+
+    assert variables["ev"] == 1010
+    assert variables["ev_source"] == "statement_net_debt"
+    assert variables["revenue"] == 100
+    assert variables["net_income"] == 10
+    assert variables["free_cashflow"] == 8
+    assert variables["current_ratio"] == 2
+    assert variables["Equity"] == 400
+
+
+def test_recalculate_derived_metrics_preserves_provider_multiples():
+    info = {
+        "currentPrice": 10,
+        "sharesOutstanding": 100,
+        "marketCap": 999,
+        "trailingPE": 8.5,
+        "priceToBook": 1.2,
+        "priceToSalesTrailing12Months": 4.1,
+        "enterpriseValue": 1_500,
+        "enterpriseToRevenue": 5.2,
+        "enterpriseToEbitda": 7.3,
+        "totalRevenue": 1,
+        "totalDebt": 900,
+        "totalCash": 800,
+        "netIncomeToCommon": 1,
+    }
+
+    result = legacy_port.recalculate_derived_metrics(info)
+
+    assert result["marketCap"] == 1_000
+    assert result["trailingPE"] == 8.5
+    assert result["priceToBook"] == 1.2
+    assert result["priceToSalesTrailing12Months"] == 4.1
+    assert result["enterpriseValue"] == 1_500
+    assert result["enterpriseToRevenue"] == 5.2
+    assert result["enterpriseToEbitda"] == 7.3

--- a/tests/test_provider_data_policy.py
+++ b/tests/test_provider_data_policy.py
@@ -1,0 +1,91 @@
+from ai_hedge.provider_data_policy import (
+    QUARANTINED_FINANCIAL_INFO_KEYS,
+    safe_company_profile,
+    valuation_only_yahooquery,
+)
+
+
+def test_safe_company_profile_uses_explicit_context_allowlists():
+    info = {
+        "shortName": "RIT 1",
+        "symbol": "RIT1.TA",
+        "longBusinessSummary": "Real-estate investment company.",
+        "currentPrice": 25,
+        "marketCap": 2_500,
+        "trailingPE": 8.5,
+        "enterpriseToRevenue": 4.2,
+        "revenueGrowth": -0.128,
+        "grossMargins": 0.94763,
+        "totalRevenue": 509_428_000,
+        "unknownProviderField": "do not leak",
+    }
+
+    profile = safe_company_profile(info)
+    market_profile = safe_company_profile(info, include_market_context=True)
+    valuation_profile = safe_company_profile(
+        info,
+        include_market_context=True,
+        include_valuation_context=True,
+    )
+
+    assert profile == {
+        "shortName": "RIT 1",
+        "symbol": "RIT1.TA",
+        "longBusinessSummary": "Real-estate investment company.",
+    }
+    assert market_profile["currentPrice"] == 25
+    assert market_profile["marketCap"] == 2_500
+    assert "trailingPE" not in market_profile
+    assert valuation_profile["trailingPE"] == 8.5
+    assert valuation_profile["enterpriseToRevenue"] == 4.2
+    assert not QUARANTINED_FINANCIAL_INFO_KEYS.intersection(valuation_profile)
+    assert "unknownProviderField" not in valuation_profile
+
+
+def test_valuation_only_yahooquery_drops_financial_data_and_unknown_columns():
+    snapshot = {
+        "status": "success",
+        "ticker": "RIT1.TA",
+        "generated_at": "2026-08-18T00:00:00Z",
+        "valuation_measures": {
+            "rows": [
+                {
+                    "asOfDate": "2026-06-30",
+                    "periodType": "TTM",
+                    "PeRatio": 8.5,
+                    "PsRatio": 4.1,
+                    "revenueGrowth": -0.128,
+                }
+            ],
+            "columns": ["asOfDate", "periodType", "PeRatio", "PsRatio", "revenueGrowth"],
+            "latest": {"periodType": "TTM", "PeRatio": 8.5, "grossMargins": 0.94},
+            "latest_by_period": {
+                "TTM": {"periodType": "TTM", "PeRatio": 8.5, "totalRevenue": 1}
+            },
+            "recent_average": {"PeRatio": 8.1, "profitMargins": 0.8},
+        },
+        "live_quote": {"currentPrice": 25, "marketCap": 2_500, "totalDebt": 99},
+        "financial_data": {"revenueGrowth": -0.128, "grossMargins": 0.94},
+        "earnings_surprise": {"rows": [{"epsActual": 1}]},
+    }
+
+    clean = valuation_only_yahooquery(snapshot)
+
+    assert clean["valuation_measures"]["rows"] == [
+        {
+            "asOfDate": "2026-06-30",
+            "periodType": "TTM",
+            "PeRatio": 8.5,
+            "PsRatio": 4.1,
+        }
+    ]
+    assert clean["valuation_measures"]["columns"] == [
+        "asOfDate",
+        "periodType",
+        "PeRatio",
+        "PsRatio",
+    ]
+    assert clean["valuation_measures"]["latest"] == {"periodType": "TTM", "PeRatio": 8.5}
+    assert clean["live_quote"] == {"currentPrice": 25, "marketCap": 2_500}
+    assert "financial_data" not in clean
+    assert "earnings_surprise" not in clean

--- a/tests/test_runner_fallback.py
+++ b/tests/test_runner_fallback.py
@@ -88,6 +88,25 @@ def test_build_sec_source_of_truth_guidance_mentions_contradictions():
     assert "valuation assumptions" in text
 
 
+def test_append_trading_agents_final_decision_adds_display_only_section():
+    original = "# Analysis\n\nFundamental valuation is complete."
+    result = runner._append_trading_agents_final_decision(
+        original,
+        {
+            "status": "success",
+            "final_committee_view": "**Rating**: BUY\n**Price Target**: 150\n**Time Horizon**: 12 months",
+            "price_target": 150,
+            "time_horizon": "12 months",
+        },
+    )
+
+    assert result.startswith(original)
+    assert result.count("## TradingAgents Final Decision") == 1
+    assert "TradingAgents Tactical Price Target:** 150" in result
+    assert "Time Horizon:** 12 months" in result
+    assert "excluded from AI Hedge valuation prompts" in result
+
+
 def test_prices_explain_uses_analysis_current_price_for_usd_targets():
     text = runner._build_prices_explain_text(
         "PAYT.TA",

--- a/tests/test_trading_agents_adapter.py
+++ b/tests/test_trading_agents_adapter.py
@@ -53,6 +53,45 @@ def test_context_framing_includes_research_lens_and_excludes_market_payload():
     assert "market_report" not in payload
 
 
+def test_final_decision_metadata_is_preserved_but_excluded_from_valuation_context():
+    raw_decision = """
+**Rating**: BUY
+**Executive Summary**: Durable growth with manageable execution risk.
+**Investment Thesis**: Earnings quality supports the tactical view.
+**Price Target**: $123.45
+**Time Horizon**: 6-12 months
+""".strip()
+    payload = ta.normalize_trading_agents_state(
+        "TEST",
+        {
+            "fundamentals_report": "Revenue quality is improving.",
+            "final_trade_decision": raw_decision,
+        },
+        decision="BUY",
+    )
+
+    assert payload["final_committee_view"] == raw_decision
+    assert payload["rating"] == "BUY"
+    assert payload["price_target"] == 123.45
+    assert payload["time_horizon"] == "6-12 months"
+
+    context = ta.build_trading_agents_context(payload)
+    assert "Durable growth" in context
+    assert "123.45" not in context
+    assert "6-12 months" not in context
+    assert "Price Target" not in context
+
+    final_decision = ta.build_trading_agents_final_decision_body(payload)
+    assert "TradingAgents Tactical Price Target:** 123.45" in final_decision
+    assert "Time Horizon:** 6-12 months" in final_decision
+    assert "excluded from AI Hedge valuation prompts" in final_decision
+
+    artifact = ta.build_trading_agents_artifact_text(payload)
+    assert artifact.index("## Independent Multi-Agent Research Lens") < artifact.index(
+        "## TradingAgents Final Decision"
+    )
+
+
 def test_compact_payload_keeps_brief_and_drops_verbose_sections(monkeypatch):
     payload = ta.normalize_trading_agents_state(
         "TEST",
@@ -76,6 +115,30 @@ def test_compact_payload_keeps_brief_and_drops_verbose_sections(monkeypatch):
     assert "fundamentals_report" not in compact
     assert "compact brief" in context
     assert "fundamental point" not in context
+
+
+def test_compaction_keeps_tactical_metadata_out_of_generated_research_brief(monkeypatch):
+    payload = ta.normalize_trading_agents_state(
+        "TEST",
+        {
+            "fundamentals_report": "fundamental evidence",
+            "final_trade_decision": "**Price Target**: 88\n**Time Horizon**: 9 months",
+        },
+        decision="HOLD",
+    )
+    monkeypatch.setattr(
+        legacy,
+        "deepseek_simple_text",
+        lambda **_kwargs: "Business remains stable.\nPrice Target: 999\nTime Horizon: 1 month",
+    )
+
+    compact = ta.compact_trading_agents_payload(payload, api_key="key")
+
+    assert compact["price_target"] == 88
+    assert compact["time_horizon"] == "9 months"
+    assert compact["rating"] == "HOLD"
+    assert compact["research_brief"] == "Business remains stable."
+    assert "999" not in ta.build_trading_agents_context(compact)
 
 
 def test_summarize_uses_observed_legacy_deepseek_wrapper(monkeypatch):

--- a/tests/test_valuation_scenarios.py
+++ b/tests/test_valuation_scenarios.py
@@ -167,7 +167,7 @@ def test_dashboard_current_assumption_values_use_original_financial_currency_sca
     values = dashboard._build_current_assumption_values(
         info={
             "financial_currency_to_USD": 3.5,
-            "freeCashflow": 10.0,
+            "freeCashflow": 999.0,
             "enterpriseToRevenue": 2.25,
             "trailingPE": 18.0,
         },
@@ -175,6 +175,7 @@ def test_dashboard_current_assumption_values_use_original_financial_currency_sca
             "financial_currency": 3.5,
             "revenue": 100.0,
             "net_income": 8.0,
+            "free_cashflow": 10.0,
             "ev": 225.0,
             "market_cap": 144.0,
         },


### PR DESCRIPTION
﻿## Summary

- Add a centralized allowlist that prevents Yahoo/yfinance INFO financial summaries (growth, margins, profitability, cash, debt, returns, EPS, and related ratios) from entering analysis, valuation, SEC, competitor, Financials, or Dream Team prompts.
- Build valuation anchors such as revenue, net income, FCF, debt, cash, equity, assets, and liquidity ratios from dated annual/quarterly statement tables; keep provider-reported valuation multiples as an isolated like-for-like comparison input.
- Remove the unreliable operating-financial cards from the live Info tab, retain live quote/valuation multiples and analyst consensus only, and convert Market peer tables to multiples-only comparisons.
- Clarify Screeners ranking: Rank is now the stock's position in the full universe under the active sort, the previous provider/universe ordering is labeled Size Rank, and CSV exports include both.
- Relabel the Info summary tile as Wall St. Consensus and render missing analyst consensus as N/A, so it cannot be mistaken for an AI Hedge recommendation.
- Stabilize Reports search across desktop and mobile: avoid redundant navigations, debounce real query changes, preserve scroll, expose loading/clear controls, reset Community results when the query changes, and use a non-shifting responsive layout.
- Preserve the raw TradingAgents tactical price target and time horizon as explicit metadata for new runs, while deterministically excluding those fields from the compact research brief and every valuation prompt boundary.
- Add a separate TradingAgents Final Decision to the dashboard and post-valuation analysis/PDF, with an independence note explaining that the tactical target does not affect AI Hedge model targets, scores, or consensus.

## Preview

URL: https://pr-122-hedge-in-a-box-site.fly.dev

## Test plan

- [x] PYTHONPATH=src python -m pytest -q tests/test_provider_data_policy.py tests/test_info_financial_quarantine.py tests/test_legacy_port_shares.py tests/test_legacy_port_currency.py tests/test_competitor_market_review.py tests/test_financials_agent.py tests/test_yahooquery_data.py tests/test_valuation_scenarios.py --basetemp=.codex-pytest-info-final (52 passed)
- [x] Targeted ESLint for Info, Market, Dream Team route, dashboard server, and Screeners
- [x] PYTHONPATH=src python -m pytest -q tests/test_trading_agents_adapter.py tests/test_runner_fallback.py --basetemp=test_tmp_cdx_ta_target_0819b (21 passed)
- [x] npm run build in frontend/ after the TradingAgents UI change
- [x] Live RIT1.TA policy check: valuation payload contains valuation measures + live quote and excludes financial_data; statement anchors resolve from dated statement rows through 2026-03-31
- [x] Preview RIT1.TA Info: HTTP 200; Valuation Multiples + Analyst Snapshot + Wall St. Consensus present; ambiguous Recommendation, Financial Data, Quality Snapshot, Revenue Growth, and Gross Margin labels absent
- [x] Preview RIT1.TA Market: HTTP 200; Equity Multiples + Enterprise Multiples present; old margins/growth comparison absent
- [x] Preview Screeners: HTTP 200; deployed client bundle contains Rank, Size Rank, and the full-universe sort-position behavior; live S&P 500 payload check preserved BKNG at #25 after ticker filtering under Overall Score descending
- [x] Preview Reports: HTTP 200; the default page returned 16 cards, TEVA search returned 6 matching TEVA/TEVA.TA reports, a missing ticker rendered the no-match state, and the deployed bundle contains debounce, clear/loading, preserved-scroll, and responsive-layout behavior
- [x] Refreshed preview: health, RIT1.TA valuation page, and report-scoped dashboard API returned HTTP 200; the legacy report loaded successfully without target/horizon metadata, and the deployed client bundle contains TradingAgents Final Decision, Tactical Price Target, Time Horizon, and the valuation-prompt independence note

## Notes for reviewer

- Existing saved analysis prose is not rewritten. The INFO model-boundary and TradingAgents decision changes apply to newly generated analyses; live UI changes apply immediately.
- TradingAgents price target/time horizon are stored independently, removed before compact summarization, sanitized again after summarization, and appended to analysis only after run_valuations returns.
- Valuation multiples remain provider-reported context and are explicitly not treated as audited accounting facts. Missing, non-positive, or inapplicable values render as unavailable.
- Screener scoring inputs are unchanged; this PR only clarifies the two rank concepts and exposes current-sort position.
- Targeted ESLint on hedge-dashboard.tsx remains non-zero on pre-existing hook/compiler findings outside the TradingAgents block; the production build and TypeScript validation pass.
- The Next build passed with the existing middleware deprecation and broad NFT trace warnings.

