### PR TITLE
Fix TradingAgents report target and rating tone

### DIFF
--- a/frontend/src/components/hedge-dashboard.tsx
+++ b/frontend/src/components/hedge-dashboard.tsx
@@ -9,7 +9,11 @@ import remarkGfm from "remark-gfm";
 import type { DashboardMethodTab, DashboardPayload, ReportListItem } from "@/lib/dashboard-types";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { canonicalModelName } from "@/lib/method-display";
-import { tradingAgentsDecisionTone, type TradingAgentsDecisionTone } from "@/lib/trading-agents";
+import {
+  tradingAgentsDecisionTone,
+  tradingAgentsDisplayDecision,
+  type TradingAgentsDecisionTone,
+} from "@/lib/trading-agents";
 
 type MainTab = "valuation" | "executive" | "bull" | "bear" | "values";
 
@@ -655,9 +659,10 @@ function TradingAgentsPanel({
     : status === "success"
       ? `Generated fresh ${generatedAt}`
       : `Unavailable ${generatedAt}`;
+  const finalCommitteeView = tradingAgentsDisplayDecision(payload.rating, payload.final_committee_view);
   const sections = [
     ["Research Brief", payload.research_brief],
-    ["Final Committee Decision", payload.final_committee_view],
+    ["Final Committee Decision", finalCommitteeView],
     ["Fundamentals Report", payload.fundamentals_report],
     ["News Report", payload.news_report],
     ["Social / Sentiment Report", payload.sentiment_report],

--- a/frontend/src/components/hedge-dashboard.tsx
+++ b/frontend/src/components/hedge-dashboard.tsx
@@ -9,6 +9,7 @@ import remarkGfm from "remark-gfm";
 import type { DashboardMethodTab, DashboardPayload, ReportListItem } from "@/lib/dashboard-types";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { canonicalModelName } from "@/lib/method-display";
+import { tradingAgentsDecisionTone, type TradingAgentsDecisionTone } from "@/lib/trading-agents";
 
 type MainTab = "valuation" | "executive" | "bull" | "bear" | "values";
 
@@ -419,19 +420,7 @@ function BulletList({ items, tone = "bull" }: { items: string[]; tone?: "bull" |
   );
 }
 
-type TabTone = "up" | "down" | "neutral";
-
-function tradingAgentsDecisionTone(text?: string): TabTone {
-  const src = String(text || "").toLowerCase();
-  const compact = src.replace(/[\s_-]+/g, "");
-  if (/\b(strong\s*buy|buy|overweight|overwhight|outperform|accumulate)\b/.test(src) || compact.includes("strongbuy")) {
-    return "up";
-  }
-  if (/\b(strong\s*sell|sell|underweight|underwhight|underperform|reduce)\b/.test(src) || compact.includes("strongsell")) {
-    return "down";
-  }
-  return "neutral";
-}
+type TabTone = TradingAgentsDecisionTone;
 
 function tabToneClass(tone: TabTone, active: boolean): string {
   if (tone === "up") {
@@ -680,7 +669,7 @@ function TradingAgentsPanel({
     if (!cleanText) return [];
     return splitMarkdownHeadingBlocks(title, cleanText);
   });
-  const decisionTone = tradingAgentsDecisionTone(payload.final_committee_view);
+  const decisionTone = tradingAgentsDecisionTone(payload.rating, payload.final_committee_view);
   const decisionPanelClass =
     decisionTone === "up"
       ? "border-emerald-500/45 bg-emerald-500/10"
@@ -716,7 +705,7 @@ function TradingAgentsPanel({
       {hasTacticalDecisionMetadata ? (
         <section className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-3">
           <p className="text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--text-secondary)]">
-            TradingAgents Final Decision
+            TradingAgents Tactical Target
           </p>
           <div className="mt-2 grid gap-2 sm:grid-cols-2">
             {tacticalPriceTarget !== null ? (
@@ -1297,7 +1286,10 @@ export function HedgeDashboard({
   }, [methodTabs]);
   const activeMethod: DashboardMethodTab | null = methodTabs.find((m) => m.name === valuationTab) || null;
   const tradingAgentsPayload = data?.trading_agents;
-  const tradingAgentsTone = tradingAgentsDecisionTone(tradingAgentsPayload?.final_committee_view);
+  const tradingAgentsTone = tradingAgentsDecisionTone(
+    tradingAgentsPayload?.rating,
+    tradingAgentsPayload?.final_committee_view,
+  );
   const hasTradingAgents =
     !!tradingAgentsPayload &&
     (Object.keys(tradingAgentsPayload).length > 0 || String(tradingAgentsPayload.status || "").trim().length > 0);

--- a/frontend/src/lib/trading-agents.test.ts
+++ b/frontend/src/lib/trading-agents.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { tradingAgentsDecisionTone } from "./trading-agents";
+
+test("uses the structured rating before words in the decision prose", () => {
+  const decision = `
+## Final Trading Decision - IBM
+
+**Rating: Underweight**
+
+IBM's dividend yield is not a reason to buy. Execute a staged sell into strength.
+`;
+
+  assert.equal(tradingAgentsDecisionTone("Underweight", decision), "down");
+});
+
+test("reads an explicit rating header for existing verbose v3 reports", () => {
+  const decision = "**Rating: Underweight**\nThis is not a reason to buy.";
+
+  assert.equal(tradingAgentsDecisionTone(undefined, decision), "down");
+});
+
+test("does not infer tone from incidental recommendation words", () => {
+  assert.equal(tradingAgentsDecisionTone(undefined, "This is not a reason to buy."), "neutral");
+});
+
+test("keeps compact legacy decisions working", () => {
+  assert.equal(tradingAgentsDecisionTone(undefined, "Overweight"), "up");
+  assert.equal(tradingAgentsDecisionTone(undefined, "Hold"), "neutral");
+});

--- a/frontend/src/lib/trading-agents.test.ts
+++ b/frontend/src/lib/trading-agents.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { tradingAgentsDecisionTone } from "./trading-agents";
+import { tradingAgentsDecisionTone, tradingAgentsDisplayDecision } from "./trading-agents";
 
 test("uses the structured rating before words in the decision prose", () => {
   const decision = `
@@ -28,4 +28,11 @@ test("does not infer tone from incidental recommendation words", () => {
 test("keeps compact legacy decisions working", () => {
   assert.equal(tradingAgentsDecisionTone(undefined, "Overweight"), "up");
   assert.equal(tradingAgentsDecisionTone(undefined, "Hold"), "neutral");
+});
+
+test("uses the structured rating as the compact decision for verbose v3 reports", () => {
+  assert.equal(
+    tradingAgentsDisplayDecision("Underweight", "**Rating: Underweight**\nLong Portfolio Manager transcript."),
+    "Underweight",
+  );
 });

--- a/frontend/src/lib/trading-agents.ts
+++ b/frontend/src/lib/trading-agents.ts
@@ -1,0 +1,46 @@
+export type TradingAgentsDecisionTone = "up" | "down" | "neutral";
+
+const UP_RATINGS = new Set(["buy", "strong buy", "overweight", "overwhight", "outperform", "accumulate"]);
+const DOWN_RATINGS = new Set(["sell", "strong sell", "underweight", "underwhight", "underperform", "reduce"]);
+
+function normalizeRating(value: unknown): string {
+  return String(value || "")
+    .replace(/\*+/g, "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\s_-]+/g, " ");
+}
+
+function explicitRatingFromText(value: unknown): string {
+  const text = String(value || "");
+  const ratingLine = text.match(
+    /(?:^|\n)\s*(?:#{1,6}\s*)?(?:[-*]\s*)?\*{0,2}rating\*{0,2}\s*:\s*\*{0,2}(strong\s+buy|strong\s+sell|overweight|overwhight|underweight|underwhight|outperform|underperform|accumulate|reduce|buy|hold|sell)\b/i,
+  );
+  if (ratingLine?.[1]) return normalizeRating(ratingLine[1]);
+
+  const finalStance = text.match(
+    /(?:^|\n)[^\n]*final\s+stance\s*:\s*[^\n]*?\b(strong\s+buy|strong\s+sell|overweight|overwhight|underweight|underwhight|outperform|underperform|accumulate|reduce|buy|hold|sell)\b/i,
+  );
+  return finalStance?.[1] ? normalizeRating(finalStance[1]) : "";
+}
+
+function toneFromRating(rating: string): TradingAgentsDecisionTone | null {
+  if (UP_RATINGS.has(rating)) return "up";
+  if (DOWN_RATINGS.has(rating)) return "down";
+  if (rating === "hold") return "neutral";
+  return null;
+}
+
+export function tradingAgentsDecisionTone(
+  rating?: unknown,
+  finalCommitteeView?: unknown,
+): TradingAgentsDecisionTone {
+  for (const candidate of [rating, finalCommitteeView]) {
+    const exactTone = toneFromRating(normalizeRating(candidate));
+    if (exactTone) return exactTone;
+
+    const explicitTone = toneFromRating(explicitRatingFromText(candidate));
+    if (explicitTone) return explicitTone;
+  }
+  return "neutral";
+}

--- a/frontend/src/lib/trading-agents.ts
+++ b/frontend/src/lib/trading-agents.ts
@@ -44,3 +44,8 @@ export function tradingAgentsDecisionTone(
   }
   return "neutral";
 }
+
+export function tradingAgentsDisplayDecision(rating?: unknown, finalCommitteeView?: unknown): string {
+  const structuredRating = String(rating || "").trim();
+  return structuredRating || String(finalCommitteeView || "").trim();
+}

--- a/src/ai_hedge/runner.py
+++ b/src/ai_hedge/runner.py
@@ -585,21 +585,6 @@ def _upsert_markdown_block(text: str, marker: str, block: str) -> str:
     return f"{block_txt}\n"
 
 
-def _append_trading_agents_final_decision(text: str, payload: Dict[str, Any]) -> str:
-    """Append the display-only TradingAgents decision after valuation has completed."""
-
-    from .trading_agents_adapter import build_trading_agents_final_decision_body
-
-    decision_body = build_trading_agents_final_decision_body(payload)
-    if not decision_body:
-        return str(text or "").strip()
-    return _upsert_markdown_block(
-        text,
-        "## TradingAgents Final Decision",
-        f"## TradingAgents Final Decision\n\n{decision_body}",
-    )
-
-
 def _wall_st_synthesis_to_markdown(wall_st_payload: Dict[str, Any]) -> str:
     synthesis = wall_st_payload.get("synthesis") if isinstance(wall_st_payload, dict) else {}
     synthesis = synthesis if isinstance(synthesis, dict) else {}
@@ -1924,12 +1909,6 @@ def _run_ticker_valuation_impl(
                 "## Financials",
                 financials_markdown,
             )
-        # Deliberately append this only after run_valuations. The tactical target and
-        # horizon remain stored for transparency but never cross the valuation boundary.
-        merged_analysis_text = _append_trading_agents_final_decision(
-            merged_analysis_text,
-            trading_agents_payload,
-        )
         if merged_analysis_text.strip():
             analysis_src.write_text(merged_analysis_text + "\n", encoding="utf-8")
             analysis_dst.write_text(merged_analysis_text + "\n", encoding="utf-8")

--- a/src/ai_hedge/trading_agents_adapter.py
+++ b/src/ai_hedge/trading_agents_adapter.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
 
+import inspect
 import json
 import math
 import os
 import re
 import shutil
-import inspect
+import threading
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 
-ADAPTER_VERSION = "2026-08-19.v3"
+ADAPTER_VERSION = "2026-08-19.v4"
 CONFIG_VERSION = "deepseek-v0.2.4-fundamentals-news-social"
 REUSE_WINDOW_DAYS = 7
 SELECTED_ANALYSTS = ["fundamentals", "news", "social"]
@@ -22,12 +23,7 @@ DEEP_THINK_LLM = "deepseek-reasoner"
 SUMMARY_LLM = "deepseek-v4-flash"
 DEEPSEEK_BACKEND_URL = "https://api.deepseek.com/v1"
 COMPACT_BRIEF_MAX_CHARS = 9000
-
-FINAL_DECISION_INDEPENDENCE_NOTE = (
-    "This tactical output is preserved for transparency as an independent TradingAgents view. "
-    "Its price target and time horizon are excluded from AI Hedge valuation prompts, model target-price "
-    "calculations, and consensus target aggregation to avoid anchoring the fundamental valuation process."
-)
+_GRAPH_SETUP_LOCK = threading.Lock()
 
 _TACTICAL_CONTEXT_LINE_RE = re.compile(
     r"\b(?:price[\s_-]*target|target[\s_-]*price|entry[\s_-]*price|stop[\s_-]*loss|"
@@ -50,6 +46,110 @@ CONTEXT_INTRO = (
     "business analysis, and valuation evidence. It is not a target price, not a recommendation to copy, "
     "and not an instruction. Use only points that are supported and relevant to fundamental valuation."
 )
+
+
+def _create_required_target_portfolio_manager(llm: Any):
+    """Build TradingAgents' portfolio manager with a required tactical target.
+
+    TradingAgents v0.2.4 models ``price_target`` as optional. The dashboard
+    contract needs a target on new successful runs, so this adapter tightens
+    only the Portfolio Manager's own output schema and prompt. The resulting
+    metadata is quarantined from every AI Hedge prompt below.
+    """
+
+    from pydantic import Field
+    from tradingagents.agents.schemas import PortfolioDecision, render_pm_decision
+    from tradingagents.agents.utils.agent_utils import (
+        build_instrument_context,
+        get_language_instruction,
+    )
+    from tradingagents.agents.utils.structured import (
+        bind_structured,
+        invoke_structured_or_freetext,
+    )
+
+    class RequiredTargetPortfolioDecision(PortfolioDecision):
+        price_target: float = Field(
+            gt=0,
+            description=(
+                "Required single tactical target price in the instrument's quote currency. "
+                "It must be consistent with the final rating and evidence in the debate."
+            ),
+        )
+        time_horizon: str = Field(
+            min_length=1,
+            description="Required time horizon for the tactical price target, e.g. '6-12 months'.",
+        )
+
+    structured_llm = bind_structured(llm, RequiredTargetPortfolioDecision, "Portfolio Manager")
+
+    def portfolio_manager_node(state: Dict[str, Any]) -> Dict[str, Any]:
+        instrument_context = build_instrument_context(state["company_of_interest"])
+        risk_debate_state = state["risk_debate_state"]
+        history = risk_debate_state["history"]
+        research_plan = state["investment_plan"]
+        trader_plan = state["trader_investment_plan"]
+        past_context = state.get("past_context", "")
+        lessons_line = (
+            f"- Lessons from prior decisions and outcomes:\n{past_context}\n"
+            if past_context
+            else ""
+        )
+
+        prompt = f"""As the Portfolio Manager, synthesize the risk analysts' debate and deliver the final trading decision.
+
+{instrument_context}
+
+---
+
+**Rating Scale** (use exactly one):
+- **Buy**: Strong conviction to enter or add to position
+- **Overweight**: Favorable outlook, gradually increase exposure
+- **Hold**: Maintain current position, no action needed
+- **Underweight**: Reduce exposure, take partial profits
+- **Sell**: Exit position or avoid entry
+
+**Required Tactical Output:**
+- Always provide one numeric **Price Target** in the instrument's quote currency.
+- Always provide a non-empty **Time Horizon** for that target.
+- The target must be the Portfolio Manager's own conclusion from this TradingAgents debate.
+- Do not omit these fields for Hold, Underweight, or Sell ratings.
+
+**Context:**
+- Research Manager's investment plan: **{research_plan}**
+- Trader's transaction proposal: **{trader_plan}**
+{lessons_line}**Risk Analysts Debate History:**
+{history}
+
+---
+
+Be decisive and ground every conclusion in specific evidence from the analysts.{get_language_instruction()}"""
+
+        final_trade_decision = invoke_structured_or_freetext(
+            structured_llm,
+            llm,
+            prompt,
+            render_pm_decision,
+            "Portfolio Manager",
+        )
+        new_risk_debate_state = {
+            "judge_decision": final_trade_decision,
+            "history": risk_debate_state["history"],
+            "aggressive_history": risk_debate_state["aggressive_history"],
+            "conservative_history": risk_debate_state["conservative_history"],
+            "neutral_history": risk_debate_state["neutral_history"],
+            "latest_speaker": "Judge",
+            "current_aggressive_response": risk_debate_state["current_aggressive_response"],
+            "current_conservative_response": risk_debate_state["current_conservative_response"],
+            "current_neutral_response": risk_debate_state["current_neutral_response"],
+            "count": risk_debate_state["count"],
+        }
+        return {
+            "risk_debate_state": new_risk_debate_state,
+            "final_trade_decision": final_trade_decision,
+        }
+
+    return portfolio_manager_node
 
 
 def _now_utc() -> datetime:
@@ -149,40 +249,6 @@ def _extract_final_decision_metadata(final_decision: Any, processed_decision: An
     }
 
 
-def _format_tactical_price(value: Any) -> str:
-    try:
-        number = float(value)
-    except Exception:
-        return ""
-    if not math.isfinite(number) or number <= 0:
-        return ""
-    return f"{number:,.2f}".rstrip("0").rstrip(".")
-
-
-def build_trading_agents_final_decision_body(payload: Dict[str, Any]) -> str:
-    """Render display-only decision metadata; this body must be appended after valuation."""
-
-    if not isinstance(payload, dict) or payload.get("status") != "success":
-        return ""
-    final_view = _text(payload.get("final_committee_view"))
-    safe_final_view = _without_tactical_decision_lines(final_view)
-    price_target = _format_tactical_price(payload.get("price_target"))
-    time_horizon = _clean_markdown_value(payload.get("time_horizon"))
-
-    parts: List[str] = []
-    if safe_final_view:
-        parts.append(safe_final_view)
-    metadata: List[str] = []
-    if price_target:
-        metadata.append(f"**TradingAgents Tactical Price Target:** {price_target} (instrument quote currency)")
-    if time_horizon:
-        metadata.append(f"**Time Horizon:** {time_horizon}")
-    if metadata:
-        parts.append("\n\n".join(metadata))
-        parts.append(f"> **Independence note:** {FINAL_DECISION_INDEPENDENCE_NOTE}")
-    return "\n\n".join(part.strip() for part in parts if str(part or "").strip()).strip()
-
-
 def _section(title: str, body: Any) -> str:
     text = _text(body)
     if not text:
@@ -216,11 +282,7 @@ def build_trading_agents_context(payload: Dict[str, Any]) -> str:
 def build_trading_agents_artifact_text(payload: Dict[str, Any]) -> str:
     body = build_trading_agents_context(payload)
     if body:
-        parts = [f"## {CONTEXT_HEADER}\n\n{body}"]
-        final_decision = build_trading_agents_final_decision_body(payload)
-        if final_decision:
-            parts.append(f"## TradingAgents Final Decision\n\n{final_decision}")
-        return "\n\n".join(parts).strip() + "\n"
+        return f"## {CONTEXT_HEADER}\n\n{body}\n"
 
     status = str(payload.get("status") or "unavailable") if isinstance(payload, dict) else "unavailable"
     error = str(payload.get("error") or payload.get("message") or "") if isinstance(payload, dict) else ""
@@ -513,6 +575,7 @@ def normalize_trading_agents_state(
         or state.get("trader_investment_plan")
     )
     metadata = _extract_final_decision_metadata(raw_final_decision, decision)
+    display_decision = _clean_markdown_value(decision) or metadata["rating"]
     payload.update(
         {
             "status": "success",
@@ -527,7 +590,10 @@ def normalize_trading_agents_state(
                 risk_debate,
                 ["aggressive_history", "conservative_history", "neutral_history", "judge_decision", "history"],
             ),
-            "final_committee_view": raw_final_decision or _text(decision),
+            # Preserve the compact v2 report contract. The raw Portfolio
+            # Manager prose is used only for metadata extraction above and is
+            # never stored in a field that crosses an AI Hedge prompt boundary.
+            "final_committee_view": display_decision,
             "rating": metadata["rating"],
             "price_target": metadata["price_target"],
             "time_horizon": metadata["time_horizon"],
@@ -603,8 +669,12 @@ def run_trading_agents_lens(
     run_date = str(trade_date or now.date().isoformat())
     try:
         from tradingagents.default_config import DEFAULT_CONFIG
+        from tradingagents.graph import setup as graph_setup
         from tradingagents.graph.trading_graph import TradingAgentsGraph
 
+        # Tighten only TradingAgents' own final output contract. This target
+        # is extracted into dashboard metadata and never enters AI Hedge
+        # analysis, dashboard-extraction, or valuation prompts.
         config = dict(DEFAULT_CONFIG)
         config.update(
             {
@@ -622,7 +692,16 @@ def run_trading_agents_lens(
                 "output_language": "English",
             }
         )
-        graph = TradingAgentsGraph(selected_analysts=list(SELECTED_ANALYSTS), debug=False, config=config)
+        # TradingAgents resolves this factory while constructing the graph.
+        # Restore the package global immediately afterward so the adapter does
+        # not change unrelated graph construction in this process.
+        with _GRAPH_SETUP_LOCK:
+            original_create_portfolio_manager = graph_setup.create_portfolio_manager
+            try:
+                graph_setup.create_portfolio_manager = _create_required_target_portfolio_manager
+                graph = TradingAgentsGraph(selected_analysts=list(SELECTED_ANALYSTS), debug=False, config=config)
+            finally:
+                graph_setup.create_portfolio_manager = original_create_portfolio_manager
         state, decision = _propagate_trading_agents_graph(graph, ticker_u, run_date)
         payload = normalize_trading_agents_state(ticker_u, state if isinstance(state, dict) else {}, decision, now=now)
         payload["trade_date"] = run_date

--- a/tests/test_runner_fallback.py
+++ b/tests/test_runner_fallback.py
@@ -88,25 +88,6 @@ def test_build_sec_source_of_truth_guidance_mentions_contradictions():
     assert "valuation assumptions" in text
 
 
-def test_append_trading_agents_final_decision_adds_display_only_section():
-    original = "# Analysis\n\nFundamental valuation is complete."
-    result = runner._append_trading_agents_final_decision(
-        original,
-        {
-            "status": "success",
-            "final_committee_view": "**Rating**: BUY\n**Price Target**: 150\n**Time Horizon**: 12 months",
-            "price_target": 150,
-            "time_horizon": "12 months",
-        },
-    )
-
-    assert result.startswith(original)
-    assert result.count("## TradingAgents Final Decision") == 1
-    assert "TradingAgents Tactical Price Target:** 150" in result
-    assert "Time Horizon:** 12 months" in result
-    assert "excluded from AI Hedge valuation prompts" in result
-
-
 def test_prices_explain_uses_analysis_current_price_for_usd_targets():
     text = runner._build_prices_explain_text(
         "PAYT.TA",

--- a/tests/test_trading_agents_adapter.py
+++ b/tests/test_trading_agents_adapter.py
@@ -70,26 +70,22 @@ def test_final_decision_metadata_is_preserved_but_excluded_from_valuation_contex
         decision="BUY",
     )
 
-    assert payload["final_committee_view"] == raw_decision
+    assert payload["final_committee_view"] == "BUY"
     assert payload["rating"] == "BUY"
     assert payload["price_target"] == 123.45
     assert payload["time_horizon"] == "6-12 months"
 
     context = ta.build_trading_agents_context(payload)
-    assert "Durable growth" in context
+    assert "Durable growth" not in context
     assert "123.45" not in context
     assert "6-12 months" not in context
     assert "Price Target" not in context
 
-    final_decision = ta.build_trading_agents_final_decision_body(payload)
-    assert "TradingAgents Tactical Price Target:** 123.45" in final_decision
-    assert "Time Horizon:** 6-12 months" in final_decision
-    assert "excluded from AI Hedge valuation prompts" in final_decision
-
     artifact = ta.build_trading_agents_artifact_text(payload)
-    assert artifact.index("## Independent Multi-Agent Research Lens") < artifact.index(
-        "## TradingAgents Final Decision"
-    )
+    assert "## Independent Multi-Agent Research Lens" in artifact
+    assert "TradingAgents Final Decision" not in artifact
+    assert "123.45" not in artifact
+    assert "6-12 months" not in artifact
 
 
 def test_compact_payload_keeps_brief_and_drops_verbose_sections(monkeypatch):
@@ -118,19 +114,23 @@ def test_compact_payload_keeps_brief_and_drops_verbose_sections(monkeypatch):
 
 
 def test_compaction_keeps_tactical_metadata_out_of_generated_research_brief(monkeypatch):
+    prompts = []
     payload = ta.normalize_trading_agents_state(
         "TEST",
         {
             "fundamentals_report": "fundamental evidence",
             "final_trade_decision": "**Price Target**: 88\n**Time Horizon**: 9 months",
+            "risk_debate_state": {
+                "judge_decision": "**Price Target**: 88\n**Time Horizon**: 9 months",
+            },
         },
         decision="HOLD",
     )
-    monkeypatch.setattr(
-        legacy,
-        "deepseek_simple_text",
-        lambda **_kwargs: "Business remains stable.\nPrice Target: 999\nTime Horizon: 1 month",
-    )
+    def fake_summary(**kwargs):
+        prompts.append(kwargs["prompt"])
+        return "Business remains stable.\nPrice Target: 999\nTime Horizon: 1 month"
+
+    monkeypatch.setattr(legacy, "deepseek_simple_text", fake_summary)
 
     compact = ta.compact_trading_agents_payload(payload, api_key="key")
 
@@ -139,6 +139,64 @@ def test_compaction_keeps_tactical_metadata_out_of_generated_research_brief(monk
     assert compact["rating"] == "HOLD"
     assert compact["research_brief"] == "Business remains stable."
     assert "999" not in ta.build_trading_agents_context(compact)
+    assert len(prompts) == 1
+    assert "88" not in prompts[0]
+    assert "9 months" not in prompts[0]
+
+
+def test_required_target_portfolio_manager_contract():
+    class FakeStructured:
+        def __init__(self, schema, owner):
+            self.schema = schema
+            self.owner = owner
+
+        def invoke(self, prompt):
+            self.owner.prompt = prompt
+            return self.schema(
+                rating="Underweight",
+                executive_summary="Reduce exposure.",
+                investment_thesis="Risk outweighs reward.",
+                price_target=210,
+                time_horizon="6 months",
+            )
+
+    class FakeLlm:
+        def __init__(self):
+            self.schema = None
+            self.prompt = ""
+
+        def with_structured_output(self, schema):
+            self.schema = schema
+            return FakeStructured(schema, self)
+
+        def invoke(self, _prompt):
+            raise AssertionError("structured output should be used")
+
+    llm = FakeLlm()
+    node = ta._create_required_target_portfolio_manager(llm)
+    state = {
+        "company_of_interest": "IBM",
+        "investment_plan": "Reduce exposure.",
+        "trader_investment_plan": "Sell into strength.",
+        "risk_debate_state": {
+            "history": "Risks dominate.",
+            "aggressive_history": "Aggressive view.",
+            "conservative_history": "Conservative view.",
+            "neutral_history": "Neutral view.",
+            "current_aggressive_response": "",
+            "current_conservative_response": "",
+            "current_neutral_response": "",
+            "count": 3,
+        },
+    }
+
+    result = node(state)
+
+    assert llm.schema.model_fields["price_target"].is_required()
+    assert llm.schema.model_fields["time_horizon"].is_required()
+    assert "Always provide one numeric **Price Target**" in llm.prompt
+    assert "**Price Target**: 210.0" in result["final_trade_decision"]
+    assert "**Time Horizon**: 6 months" in result["final_trade_decision"]
 
 
 def test_summarize_uses_observed_legacy_deepseek_wrapper(monkeypatch):


### PR DESCRIPTION
## Summary

- Restore the compact TradingAgents report contract: the final committee field is the processed rating instead of the full Portfolio Manager transcript, including a UI compatibility path for already-stored v3 reports.
- Require a TradingAgents tactical price target and time horizon on new successful runs, expose them only as dashboard metadata in the Valuation tab, and exclude them from AI Hedge prompts, generated analysis, and PDF artifacts.
- Derive TradingAgents colors from the structured rating (with explicit legacy-header fallback), so Underweight is red even when the prose contains incidental bullish words.

## Preview

URL: https://pr-123-hedge-in-a-box-site.fly.dev

## Test plan

- [x] `PYTHONPATH=src python -m pytest -q tests/test_trading_agents_adapter.py tests/test_runner_fallback.py tests/test_valuation_scenarios.py --basetemp=.tmp/pytest-tradingagents-compat` (31 passed)
- [x] Compile and run `frontend/src/lib/trading-agents.test.ts` with Node test runner (5 passed)
- [x] `eslint` on the new TradingAgents tone/display helper and tests
- [x] `npm run build` in `frontend/`
- [x] Preview health and IBM Valuation routes return HTTP 200
- [x] Preview IBM payload confirms the v3 edge case (`rating: Underweight` while prose contains incidental `buy`), and the deployed bundle uses the structured rating for compact display and red tone logic

## Notes for reviewer

- `ADAPTER_VERSION` is bumped to v4 so a fresh run cannot reuse the malformed v3 TradingAgents artifact.
- The required target contract is limited to TradingAgents' Portfolio Manager. Target and horizon lines are stripped before research-summary, dashboard-extraction, and valuation prompt boundaries.
- Existing IBM v3 data has no target; the preview now renders that historical report compactly and with the correct bearish tone, while a fresh v4 run is required to generate target metadata.
- File-wide lint for `hedge-dashboard.tsx` still reports pre-existing hook/manual-memoization issues outside this diff; the production build and lint for the new helper pass.