### PR TITLE
Sync active analysis runs across devices

### DIFF
--- a/frontend/src/app/api/run-analysis/[jobId]/route.ts
+++ b/frontend/src/app/api/run-analysis/[jobId]/route.ts
@@ -218,11 +218,27 @@ async function reconcileCompletedStatus(status: RunStatusPayload): Promise<RunSt
 }
 
 export async function GET(
-  _: Request,
+  req: Request,
   context: { params: Promise<{ jobId: string }> },
 ) {
   reconcileStaleRunsAfterRestart();
   void reconcileStaleRunsViaSql();
+
+  const bypassAuth = shouldBypassAuthForHostname(hostnameFromRequestUrl(req.url));
+  const session = await auth();
+  const userId = session?.user?.id || (bypassAuth ? "local-dev" : "");
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!bypassAuth && session?.user?.isGuest) {
+    return NextResponse.json(
+      {
+        error: "Please sign in with Google to view this run.",
+        code: "SIGN_IN_REQUIRED",
+      },
+      { status: 403 },
+    );
+  }
 
   const { jobId } = await context.params;
   const cleanJobId = String(jobId || "").trim();
@@ -233,6 +249,11 @@ export async function GET(
   const fsStatus = readRunStatus(cleanJobId);
   const dbStatus = await readRunStatusFromDb(cleanJobId);
   if (!fsStatus && !dbStatus) {
+    return NextResponse.json({ error: "Job not found." }, { status: 404 });
+  }
+
+  const ownerId = String(dbStatus?.user_id || fsStatus?.user_id || "").trim();
+  if (!bypassAuth && ownerId !== userId) {
     return NextResponse.json({ error: "Job not found." }, { status: 404 });
   }
 
@@ -328,7 +349,7 @@ export async function DELETE(
 
   // Only the run owner can cancel unless local bypass is active.
   const statusUserId = String(status.user_id || "").trim();
-  if (!bypassAuth && statusUserId && statusUserId !== userId) {
+  if (!bypassAuth && statusUserId !== userId) {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 

--- a/frontend/src/app/api/run-analysis/route.ts
+++ b/frontend/src/app/api/run-analysis/route.ts
@@ -9,6 +9,7 @@ import { auth } from "@/auth";
 import { hostnameFromRequestUrl, shouldBypassAuthForHostname } from "@/lib/auth-bypass";
 import {
   appBootIso,
+  listActiveRunStatusesFromFs,
   reconcileStaleRunsAfterRestart,
   reconcileStaleRunsViaSql,
   TICKER_RE,
@@ -18,7 +19,7 @@ import {
   runStatusFile,
   siteRunsRoot,
 } from "@/lib/site-runner";
-import { insertQueuedRun, updateRunStatusFromNode } from "@/lib/site-runs-db";
+import { insertQueuedRun, listActiveRunsForUser, updateRunStatusFromNode } from "@/lib/site-runs-db";
 import { yahooValidate } from "@/lib/yahoo-lookup";
 
 export const runtime = "nodejs";
@@ -31,6 +32,32 @@ function nowIso(): string {
 function writeStatus(filePath: string, payload: RunStatusPayload): void {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   fs.writeFileSync(filePath, JSON.stringify(payload, null, 2), "utf-8");
+}
+
+export async function GET(req: Request) {
+  reconcileStaleRunsAfterRestart();
+  void reconcileStaleRunsViaSql();
+
+  const bypassAuth = shouldBypassAuthForHostname(hostnameFromRequestUrl(req.url));
+  const session = await auth();
+  const userId = session?.user?.id || (bypassAuth ? "local-dev" : "");
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!bypassAuth && session?.user?.isGuest) {
+    return NextResponse.json(
+      {
+        error: "Please sign in with Google to view active runs.",
+        code: "SIGN_IN_REQUIRED",
+      },
+      { status: 403 },
+    );
+  }
+
+  const dbRuns = await listActiveRunsForUser(userId);
+  const runs = dbRuns ?? listActiveRunStatusesFromFs(userId);
+
+  return NextResponse.json({ count: runs.length, runs });
 }
 
 export async function POST(req: Request) {

--- a/frontend/src/components/shell/active-runs-store.ts
+++ b/frontend/src/components/shell/active-runs-store.ts
@@ -7,8 +7,17 @@ type RunStatusApi = {
   ticker: string;
   status: "queued" | "running" | "completed" | "failed";
   llm_progress_pct?: number;
+  created_at?: string;
   error?: string;
 };
+
+type ActiveRunsApi = {
+  runs?: RunStatusApi[];
+};
+
+type RunStatusResult =
+  | { ok: true; status: RunStatusApi }
+  | { ok: false; statusCode: number };
 
 export type CompletionEvent = {
   job_id: string;
@@ -42,7 +51,34 @@ async function pollOnce() {
   if (polling) return;
   polling = true;
   try {
-    const current = listActiveRuns();
+    const discovered: ClientActiveRun[] = [];
+    try {
+      const res = await fetch("/api/run-analysis", { cache: "no-store" });
+      if (res.ok) {
+        const payload = (await res.json()) as ActiveRunsApi;
+        for (const run of payload.runs || []) {
+          if (run.status !== "queued" && run.status !== "running") continue;
+          const activeRun: ClientActiveRun = {
+            job_id: run.job_id,
+            ticker: String(run.ticker || "").toUpperCase(),
+            status: run.status,
+            llm_progress_pct: safePct(run.llm_progress_pct),
+            created_at: run.created_at || new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+          };
+          upsertActiveRun(activeRun);
+          discovered.push(activeRun);
+        }
+      }
+    } catch {
+      // The per-job poll below keeps locally-known runs alive during outages.
+    }
+
+    const currentById = new Map<string, ClientActiveRun>();
+    for (const run of [...listActiveRuns(), ...discovered]) {
+      currentById.set(run.job_id, run);
+    }
+    const current = Array.from(currentById.values());
     if (!current.length) {
       latestRuns = [];
       emit();
@@ -52,8 +88,8 @@ async function pollOnce() {
     const results = await Promise.allSettled(
       current.map(async (run) => {
         const res = await fetch(`/api/run-analysis/${encodeURIComponent(run.job_id)}`, { cache: "no-store" });
-        if (!res.ok) throw new Error(String(res.status));
-        return (await res.json()) as RunStatusApi;
+        if (!res.ok) return { ok: false, statusCode: res.status } as RunStatusResult;
+        return { ok: true, status: (await res.json()) as RunStatusApi } as RunStatusResult;
       }),
     );
 
@@ -65,7 +101,16 @@ async function pollOnce() {
         nextRuns.push(localRun);
         continue;
       }
-      const api = result.value;
+      if (!result.value.ok) {
+        if ([401, 403, 404].includes(result.value.statusCode)) {
+          removeActiveRun(localRun.job_id);
+          delete previousStatuses[localRun.job_id];
+          continue;
+        }
+        nextRuns.push(localRun);
+        continue;
+      }
+      const api = result.value.status;
       const nextStatus = api.status;
       const prevStatus = previousStatuses[localRun.job_id] || localRun.status;
       previousStatuses[localRun.job_id] = nextStatus;
@@ -80,6 +125,7 @@ async function pollOnce() {
           for (const listener of completionListeners) listener(event);
         }
         removeActiveRun(localRun.job_id);
+        delete previousStatuses[localRun.job_id];
         continue;
       }
 

--- a/frontend/src/lib/site-runner.ts
+++ b/frontend/src/lib/site-runner.ts
@@ -74,6 +74,36 @@ export function readRunStatus(jobId: string): RunStatusPayload | null {
   }
 }
 
+export function listActiveRunStatusesFromFs(userId: string, limit = 20): RunStatusPayload[] {
+  const cleanUserId = String(userId || "").trim();
+  if (!cleanUserId) return [];
+
+  const root = siteRunsRoot();
+  if (!fs.existsSync(root)) return [];
+
+  let entries: fs.Dirent[] = [];
+  try {
+    entries = fs.readdirSync(root, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const runs: RunStatusPayload[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const status = readRunStatus(entry.name);
+    if (!status) continue;
+    if (String(status.user_id || "").trim() !== cleanUserId) continue;
+    if (status.status !== "queued" && status.status !== "running") continue;
+    runs.push(status);
+  }
+
+  const safeLimit = Math.max(1, Math.min(100, Math.trunc(limit)));
+  return runs
+    .sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at))
+    .slice(0, safeLimit);
+}
+
 export function readProgressLines(progressPath: string, maxLines = 80): string[] {
   if (!progressPath || !fs.existsSync(progressPath)) {
     return [];

--- a/frontend/src/lib/site-runs-db.ts
+++ b/frontend/src/lib/site-runs-db.ts
@@ -29,6 +29,27 @@ interface SiteRunRow {
   report_id: string | null;
 }
 
+function rowToRunStatus(row: SiteRunRow): Partial<RunStatusPayload> {
+  const llmTotal = asNumber(row.llm_total_estimated, 30);
+  const llmDone = asNumber(row.llm_completed, 0);
+  const llmPct = llmTotal > 0 ? Math.min(100, Number(((llmDone / llmTotal) * 100).toFixed(2))) : 0;
+
+  return {
+    job_id: row.job_id,
+    ticker: row.ticker,
+    status: row.status as RunStatusPayload["status"],
+    created_at: row.created_at,
+    started_at: row.started_at,
+    finished_at: row.finished_at,
+    user_id: row.user_id,
+    llm_total_estimated: llmTotal,
+    llm_completed: llmDone,
+    llm_progress_pct: llmPct,
+    error: row.error || "",
+    report_id: row.report_id,
+  };
+}
+
 /**
  * Insert the row for a freshly-queued run. Best-effort: returns false on any
  * failure so the FS sink keeps running. The Python worker will UPSERT the same
@@ -95,26 +116,48 @@ export async function readRunStatusFromDb(jobId: string): Promise<Partial<RunSta
     const row = rows[0];
     if (!row) return null;
 
-    const llmTotal = asNumber(row.llm_total_estimated, 30);
-    const llmDone = asNumber(row.llm_completed, 0);
-    const llmPct = llmTotal > 0 ? Math.min(100, Number(((llmDone / llmTotal) * 100).toFixed(2))) : 0;
-
-    return {
-      job_id: row.job_id,
-      ticker: row.ticker,
-      status: row.status as RunStatusPayload["status"],
-      created_at: row.created_at,
-      started_at: row.started_at,
-      finished_at: row.finished_at,
-      user_id: row.user_id,
-      llm_total_estimated: llmTotal,
-      llm_completed: llmDone,
-      llm_progress_pct: llmPct,
-      error: row.error || "",
-      report_id: row.report_id,
-    };
+    return rowToRunStatus(row);
   } catch (err) {
     console.warn(`[site-runs-db] readRunStatusFromDb failed for ${jobId}:`, err);
+    return null;
+  }
+}
+
+/**
+ * Return the active runs owned by one signed-in user. A null result means the
+ * durable store is unavailable; an empty array is a successful query with no
+ * active runs. Keeping those cases distinct lets callers use the FS fallback
+ * only when it is actually needed.
+ */
+export async function listActiveRunsForUser(
+  userId: string,
+  limit = 20,
+): Promise<Partial<RunStatusPayload>[] | null> {
+  const sql = getSql();
+  const cleanUserId = asUuid(userId);
+  if (!sql || !cleanUserId) return null;
+  const safeLimit = Math.max(1, Math.min(100, Math.trunc(limit)));
+
+  try {
+    const rows = (await sql`
+      SELECT job_id, ticker,
+             user_id::text AS user_id,
+             status,
+             created_at::text AS created_at,
+             started_at::text AS started_at,
+             finished_at::text AS finished_at,
+             llm_total_estimated, llm_completed,
+             error,
+             report_id::text AS report_id
+        FROM site_runs
+       WHERE user_id = ${cleanUserId}::uuid
+         AND status IN ('queued', 'running')
+       ORDER BY created_at DESC
+       LIMIT ${safeLimit};
+    `) as unknown as SiteRunRow[];
+    return rows.map(rowToRunStatus);
+  } catch (err) {
+    console.warn(`[site-runs-db] listActiveRunsForUser failed for ${cleanUserId}:`, err);
     return null;
   }
 }

--- a/scripts/site_run.py
+++ b/scripts/site_run.py
@@ -193,6 +193,7 @@ def main() -> int:
         write_err: str | None = None
         try:
             from ai_hedge.db.writer import (
+                attribute_report_to_user,
                 find_report_id_by_source_run_id,
                 write_run_to_db,
             )
@@ -208,11 +209,17 @@ def main() -> int:
                     source="site",
                     max_attempts=5,
                     retry_backoff_seconds=2.0,
+                    user_id=existing_status.get("user_id"),
                 )
                 report_id = find_report_id_by_source_run_id(
                     source_run_id=job_id,
                     source="site",
                     ticker=ticker,
+                )
+            if report_id:
+                attribute_report_to_user(
+                    report_id,
+                    existing_status.get("user_id"),
                 )
             if not report_id:
                 base_msg = (

--- a/src/ai_hedge/db/writer.py
+++ b/src/ai_hedge/db/writer.py
@@ -4,6 +4,44 @@ import os
 import time
 import sys
 from pathlib import Path
+from uuid import UUID
+
+
+def _normalized_uuid(value: object) -> str | None:
+    try:
+        return str(UUID(str(value or "").strip()))
+    except (ValueError, TypeError, AttributeError):
+        return None
+
+
+def attribute_report_to_user(report_id: str, user_id: str | None) -> bool:
+    """Best-effort ownership attribution for a completed site report."""
+    clean_report_id = _normalized_uuid(report_id)
+    clean_user_id = _normalized_uuid(user_id)
+    if not clean_report_id or not clean_user_id:
+        return False
+    if not (os.environ.get("DATABASE_URL_UNPOOLED") or os.environ.get("DATABASE_URL")):
+        return False
+    try:
+        from ai_hedge.db.connection import get_conn
+
+        with get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    UPDATE reports
+                       SET user_id = %s
+                     WHERE id = %s
+                       AND (user_id IS NULL OR user_id = %s)
+                     RETURNING id;
+                    """,
+                    (clean_user_id, clean_report_id, clean_user_id),
+                )
+                updated = cur.fetchone() is not None
+            conn.commit()
+        return updated
+    except Exception:
+        return False
 
 
 def find_report_id_by_source_run_id(
@@ -53,6 +91,7 @@ def write_run_to_db(
     max_attempts: int = 1,
     retry_backoff_seconds: float = 1.5,
     r2_keys: dict | None = None,
+    user_id: str | None = None,
 ) -> tuple[str | None, str | None]:
     """
     Best-effort DB write at the end of a successful run.
@@ -98,6 +137,7 @@ def write_run_to_db(
 
     if r2_keys is not None:
         bundle["artifact_row"]["r2_keys"] = r2_keys
+    bundle["report_row"]["user_id"] = _normalized_uuid(user_id)
 
     attempts = max(1, int(max_attempts or 1))
     last_exc: Exception | None = None

--- a/tests/test_db_writer_user_attribution.py
+++ b/tests/test_db_writer_user_attribution.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from ai_hedge.db import connection, repository, transform, writer
+
+
+class FakeConnection:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def commit(self):
+        return None
+
+
+class FakeAttributionCursor:
+    def __init__(self):
+        self.params = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def execute(self, _sql, params):
+        self.params = params
+
+    def fetchone(self):
+        return (self.params[1],)
+
+
+class FakeAttributionConnection(FakeConnection):
+    def __init__(self):
+        self.cursor_instance = FakeAttributionCursor()
+        self.committed = False
+
+    def cursor(self):
+        return self.cursor_instance
+
+    def commit(self):
+        self.committed = True
+
+
+def test_write_run_to_db_persists_normalized_user_id(monkeypatch, tmp_path):
+    user_id = "A2D2C986-B9D9-4CD6-81A5-11F9D85B1A34"
+    captured: dict[str, object] = {}
+    bundle = {
+        "ticker_row": {"symbol": "AAPL"},
+        "report_row": {"ticker": "AAPL", "user_id": None},
+        "artifact_row": {"dashboard": {}},
+    }
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test")
+    monkeypatch.setattr(connection, "get_conn", FakeConnection)
+    monkeypatch.setattr(transform, "ticker_dir_to_row", lambda *_args, **_kwargs: bundle)
+    monkeypatch.setattr(repository, "upsert_ticker", lambda *_args, **_kwargs: None)
+
+    def fake_insert_report(_conn, report_row, _artifact_row):
+        captured.update(report_row)
+        return ("e37cdde7-e6d1-41d2-aa28-149f12f6a396", True)
+
+    monkeypatch.setattr(repository, "insert_report", fake_insert_report)
+
+    report_id, error = writer.write_run_to_db(
+        tmp_path,
+        source="site",
+        user_id=user_id,
+    )
+
+    assert error is None
+    assert report_id == "e37cdde7-e6d1-41d2-aa28-149f12f6a396"
+    assert captured["user_id"] == user_id.lower()
+
+
+def test_write_run_to_db_rejects_non_uuid_user_id(monkeypatch, tmp_path):
+    captured: dict[str, object] = {}
+    bundle = {
+        "ticker_row": {"symbol": "AAPL"},
+        "report_row": {"ticker": "AAPL", "user_id": "unexpected"},
+        "artifact_row": {"dashboard": {}},
+    }
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test")
+    monkeypatch.setattr(connection, "get_conn", FakeConnection)
+    monkeypatch.setattr(transform, "ticker_dir_to_row", lambda *_args, **_kwargs: bundle)
+    monkeypatch.setattr(repository, "upsert_ticker", lambda *_args, **_kwargs: None)
+
+    def fake_insert_report(_conn, report_row, _artifact_row):
+        captured.update(report_row)
+        return ("e37cdde7-e6d1-41d2-aa28-149f12f6a396", True)
+
+    monkeypatch.setattr(repository, "insert_report", fake_insert_report)
+
+    _, error = writer.write_run_to_db(
+        tmp_path,
+        source="site",
+        user_id="local-dev",
+    )
+
+    assert error is None
+    assert captured["user_id"] is None
+
+
+def test_attribute_report_to_user_updates_only_the_requested_owner(monkeypatch):
+    report_id = "e37cdde7-e6d1-41d2-aa28-149f12f6a396"
+    user_id = "a2d2c986-b9d9-4cd6-81a5-11f9d85b1a34"
+    fake_conn = FakeAttributionConnection()
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test")
+    monkeypatch.setattr(connection, "get_conn", lambda: fake_conn)
+
+    assert writer.attribute_report_to_user(report_id, user_id) is True
+    assert fake_conn.cursor_instance.params == (user_id, report_id, user_id)
+    assert fake_conn.committed is True


### PR DESCRIPTION
## Summary

- discover queued and running analyses from the server by the authenticated user, so the same run appears across devices and browsers
- keep local run tracking as an outage fallback while enforcing run ownership on status and cancellation endpoints
- persist report ownership when the worker completes, without depending on the originating browser to keep polling

## Preview

URL: https://pr-124-hedge-in-a-box-site.fly.dev

## Test plan

- [x] `npm exec eslint -- src/lib/site-runs-db.ts src/lib/site-runner.ts src/app/api/run-analysis/route.ts src/app/api/run-analysis/[jobId]/route.ts src/components/shell/active-runs-store.ts`
- [x] `python -m pytest tests/test_valuation_scenarios.py tests/test_db_writer_user_attribution.py -q` (13 passed)
- [x] `python -m py_compile scripts/site_run.py src/ai_hedge/db/writer.py`
- [x] `npm run build`
- [x] local runtime smoke: an FS-backed active run owned by `local-dev` was returned by both the user run list and per-job status routes with matching job, ticker, status, and progress
- [x] deployed preview: home returned HTTP 200 with Hedge in a Box content; `/api/run-analysis` returned HTTP 200 with `{ count: 0, runs: [] }`; an unknown job returned HTTP 404

## Notes for reviewer

- No schema migration is required; this uses the existing indexed `site_runs.user_id` field and falls back to the current filesystem status sink when Neon is unavailable.
- Standalone `npm exec tsc -- --noEmit` still reports four pre-existing nullability errors in `hit-rate-aggregate.test.ts` and `ticker-summary-aggregate.test.ts`; the production build TypeScript phase passes.