### PR TITLE
Add Top 20 model and persona portfolio returns

### DIFF
--- a/.github/workflows/portfolio-performance.yml
+++ b/.github/workflows/portfolio-performance.yml
@@ -1,0 +1,95 @@
+name: Portfolio Performance Refresh
+
+on:
+  schedule:
+    # Weekdays after the US close, with enough margin for delayed market data.
+    - cron: '30 23 * * 1-5'
+  workflow_dispatch:
+    inputs:
+      track:
+        description: Portfolio track to refresh
+        type: choice
+        required: true
+        default: paper
+        options:
+          - paper
+          - backtest
+      through:
+        description: Optional inclusive end date (YYYY-MM-DD)
+        type: string
+        required: false
+      start_cutoff:
+        description: Backtest first month-end cutoff (YYYY-MM-DD)
+        type: string
+        required: false
+        default: '2026-04-30'
+      replace_backtest:
+        description: Explicitly replace the selected backtest methodology version
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: portfolio-performance-${{ github.event.inputs.track || 'paper' }}
+  cancel-in-progress: false
+
+env:
+  FLY_APP: hedge-in-a-box-site
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Install flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Resolve Fly token
+        env:
+          FLY_API_TOKEN_PRIMARY: ${{ secrets.FLY_API_TOKEN }}
+          FLY_TOKEN: ${{ secrets.FLY_TOKEN }}
+          FLY_AUTH_TOKEN_INPUT: ${{ secrets.FLY_AUTH_TOKEN }}
+        run: |
+          TOKEN="${FLY_API_TOKEN_PRIMARY:-${FLY_TOKEN:-$FLY_AUTH_TOKEN_INPUT}}"
+          if [ -z "$TOKEN" ]; then
+            echo "::error::No Fly token found. Set FLY_API_TOKEN in repo secrets."
+            exit 1
+          fi
+          echo "FLY_API_TOKEN=$TOKEN" >> "$GITHUB_ENV"
+
+      - name: Refresh portfolio data inside Fly
+        env:
+          INPUT_TRACK: ${{ github.event.inputs.track }}
+          INPUT_THROUGH: ${{ github.event.inputs.through }}
+          INPUT_START_CUTOFF: ${{ github.event.inputs.start_cutoff }}
+          INPUT_REPLACE: ${{ github.event.inputs.replace_backtest }}
+        run: |
+          set -euo pipefail
+          TRACK="${INPUT_TRACK:-paper}"
+          if [ "$TRACK" != "paper" ] && [ "$TRACK" != "backtest" ]; then
+            echo "::error::track must be paper or backtest"
+            exit 1
+          fi
+          COMMAND="cd /app/frontend && npm run portfolio:refresh -- --track $TRACK"
+          if [ -n "${INPUT_THROUGH:-}" ]; then
+            if ! [[ "$INPUT_THROUGH" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+              echo "::error::through must use YYYY-MM-DD"
+              exit 1
+            fi
+            COMMAND="$COMMAND --through $INPUT_THROUGH"
+          fi
+          if [ "$TRACK" = "backtest" ]; then
+            START_CUTOFF="${INPUT_START_CUTOFF:-2026-04-30}"
+            if ! [[ "$START_CUTOFF" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+              echo "::error::start_cutoff must use YYYY-MM-DD"
+              exit 1
+            fi
+            COMMAND="$COMMAND --start-cutoff $START_CUTOFF"
+            if [ "${INPUT_REPLACE:-false}" = "true" ]; then
+              COMMAND="$COMMAND --replace-backtest"
+            fi
+          fi
+          flyctl ssh console --app "$FLY_APP" --command "$COMMAND"

--- a/.github/workflows/portfolio-performance.yml
+++ b/.github/workflows/portfolio-performance.yml
@@ -92,4 +92,4 @@ jobs:
               COMMAND="$COMMAND --replace-backtest"
             fi
           fi
-          flyctl ssh console --app "$FLY_APP" --command "$COMMAND"
+          flyctl ssh console --app "$FLY_APP" --command "sh -lc '$COMMAND'"

--- a/.github/workflows/portfolio-performance.yml
+++ b/.github/workflows/portfolio-performance.yml
@@ -93,3 +93,10 @@ jobs:
             fi
           fi
           flyctl ssh console --app "$FLY_APP" --command "sh -lc '$COMMAND'"
+
+      - name: Refresh backtest alongside scheduled paper tracking
+        if: github.event_name == 'schedule'
+        run: >-
+          flyctl ssh console --app "$FLY_APP" --command
+          "sh -lc 'cd /app/frontend && npm run portfolio:refresh --
+          --track backtest --start-cutoff 2026-04-30'"

--- a/.github/workflows/preview-site.yml
+++ b/.github/workflows/preview-site.yml
@@ -254,9 +254,9 @@ jobs:
             exit 0
           fi
           flyctl ssh console --app "${{ env.PREVIEW_APP }}" --command \
-            "cd /app/frontend && npm run portfolio:refresh -- --track backtest --start-cutoff 2026-04-30"
+            "sh -lc 'cd /app/frontend && npm run portfolio:refresh -- --track backtest --start-cutoff 2026-04-30'"
           flyctl ssh console --app "${{ env.PREVIEW_APP }}" --command \
-            "cd /app/frontend && npm run portfolio:refresh -- --track paper"
+            "sh -lc 'cd /app/frontend && npm run portfolio:refresh -- --track paper'"
 
       - name: Diagnostics on deploy failure
         if: failure() && steps.deploy.conclusion == 'failure'

--- a/.github/workflows/preview-site.yml
+++ b/.github/workflows/preview-site.yml
@@ -256,7 +256,7 @@ jobs:
           flyctl ssh console --app "${{ env.PREVIEW_APP }}" --command \
             "sh -lc 'cd /app/frontend && npm run portfolio:refresh -- --track backtest --start-cutoff 2026-04-30'"
           flyctl ssh console --app "${{ env.PREVIEW_APP }}" --command \
-            "sh -lc 'cd /app/frontend && npm run portfolio:refresh -- --track paper'"
+            "sh -lc 'cd /app/frontend && npm run portfolio:refresh -- --track paper --paper-cutoff 2026-08-17'"
 
       - name: Diagnostics on deploy failure
         if: failure() && steps.deploy.conclusion == 'failure'

--- a/.github/workflows/preview-site.yml
+++ b/.github/workflows/preview-site.yml
@@ -241,6 +241,23 @@ jobs:
             --ha=false \
             --wait-timeout 5m
 
+      - name: Bootstrap portfolio performance preview data
+        env:
+          FLY_API_TOKEN: ${{ env.FLY_AUTH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if ! gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --paginate --jq '.[].filename' \
+            | grep -qx 'src/ai_hedge/db/migrations/006_portfolio_performance.sql'; then
+            echo "Portfolio migration is not part of this PR; skipping preview backfill."
+            exit 0
+          fi
+          flyctl ssh console --app "${{ env.PREVIEW_APP }}" --command \
+            "cd /app/frontend && npm run portfolio:refresh -- --track backtest --start-cutoff 2026-04-30"
+          flyctl ssh console --app "${{ env.PREVIEW_APP }}" --command \
+            "cd /app/frontend && npm run portfolio:refresh -- --track paper"
+
       - name: Diagnostics on deploy failure
         if: failure() && steps.deploy.conclusion == 'failure'
         env:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,6 +29,7 @@
         "eslint": "^9",
         "eslint-config-next": "16.2.4",
         "tailwindcss": "^4",
+        "tsx": "^4.23.12",
         "typescript": "^5"
       }
     },
@@ -305,6 +306,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -2570,6 +3013,48 @@
         "benchmarks"
       ]
     },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "dev": true,
@@ -3119,6 +3604,21 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -7288,6 +7788,25 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "portfolio:refresh": "tsx scripts/refresh-portfolio-performance.ts",
+    "test:portfolio": "tsx --test src/lib/discovery-engine.test.ts src/lib/portfolio-performance-engine.test.ts"
   },
   "dependencies": {
     "@neondatabase/serverless": "^1.1.0",
@@ -30,6 +32,7 @@
     "eslint": "^9",
     "eslint-config-next": "16.2.4",
     "tailwindcss": "^4",
+    "tsx": "^4.23.12",
     "typescript": "^5"
   }
 }

--- a/frontend/scripts/refresh-portfolio-performance.ts
+++ b/frontend/scripts/refresh-portfolio-performance.ts
@@ -1,0 +1,412 @@
+import { randomUUID } from "node:crypto";
+import { spawn } from "node:child_process";
+import path from "node:path";
+
+import {
+  allDiscoveryLenses,
+  prepareDiscoveryUniverse,
+  scoreDiscoveryCandidates,
+  type DiscoveryLensSelection,
+  type DiscoverySourceReport,
+} from "../src/lib/discovery-engine";
+import { isExcludedTicker } from "../src/lib/excluded-tickers";
+import {
+  acquirePortfolioRefreshLock,
+  deletePortfolioTrack,
+  insertPortfolioSnapshot,
+  listPortfolioReportInputs,
+  loadMarketPrices,
+  loadPortfolioSnapshots,
+  releasePortfolioRefreshLock,
+  upsertMarketPrices,
+  upsertPortfolioNav,
+  type PortfolioReportInput,
+} from "../src/lib/portfolio-db";
+import {
+  buildHoldingsForSnapshot,
+  computePortfolioNavSeries,
+  firstExecutionDateForCandidates,
+  latestPriceOnOrBefore,
+  PORTFOLIO_BENCHMARK_SYMBOL,
+  PORTFOLIO_METHODOLOGY_VERSION,
+  PORTFOLIO_PROVIDER,
+  type MarketPricePoint,
+  type PortfolioSnapshotDefinition,
+  type PortfolioTrack,
+} from "../src/lib/portfolio-performance-engine";
+
+type PriceBundle = {
+  provider: string;
+  benchmark_symbol: string;
+  assets: Record<
+    string,
+    Array<{
+      symbol: string;
+      date: string;
+      adjusted_close_local: number;
+      currency: string;
+      fx_to_usd: number;
+      adjusted_close_usd: number;
+    }>
+  >;
+  errors?: Array<{ symbol: string; error: string }>;
+};
+
+type CliArgs = {
+  track: PortfolioTrack;
+  startCutoff: string;
+  throughDate: string;
+  replaceBacktest: boolean;
+};
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NY_TIME_ZONE = "America/New_York";
+
+function parseCliArgs(): CliArgs {
+  const values = process.argv.slice(2);
+  const valueFor = (name: string): string | null => {
+    const index = values.indexOf(name);
+    return index >= 0 ? values[index + 1] || null : null;
+  };
+  const rawTrack = valueFor("--track") || "paper";
+  if (rawTrack !== "paper" && rawTrack !== "backtest") {
+    throw new Error("--track must be paper or backtest.");
+  }
+  const track: PortfolioTrack = rawTrack;
+  const throughDate = valueFor("--through") || new Date().toISOString().slice(0, 10);
+  const startCutoff = valueFor("--start-cutoff") || "2026-04-30";
+  for (const [name, value] of [["--through", throughDate], ["--start-cutoff", startCutoff]]) {
+    const parsed = Date.parse(`${value}T00:00:00Z`);
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(value) || !Number.isFinite(parsed) || isoDate(new Date(parsed)) !== value) {
+      throw new Error(`${name} must be a valid YYYY-MM-DD date.`);
+    }
+  }
+  return {
+    track,
+    startCutoff,
+    throughDate,
+    replaceBacktest: values.includes("--replace-backtest"),
+  };
+}
+
+function nyDateParts(value: Date): { year: number; month: number; day: number } {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: NY_TIME_ZONE,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(value);
+  const get = (type: string) => Number(parts.find((part) => part.type === type)?.value || 0);
+  return { year: get("year"), month: get("month"), day: get("day") };
+}
+
+function nyDateString(value: Date): string {
+  const parts = nyDateParts(value);
+  return `${parts.year}-${String(parts.month).padStart(2, "0")}-${String(parts.day).padStart(2, "0")}`;
+}
+
+function timeZoneOffsetMs(value: Date, timeZone: string): number {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(value);
+  const get = (type: string) => Number(parts.find((part) => part.type === type)?.value || 0);
+  const representedUtc = Date.UTC(
+    get("year"),
+    get("month") - 1,
+    get("day"),
+    get("hour"),
+    get("minute"),
+    get("second"),
+  );
+  return representedUtc - value.getTime();
+}
+
+function cutoffAtForNyDate(dateValue: string): Date {
+  const [year, month, day] = dateValue.split("-").map(Number);
+  const localGuess = new Date(Date.UTC(year, month - 1, day, 23, 59, 59));
+  const firstOffset = timeZoneOffsetMs(localGuess, NY_TIME_ZONE);
+  const firstUtc = new Date(localGuess.getTime() - firstOffset);
+  const correctedOffset = timeZoneOffsetMs(firstUtc, NY_TIME_ZONE);
+  return new Date(localGuess.getTime() - correctedOffset);
+}
+
+function isoDate(value: Date): string {
+  return value.toISOString().slice(0, 10);
+}
+
+function addDays(dateValue: string, days: number): string {
+  return isoDate(new Date(Date.parse(`${dateValue}T00:00:00Z`) + days * DAY_MS));
+}
+
+function previousNyCalendarDay(now: Date): string {
+  const parts = nyDateParts(now);
+  return isoDate(new Date(Date.UTC(parts.year, parts.month - 1, parts.day) - DAY_MS));
+}
+
+function previousMonthEnd(now: Date): string {
+  const parts = nyDateParts(now);
+  return isoDate(new Date(Date.UTC(parts.year, parts.month - 1, 0)));
+}
+
+function monthlyCutoffDates(startDate: string, endDate: string): string[] {
+  const [startYear, startMonth] = startDate.split("-").map(Number);
+  const output: string[] = [];
+  let cursor = new Date(Date.UTC(startYear, startMonth, 0));
+  while (isoDate(cursor) <= endDate) {
+    if (isoDate(cursor) >= startDate) output.push(isoDate(cursor));
+    cursor = new Date(Date.UTC(cursor.getUTCFullYear(), cursor.getUTCMonth() + 2, 0));
+  }
+  return output;
+}
+
+function runPriceProvider(payload: object): Promise<PriceBundle> {
+  const repoRoot = path.resolve(process.cwd(), "..");
+  const script = path.resolve(repoRoot, "scripts", "portfolio_prices.py");
+  const python = process.env.PYTHON_EXECUTABLE || "python";
+  return new Promise((resolve, reject) => {
+    const child = spawn(python, [script], {
+      cwd: repoRoot,
+      env: { ...process.env, PYTHONPATH: path.resolve(repoRoot, "src"), PYTHONUNBUFFERED: "1" },
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => { stdout += String(chunk); });
+    child.stderr.on("data", (chunk) => { stderr += String(chunk); });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code !== 0) {
+        reject(new Error(stderr.trim() || `portfolio_prices.py exited with ${code}`));
+        return;
+      }
+      try {
+        resolve(JSON.parse(stdout) as PriceBundle);
+      } catch (error) {
+        reject(new Error(`Invalid portfolio price JSON: ${String(error)}`));
+      }
+    });
+    child.stdin.end(JSON.stringify(payload));
+  });
+}
+
+function flattenPriceBundle(bundle: PriceBundle): MarketPricePoint[] {
+  return Object.values(bundle.assets || {}).flatMap((rows) => rows.map((row) => ({
+    symbol: row.symbol,
+    date: row.date,
+    adjustedCloseLocal: Number(row.adjusted_close_local),
+    currency: row.currency,
+    fxToUsd: Number(row.fx_to_usd),
+    adjustedCloseUsd: Number(row.adjusted_close_usd),
+  })));
+}
+
+function reportsVisibleAt(
+  reports: PortfolioReportInput[],
+  cutoffAt: Date,
+  track: PortfolioTrack,
+): PortfolioReportInput[] {
+  const cutoffMs = cutoffAt.getTime();
+  const windowStart = cutoffMs - 90 * DAY_MS;
+  const visible = reports.filter((report) => {
+    const generatedMs = Date.parse(report.generatedAt);
+    if (generatedMs < windowStart || generatedMs > cutoffMs || isExcludedTicker(report.ticker)) return false;
+    if (track === "paper" && Date.parse(report.createdAt) > cutoffMs) return false;
+    return report.deletedAt === null || Date.parse(report.deletedAt) > cutoffMs;
+  });
+  const deduped = new Map<string, PortfolioReportInput>();
+  for (const report of visible.sort((a, b) => Date.parse(a.generatedAt) - Date.parse(b.generatedAt))) {
+    const key = report.sourceRunId ? `${report.ticker}:${report.sourceRunId}` : report.id;
+    deduped.set(key, report);
+  }
+  return Array.from(deduped.values());
+}
+
+function groupSnapshotsByLens(snapshots: PortfolioSnapshotDefinition[]): PortfolioSnapshotDefinition[][] {
+  const grouped = new Map<string, PortfolioSnapshotDefinition[]>();
+  for (const snapshot of snapshots) {
+    const key = `${snapshot.lens.type}:${snapshot.lens.key || "overall"}`;
+    if (!grouped.has(key)) grouped.set(key, []);
+    grouped.get(key)!.push(snapshot);
+  }
+  return Array.from(grouped.values());
+}
+
+function lensMapKey(lens: DiscoveryLensSelection): string {
+  return `${lens.type}:${lens.key || "overall"}`;
+}
+
+async function main() {
+  const args = parseCliArgs();
+  if (args.replaceBacktest && args.track !== "backtest") {
+    throw new Error("--replace-backtest is only valid with --track backtest.");
+  }
+  const owner = `${process.env.HOSTNAME || "local"}:${process.pid}:${randomUUID()}`;
+  const lockKey = `portfolio-performance:${args.track}:${PORTFOLIO_METHODOLOGY_VERSION}`;
+  if (!(await acquirePortfolioRefreshLock(lockKey, owner))) {
+    console.log(`[portfolio] ${lockKey} is already running; exiting cleanly.`);
+    return;
+  }
+
+  try {
+    if (args.replaceBacktest) {
+      await deletePortfolioTrack("backtest", PORTFOLIO_METHODOLOGY_VERSION);
+    }
+    let existing = await loadPortfolioSnapshots(args.track, PORTFOLIO_METHODOLOGY_VERSION);
+    const now = new Date();
+    let cutoffs: string[];
+    if (args.track === "backtest") {
+      cutoffs = monthlyCutoffDates(args.startCutoff, previousMonthEnd(new Date(`${args.throughDate}T23:59:59Z`)));
+    } else if (!existing.length) {
+      cutoffs = [previousNyCalendarDay(now)];
+    } else {
+      const existingCutoffDates = Array.from(new Set(
+        existing.map((snapshot) => nyDateString(new Date(snapshot.cutoffAt))),
+      )).sort();
+      const latestCutoffDate = existingCutoffDates[existingCutoffDates.length - 1];
+      cutoffs = Array.from(new Set([
+        ...existingCutoffDates,
+        ...monthlyCutoffDates(addDays(latestCutoffDate, 1), previousMonthEnd(now)),
+      ])).sort();
+    }
+
+    const allCutoffDates = [...cutoffs, ...existing.map((snapshot) => nyDateString(new Date(snapshot.cutoffAt)))];
+    const earliestCutoff = allCutoffDates.sort()[0] || previousNyCalendarDay(now);
+    const earliestReport = addDays(earliestCutoff, -90);
+    const reports = await listPortfolioReportInputs({
+      earliestGeneratedAt: `${earliestReport}T00:00:00Z`,
+      latestGeneratedAt: `${args.throughDate}T23:59:59Z`,
+    });
+    const currencyByTicker = new Map<string, string>();
+    for (const report of reports) currencyByTicker.set(report.ticker, report.currency);
+    for (const snapshot of existing) {
+      for (const holding of snapshot.holdings) currencyByTicker.set(holding.ticker, holding.currency);
+    }
+    const instruments = Array.from(currencyByTicker.entries()).map(([symbol, currency]) => ({ symbol, currency }));
+    const priceStart = addDays(earliestCutoff, -10);
+    const priceBundle = await runPriceProvider({
+      start: priceStart,
+      end: args.throughDate,
+      instruments,
+      workers: Number(process.env.PORTFOLIO_PRICE_WORKERS || 8),
+    });
+    const fetchedPoints = flattenPriceBundle(priceBundle);
+    await upsertMarketPrices(fetchedPoints, PORTFOLIO_PROVIDER);
+    const symbols = Array.from(new Set([...currencyByTicker.keys(), PORTFOLIO_BENCHMARK_SYMBOL]));
+    const priceBySymbol = await loadMarketPrices({
+      symbols,
+      startDate: priceStart,
+      endDate: args.throughDate,
+      source: PORTFOLIO_PROVIDER,
+    });
+    const benchmarkPoints = priceBySymbol.get(PORTFOLIO_BENCHMARK_SYMBOL) || [];
+    const knownLenses = new Map<string, DiscoveryLensSelection>();
+    const lensFirstCutoff = new Map<string, string>();
+    knownLenses.set("overall:overall", { type: "overall", key: null, label: "Overall" });
+    lensFirstCutoff.set("overall:overall", earliestCutoff);
+    for (const snapshot of existing) {
+      const key = lensMapKey(snapshot.lens);
+      const cutoffDate = nyDateString(new Date(snapshot.cutoffAt));
+      knownLenses.set(key, snapshot.lens);
+      const previous = lensFirstCutoff.get(key);
+      if (!previous || cutoffDate < previous) lensFirstCutoff.set(key, cutoffDate);
+    }
+
+    for (const cutoffDate of cutoffs) {
+      const cutoffAt = cutoffAtForNyDate(cutoffDate);
+      if (!benchmarkPoints.some((point) => point.date > cutoffDate)) {
+        console.warn(`[portfolio] no benchmark session after ${cutoffDate}; snapshot deferred.`);
+        continue;
+      }
+      const visibleReports = reportsVisibleAt(reports, cutoffAt, args.track);
+      const discoveryReports: DiscoverySourceReport[] = visibleReports.map((report) => ({
+        ticker: report.ticker,
+        generatedAt: report.generatedAt,
+        payload: report.dashboard,
+        reportId: report.id,
+      }));
+      const localPriceByTicker = new Map<string, number | null>();
+      for (const ticker of new Set(discoveryReports.map((report) => report.ticker))) {
+        const point = latestPriceOnOrBefore(priceBySymbol.get(ticker) || [], cutoffDate);
+        localPriceByTicker.set(ticker, point?.adjustedCloseLocal ?? null);
+      }
+      const universe = prepareDiscoveryUniverse({
+        reports: discoveryReports,
+        priceByTicker: localPriceByTicker,
+        asOfMs: cutoffAt.getTime(),
+      });
+      for (const lens of allDiscoveryLenses(universe)) {
+        const key = lensMapKey(lens);
+        knownLenses.set(key, lens);
+        if (!lensFirstCutoff.has(key)) lensFirstCutoff.set(key, cutoffDate);
+      }
+      let createdForCutoff = 0;
+      for (const lens of knownLenses.values()) {
+        if (String(lensFirstCutoff.get(lensMapKey(lens)) || cutoffDate) > cutoffDate) continue;
+        const candidates = scoreDiscoveryCandidates(universe, lens);
+        const executionDate = firstExecutionDateForCandidates({
+          candidates,
+          cutoffDate,
+          benchmarkPoints,
+          priceBySymbol,
+        });
+        if (!executionDate) {
+          console.warn(`[portfolio] ${lens.type}:${lens.key || "overall"} has no common execution session after ${cutoffDate}; snapshot deferred.`);
+          continue;
+        }
+        const holdings = buildHoldingsForSnapshot({
+          candidates,
+          executionDate,
+          priceBySymbol,
+          currencyByTicker,
+        });
+        await insertPortfolioSnapshot({
+          track: args.track,
+          lens,
+          cutoffAt: cutoffAt.toISOString(),
+          executionDate,
+          methodologyVersion: PORTFOLIO_METHODOLOGY_VERSION,
+          candidateCount: candidates.length,
+          status: holdings.length ? "ready" : "no_positions",
+          holdings,
+        });
+        createdForCutoff += 1;
+      }
+      console.log(`[portfolio] ${args.track} cutoff ${cutoffDate}: ${createdForCutoff} snapshots (${visibleReports.length} reports).`);
+    }
+
+    existing = await loadPortfolioSnapshots(args.track, PORTFOLIO_METHODOLOGY_VERSION);
+    for (const lensSnapshots of groupSnapshotsByLens(existing)) {
+      const first = lensSnapshots[0];
+      const nav = computePortfolioNavSeries({
+        snapshots: lensSnapshots,
+        priceBySymbol,
+        benchmarkPoints,
+        throughDate: args.throughDate,
+      });
+      await upsertPortfolioNav({
+        track: args.track,
+        lensType: first.lens.type,
+        lensKey: first.lens.key || "overall",
+        methodologyVersion: PORTFOLIO_METHODOLOGY_VERSION,
+        points: nav,
+      });
+    }
+    if (priceBundle.errors?.length) {
+      console.warn(`[portfolio] provider returned ${priceBundle.errors.length} symbol warnings.`);
+    }
+    console.log(`[portfolio] refreshed ${args.track}: ${existing.length} snapshots, ${fetchedPoints.length} price rows.`);
+  } finally {
+    await releasePortfolioRefreshLock(lockKey, owner);
+  }
+}
+
+main().catch((error) => {
+  console.error(`[portfolio] ${error instanceof Error ? error.stack || error.message : String(error)}`);
+  process.exitCode = 1;
+});

--- a/frontend/scripts/refresh-portfolio-performance.ts
+++ b/frontend/scripts/refresh-portfolio-performance.ts
@@ -55,6 +55,7 @@ type PriceBundle = {
 type CliArgs = {
   track: PortfolioTrack;
   startCutoff: string;
+  paperCutoff: string | null;
   throughDate: string;
   replaceBacktest: boolean;
 };
@@ -75,7 +76,12 @@ function parseCliArgs(): CliArgs {
   const track: PortfolioTrack = rawTrack;
   const throughDate = valueFor("--through") || new Date().toISOString().slice(0, 10);
   const startCutoff = valueFor("--start-cutoff") || "2026-04-30";
-  for (const [name, value] of [["--through", throughDate], ["--start-cutoff", startCutoff]]) {
+  const paperCutoff = valueFor("--paper-cutoff");
+  for (const [name, value] of [
+    ["--through", throughDate],
+    ["--start-cutoff", startCutoff],
+    ...(paperCutoff ? [["--paper-cutoff", paperCutoff]] : []),
+  ]) {
     const parsed = Date.parse(`${value}T00:00:00Z`);
     if (!/^\d{4}-\d{2}-\d{2}$/.test(value) || !Number.isFinite(parsed) || isoDate(new Date(parsed)) !== value) {
       throw new Error(`${name} must be a valid YYYY-MM-DD date.`);
@@ -84,6 +90,7 @@ function parseCliArgs(): CliArgs {
   return {
     track,
     startCutoff,
+    paperCutoff,
     throughDate,
     replaceBacktest: values.includes("--replace-backtest"),
   };
@@ -246,6 +253,9 @@ async function main() {
   if (args.replaceBacktest && args.track !== "backtest") {
     throw new Error("--replace-backtest is only valid with --track backtest.");
   }
+  if (args.paperCutoff && args.track !== "paper") {
+    throw new Error("--paper-cutoff is only valid with --track paper.");
+  }
   const owner = `${process.env.HOSTNAME || "local"}:${process.pid}:${randomUUID()}`;
   const lockKey = `portfolio-performance:${args.track}:${PORTFOLIO_METHODOLOGY_VERSION}`;
   if (!(await acquirePortfolioRefreshLock(lockKey, owner))) {
@@ -263,7 +273,7 @@ async function main() {
     if (args.track === "backtest") {
       cutoffs = monthlyCutoffDates(args.startCutoff, previousMonthEnd(new Date(`${args.throughDate}T23:59:59Z`)));
     } else if (!existing.length) {
-      cutoffs = [previousNyCalendarDay(now)];
+      cutoffs = [args.paperCutoff || previousNyCalendarDay(now)];
     } else {
       const existingCutoffDates = Array.from(new Set(
         existing.map((snapshot) => nyDateString(new Date(snapshot.cutoffAt))),

--- a/frontend/src/app/(app)/hit-rate/page.tsx
+++ b/frontend/src/app/(app)/hit-rate/page.tsx
@@ -309,12 +309,36 @@ export default function HitRatePage() {
   }, [data, mode]);
 
   return (
-    <div className="mx-auto w-full max-w-[1600px] px-4 py-6 text-zinc-100 sm:px-8">
-      <header className="mb-6 rounded-2xl border border-white/10 bg-black/35 p-4 backdrop-blur-xl">
+    <div className="mx-auto w-full max-w-[1600px] px-4 py-6 text-[color:var(--text-primary)] sm:px-8">
+      <header className="mb-6 rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-overlay)] p-4 sm:p-5">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--accent)]">Measurement</p>
+        <h1 className="mt-1 font-display text-2xl">Our Track Record</h1>
+        <p className="mt-1 max-w-3xl text-sm text-[color:var(--text-muted)]">
+          Two simple views of how our analysis performs over time.
+        </p>
+        <div className="mt-4 grid gap-3 md:grid-cols-2">
+          <article className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
+            <h2 className="font-semibold text-[color:var(--text-primary)]">Portfolio Returns</h2>
+            <p className="mt-1 text-sm leading-relaxed text-[color:var(--text-muted)]">
+              Shows what happened to each monthly Top 20 portfolio, compared with the S&amp;P 500 Total Return Index.
+            </p>
+          </article>
+          <article className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
+            <h2 className="font-semibold text-[color:var(--text-primary)]">Hit Rate</h2>
+            <p className="mt-1 text-sm leading-relaxed text-[color:var(--text-muted)]">
+              Shows how often our targets, allocations, and signals pointed in the right direction after each report.
+            </p>
+          </article>
+        </div>
+      </header>
+
+      <PortfolioReturnsSection />
+
+      <section className="mb-6 rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-overlay)] p-4 sm:p-5">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
-            <h1 className="font-display text-2xl">Hit Rate</h1>
-            <p className="text-xs uppercase tracking-[0.2em] text-zinc-500">Global Accuracy Across All Historical Reports</p>
+            <h2 className="font-display text-xl text-[color:var(--text-primary)]">Hit Rate</h2>
+            <p className="mt-1 text-sm text-[color:var(--text-muted)]">Accuracy across all historical reports.</p>
           </div>
           <div className="flex flex-wrap items-center gap-2">
             <div className="inline-flex rounded-lg border border-white/15 bg-white/5 p-1">
@@ -345,15 +369,13 @@ export default function HitRatePage() {
               type="button"
               onClick={() => setRefreshToken((v) => v + 1)}
               disabled={loading}
-              className="rounded-lg border border-white/20 bg-white/5 px-3 py-2 text-xs uppercase tracking-[0.14em] text-zinc-200 transition hover:border-white/40 hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-60"
+              className="rounded-lg border border-white/20 bg-white/5 px-3 py-2 text-xs uppercase tracking-[0.14em] text-zinc-200 transition hover:border-white/40 hover:bg-white/10 disabled:cursor-not-allowed disabled:text-[color:var(--text-disabled)] disabled:opacity-60"
             >
               {loading ? "Refreshing..." : "Refresh Hit Rate"}
             </button>
           </div>
         </div>
-      </header>
-
-      <PortfolioReturnsSection />
+      </section>
 
       {loading || !data ? (
         <div className="grid gap-4 md:grid-cols-3">

--- a/frontend/src/app/(app)/hit-rate/page.tsx
+++ b/frontend/src/app/(app)/hit-rate/page.tsx
@@ -3,6 +3,8 @@
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 
+import { PortfolioReturnsSection } from "@/components/portfolio-returns-section";
+
 type MetricCounts = {
   hits: number;
   misses: number;
@@ -350,6 +352,8 @@ export default function HitRatePage() {
           </div>
         </div>
       </header>
+
+      <PortfolioReturnsSection />
 
       {loading || !data ? (
         <div className="grid gap-4 md:grid-cols-3">

--- a/frontend/src/app/api/discovery/route.ts
+++ b/frontend/src/app/api/discovery/route.ts
@@ -1,381 +1,114 @@
-import path from "node:path";
-
 import { NextResponse } from "next/server";
 
-import { DashboardPayload, DiscoveryRow } from "@/lib/dashboard-types";
+import type { DashboardPayload } from "@/lib/dashboard-types";
 import { getLiveCurrentPricesBatch } from "@/lib/dashboard-server";
 import { isDbEnabled } from "@/lib/db";
 import { getDeletedReportFilter, siteRunIdFromPathLike } from "@/lib/deleted-reports";
+import {
+  normalizeDiscoveryLensType,
+  prepareDiscoveryUniverse,
+  rankDiscoveryRows,
+  resolveDiscoveryLens,
+  scoreDiscoveryCandidates,
+  type DiscoverySourceReport,
+} from "@/lib/discovery-engine";
 import { isExcludedTicker } from "@/lib/excluded-tickers";
 import { listAllDashboardsForHitRate } from "@/lib/reports-db";
 import { listDashboardReports, readJson } from "@/lib/server-outputs";
-import {
-  computeTickerSummaryAggregation,
-  filterReportsByWindow,
-  type SummarySourceReport,
-} from "@/lib/ticker-summary-aggregate";
 
-type DiscoveryLensType = "overall" | "model" | "valuator";
-
-type LensSelection = {
-  type: DiscoveryLensType;
-  key: string | null;
-  label: string;
-};
-
-type PreparedTicker = {
+type LoadedDashboard = {
   ticker: string;
-  summary: ReturnType<typeof computeTickerSummaryAggregation>;
-  current: number;
-  latestUpdatedAt: string;
-  companyName: string;
+  payload: DashboardPayload;
+  updatedAt: string;
+  reportId?: string;
 };
 
-function safeNum(v: unknown): number {
-  const n = Number(v);
-  return Number.isFinite(n) ? n : 0;
-}
-
-function safeNumOrNull(v: unknown): number | null {
-  const n = Number(v);
-  return Number.isFinite(n) ? n : null;
-}
-
-function avgNums(values: number[]): number {
-  if (!values.length) return 0;
-  return values.reduce((sum, value) => sum + value, 0) / values.length;
-}
-
-function combinedScore(investmentPct?: number | null, targetReturnPct?: number | null): number | null {
-  const hasInvestment = typeof investmentPct === "number" && Number.isFinite(investmentPct);
-  const hasTarget = typeof targetReturnPct === "number" && Number.isFinite(targetReturnPct);
-  if (!hasInvestment && !hasTarget) return null;
-  if (hasInvestment && hasTarget) return (0.4 * Number(investmentPct)) + (0.6 * Number(targetReturnPct));
-  return hasInvestment ? Number(investmentPct) : Number(targetReturnPct);
-}
-
-function confidenceAdjustedScore(baseScore?: number | null, overallCv?: number | null): number | null {
-  if (typeof baseScore !== "number" || !Number.isFinite(baseScore)) return null;
-  const cv = typeof overallCv === "number" && Number.isFinite(overallCv) ? Math.max(0, overallCv) : 0;
-  const confidenceFactor = 1 / (1 + Math.pow(cv, 1.3));
-  return baseScore * confidenceFactor;
-}
-
-function reportMs(value: string): number {
-  const ms = Date.parse(String(value || ""));
-  return Number.isFinite(ms) ? ms : 0;
-}
-
-function meanCurrentPriceInWindow(reports: SummarySourceReport[]): number | null {
-  const values = reports
-    .map((report) => safeNumOrNull(report.payload.valuation_hub?.consensus?.current_price))
-    .filter((value): value is number => typeof value === "number" && Number.isFinite(value) && value > 0);
-  if (!values.length) return null;
-  return avgNums(values);
-}
-
-function normalizeLensType(value: string | null | undefined): DiscoveryLensType {
-  const raw = String(value || "").trim().toLowerCase();
-  if (raw === "model") return "model";
-  if (raw === "valuator") return "valuator";
-  return "overall";
-}
-
-function cleanLensKey(value: string | null | undefined): string | null {
-  const key = String(value || "").trim();
-  return key ? key : null;
-}
-
-function resolveLensSelection(
-  lensType: DiscoveryLensType,
-  lensKey: string | null,
-  models: string[],
-  valuators: string[],
-): LensSelection {
-  if (lensType === "model") {
-    if (lensKey && models.includes(lensKey)) {
-      return { type: "model", key: lensKey, label: `Model: ${lensKey}` };
-    }
-    const fallback = models[0] || null;
-    if (fallback) return { type: "model", key: fallback, label: `Model: ${fallback}` };
-    return { type: "overall", key: null, label: "Overall" };
-  }
-  if (lensType === "valuator") {
-    if (lensKey && valuators.includes(lensKey)) {
-      return { type: "valuator", key: lensKey, label: `Valuator: ${lensKey}` };
-    }
-    const fallback = valuators[0] || null;
-    if (fallback) return { type: "valuator", key: fallback, label: `Valuator: ${fallback}` };
-    return { type: "overall", key: null, label: "Overall" };
-  }
-  return { type: "overall", key: null, label: "Overall" };
-}
-
-function resolveLensMetricsForTicker(
-  prepared: PreparedTicker,
-  lens: LensSelection,
-): { target: number | null; allocation: number | null } | null {
-  const summary = prepared.summary;
-  if (lens.type === "overall") {
-    return {
-      target: safeNumOrNull(summary.overview.mean_target_price),
-      allocation:
-        typeof summary.overview.mean_allocation_pct === "number" && Number.isFinite(summary.overview.mean_allocation_pct)
-          ? summary.overview.mean_allocation_pct
-          : null,
-    };
-  }
-  if (!lens.key) return null;
-  const pool = lens.type === "model" ? summary.by_model : summary.by_valuator;
-  const row = pool.find((entry) => String(entry.label || "").trim() === lens.key);
-  if (!row) return null;
-  return {
-    target: safeNumOrNull(row.mean_target_price),
-    allocation:
-      typeof row.mean_allocation_pct === "number" && Number.isFinite(row.mean_allocation_pct)
-        ? row.mean_allocation_pct
-        : null,
-  };
-}
-
-async function loadDashboards(): Promise<
-  Array<{ ticker: string; payload: DashboardPayload; updatedAt: string; sourceLabel: string }>
-> {
-  const merged = new Map<string, { ticker: string; payload: DashboardPayload; updatedAt: string; sourceLabel: string }>();
+async function loadDashboards(): Promise<LoadedDashboard[]> {
+  const merged = new Map<string, LoadedDashboard>();
   const deletedFilter = await getDeletedReportFilter();
   const dbEnabled = isDbEnabled();
 
   try {
     const dbRows = await listAllDashboardsForHitRate();
-    for (const r of dbRows) {
-      const row = {
-        ticker: String(r.ticker).toUpperCase(),
-        payload: r.dashboard as DashboardPayload,
-        updatedAt: new Date(r.generated_at).toISOString(),
-        sourceLabel: r.ticker,
+    for (const record of dbRows) {
+      const ticker = String(record.ticker || "").trim().toUpperCase();
+      if (!ticker || isExcludedTicker(ticker)) continue;
+      const row: LoadedDashboard = {
+        ticker,
+        payload: record.dashboard as DashboardPayload,
+        updatedAt: new Date(record.generated_at).toISOString(),
+        reportId: String(record.id || "").trim() || undefined,
       };
-      if (isExcludedTicker(row.ticker)) continue;
-      const runId = String(r.source_run_id || "").trim();
-      const key = runId ? `run:${row.ticker}:${runId}` : `db:${row.ticker}:${row.updatedAt}`;
+      const runId = String(record.source_run_id || "").trim();
+      const key = runId ? `run:${ticker}:${runId}` : `db:${ticker}:${row.updatedAt}`;
       merged.set(key, row);
     }
     if (dbEnabled) {
-      return Array.from(merged.values()).sort(
-        (a, b) => Date.parse(String(b.updatedAt || "")) - Date.parse(String(a.updatedAt || "")),
-      );
+      return Array.from(merged.values()).sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt));
     }
-  } catch (err) {
-    console.warn("[discovery] DB read failed:", err);
+  } catch (error) {
+    console.warn("[discovery] DB read failed:", error);
   }
 
   for (const entry of listDashboardReports()) {
     const payload = readJson<DashboardPayload>(entry.path);
     if (!payload) continue;
-    const ticker = String(payload.ticker || entry.ticker || "").toUpperCase();
+    const ticker = String(payload.ticker || entry.ticker || "").trim().toUpperCase();
     if (!ticker || isExcludedTicker(ticker)) continue;
     const updatedAt =
       typeof payload.generated_at === "string" && payload.generated_at.trim()
         ? payload.generated_at
         : new Date(entry.mtimeMs).toISOString();
-    const row = {
-      ticker,
-      payload,
-      updatedAt,
-      sourceLabel: entry.path,
-    };
+    const row: LoadedDashboard = { ticker, payload, updatedAt, reportId: entry.report_id || undefined };
     const runId = siteRunIdFromPathLike(entry.path);
     const key = runId ? `run:${ticker}:${runId}` : `file:${entry.path}`;
-    if (deletedFilter.isDeleted(entry.report_id, ticker, runId)) continue;
-    if (merged.has(key)) continue;
+    if (deletedFilter.isDeleted(entry.report_id, ticker, runId) || merged.has(key)) continue;
     merged.set(key, row);
   }
 
-  return Array.from(merged.values()).sort(
-    (a, b) => Date.parse(String(b.updatedAt || "")) - Date.parse(String(a.updatedAt || "")),
-  );
+  return Array.from(merged.values()).sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt));
 }
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
-  const requestedLensType = normalizeLensType(url.searchParams.get("lens_type"));
-  const requestedLensKey = cleanLensKey(url.searchParams.get("lens_key"));
+  const requestedType = normalizeDiscoveryLensType(url.searchParams.get("lens_type"));
+  const requestedKey = String(url.searchParams.get("lens_key") || "").trim() || null;
+  const asOfMs = Date.now();
   const items = await loadDashboards();
-
-  const rows: DiscoveryRow[] = [];
-  const byTicker = new Map<string, SummarySourceReport[]>();
-  for (const item of items) {
-    const ticker = String(item.ticker || "").toUpperCase();
-    if (!ticker || isExcludedTicker(ticker)) continue;
-    if (!byTicker.has(ticker)) {
-      byTicker.set(ticker, []);
-    }
-    byTicker.get(ticker)!.push({
-      ticker,
-      generatedAt: item.updatedAt,
-      payload: item.payload,
-    });
-  }
-
-  const tickers = Array.from(byTicker.keys());
-  const livePriceMap = await getLiveCurrentPricesBatch(tickers);
-  const availableModelsSet = new Set<string>();
-  const availableValuatorsSet = new Set<string>();
-  const preparedTickers: PreparedTicker[] = [];
-
-  for (const ticker of tickers) {
-    const sourceReports = byTicker.get(ticker) || [];
-    const windowReports = filterReportsByWindow(sourceReports, "3m");
-    if (!windowReports.length) continue;
-
-    const summary = computeTickerSummaryAggregation(sourceReports, "3m");
-    const liveCurrent = safeNumOrNull(livePriceMap[ticker]);
-    const fallbackCurrent = meanCurrentPriceInWindow(windowReports);
-    const current = typeof liveCurrent === "number" && liveCurrent > 0 ? liveCurrent : fallbackCurrent;
-    const latestWindowReport = windowReports
-      .slice()
-      .sort((a, b) => reportMs(b.generatedAt) - reportMs(a.generatedAt))[0];
-
-    for (const row of summary.by_model) {
-      const label = String(row.label || "").trim();
-      if (label && label.toLowerCase() !== "overall") {
-        availableModelsSet.add(label);
-      }
-    }
-    for (const row of summary.by_valuator) {
-      const label = String(row.label || "").trim();
-      if (label) availableValuatorsSet.add(label);
-    }
-
-    if (!current) continue;
-    preparedTickers.push({
-      ticker,
-      summary,
-      current,
-      latestUpdatedAt: latestWindowReport?.generatedAt || new Date().toISOString(),
-      companyName:
-        latestWindowReport?.payload?.header?.company_name ||
-        ticker ||
-        path.basename(String(ticker)),
-    });
-  }
-
-  const availableModels = Array.from(availableModelsSet).sort((a, b) => a.localeCompare(b));
-  const availableValuators = Array.from(availableValuatorsSet).sort((a, b) => a.localeCompare(b));
-  const lens = resolveLensSelection(requestedLensType, requestedLensKey, availableModels, availableValuators);
-
-  for (const prepared of preparedTickers) {
-    const metrics = resolveLensMetricsForTicker(prepared, lens);
-    if (!metrics) continue;
-    const meanTarget = safeNum(metrics.target);
-    if (!meanTarget) continue;
-
-    const returnPct = ((meanTarget - prepared.current) / prepared.current) * 100;
-    const overvaluation = ((prepared.current - meanTarget) / prepared.current) * 100;
-    const confidenceCv =
-      typeof prepared.summary.overview.mean_disagreement_score === "number" &&
-      Number.isFinite(prepared.summary.overview.mean_disagreement_score)
-        ? Math.abs(prepared.summary.overview.mean_disagreement_score)
-        : Number.POSITIVE_INFINITY;
-    const positionPct = metrics.allocation;
-    const baseScore = combinedScore(positionPct, returnPct);
-    const misalignedSignal =
-      typeof positionPct === "number" &&
-      Number.isFinite(positionPct) &&
-      typeof returnPct === "number" &&
-      Number.isFinite(returnPct) &&
-      Math.abs(positionPct) > 1e-9 &&
-      Math.abs(returnPct) > 1e-9 &&
-      (positionPct * returnPct) < 0;
-    const penalizedCv = Number.isFinite(confidenceCv) ? (misalignedSignal ? confidenceCv * 1.5 : confidenceCv) : null;
-    const adjustedScore = confidenceAdjustedScore(baseScore, penalizedCv);
-    rows.push({
-      ticker: prepared.ticker,
-      company_name: prepared.companyName,
-      margin_safety_pct: returnPct,
-      overvaluation_pct: overvaluation,
-      dispersion: confidenceCv,
-      return_pct: returnPct,
-      investment_allocation_pct: positionPct,
-      confidence_cv: confidenceCv,
-      points_score: typeof adjustedScore === "number" && Number.isFinite(adjustedScore) ? adjustedScore : null,
-      updated_at: prepared.latestUpdatedAt,
-    });
-  }
-
-  const topUndervalued = [...rows]
-    .filter((row) => row.return_pct > 0)
-    .sort((a, b) => b.return_pct - a.return_pct)
-    .slice(0, 20);
-
-  const topOvervalued = [...rows]
-    .filter((row) => row.return_pct < 0)
-    .sort((a, b) => a.return_pct - b.return_pct)
-    .slice(0, 20);
-
-  const topConviction = [...rows]
-    .sort((a, b) => a.confidence_cv - b.confidence_cv)
-    .slice(0, 20);
-
-  const topHighestAllocation = [...rows]
-    .filter(
-      (row) =>
-        typeof row.investment_allocation_pct === "number" &&
-        Number.isFinite(row.investment_allocation_pct) &&
-        Number(row.investment_allocation_pct) > 0,
-    )
-    .sort((a, b) => Number(b.investment_allocation_pct) - Number(a.investment_allocation_pct))
-    .slice(0, 20);
-
-  const topLowestAllocation = [...rows]
-    .filter(
-      (row) =>
-        typeof row.investment_allocation_pct === "number" &&
-        Number.isFinite(row.investment_allocation_pct) &&
-        Number(row.investment_allocation_pct) < 0,
-    )
-    .sort((a, b) => Number(a.investment_allocation_pct) - Number(b.investment_allocation_pct))
-    .slice(0, 20);
-
-  const topScores = [...rows]
-    .filter(
-      (row) =>
-        typeof row.points_score === "number" &&
-        Number.isFinite(row.points_score) &&
-        Number(row.points_score) > 0,
-    )
-    .sort((a, b) => Number(b.points_score) - Number(a.points_score))
-    .slice(0, 20);
-
-  const lowestScores = [...rows]
-    .filter(
-      (row) =>
-        typeof row.points_score === "number" &&
-        Number.isFinite(row.points_score) &&
-        Number(row.points_score) < 0,
-    )
-    .sort((a, b) => Number(a.points_score) - Number(b.points_score))
-    .slice(0, 20);
+  const reports: DiscoverySourceReport[] = items.map((item) => ({
+    ticker: item.ticker,
+    generatedAt: item.updatedAt,
+    payload: item.payload,
+    reportId: item.reportId,
+  }));
+  const tickers = Array.from(new Set(reports.map((report) => report.ticker)));
+  const livePrices = await getLiveCurrentPricesBatch(tickers);
+  const priceByTicker = new Map<string, number | null>(
+    tickers.map((ticker) => {
+      const price = Number(livePrices[ticker]);
+      return [ticker, Number.isFinite(price) ? price : null];
+    }),
+  );
+  const universe = prepareDiscoveryUniverse({ reports, priceByTicker, asOfMs });
+  const lens = resolveDiscoveryLens(requestedType, requestedKey, universe.models, universe.valuators);
+  const ranked = rankDiscoveryRows(scoreDiscoveryCandidates(universe, lens));
 
   return NextResponse.json({
-    generated_at: new Date().toISOString(),
+    generated_at: new Date(asOfMs).toISOString(),
     lens,
-    lens_options: {
-      models: availableModels,
-      valuators: availableValuators,
-    },
+    lens_options: { models: universe.models, valuators: universe.valuators },
     window: "3m",
     window_hours: 24 * 90,
-    count: rows.length,
-    top_undervalued: topUndervalued,
-    top_overvalued: topOvervalued,
-    top_conviction: topConviction,
-    top_highest_allocation: topHighestAllocation,
-    top_lowest_allocation: topLowestAllocation,
-    top_scores: topScores,
-    lowest_scores: lowestScores,
-    // Backward-compatible aliases.
-    top_gems: topUndervalued,
-    bubbles: topOvervalued,
-    high_conviction: topConviction,
+    count: ranked.all.length,
+    top_undervalued: ranked.topUndervalued,
+    top_overvalued: ranked.topOvervalued,
+    top_conviction: ranked.topConviction,
+    top_highest_allocation: ranked.topHighestAllocation,
+    top_lowest_allocation: ranked.topLowestAllocation,
+    top_scores: ranked.topScores,
+    lowest_scores: ranked.lowestScores,
+    top_gems: ranked.topUndervalued,
+    bubbles: ranked.topOvervalued,
+    high_conviction: ranked.topConviction,
   });
 }

--- a/frontend/src/app/api/portfolio-performance/route.ts
+++ b/frontend/src/app/api/portfolio-performance/route.ts
@@ -1,0 +1,108 @@
+import { NextResponse } from "next/server";
+
+import { loadPortfolioNav, type StoredPortfolioNavPoint } from "@/lib/portfolio-db";
+import {
+  PORTFOLIO_BENCHMARK_SYMBOL,
+  PORTFOLIO_METHODOLOGY_VERSION,
+  PORTFOLIO_PROVIDER,
+  summarizePortfolioPeriod,
+  type PortfolioPeriod,
+  type PortfolioTrack,
+} from "@/lib/portfolio-performance-engine";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+const VALID_PERIODS = new Set<PortfolioPeriod>(["1m", "3m", "6m", "1y", "all"]);
+
+function parseTrack(value: string | null): PortfolioTrack {
+  return value === "backtest" ? "backtest" : "paper";
+}
+
+function parsePeriod(value: string | null): PortfolioPeriod {
+  const normalized = String(value || "all").toLowerCase() as PortfolioPeriod;
+  return VALID_PERIODS.has(normalized) ? normalized : "all";
+}
+
+function groupByLens(rows: StoredPortfolioNavPoint[]): StoredPortfolioNavPoint[][] {
+  const grouped = new Map<string, StoredPortfolioNavPoint[]>();
+  for (const row of rows) {
+    const key = `${row.lensType}:${row.lensKey}`;
+    if (!grouped.has(key)) grouped.set(key, []);
+    grouped.get(key)!.push(row);
+  }
+  return Array.from(grouped.values());
+}
+
+function summarizeLens(rows: StoredPortfolioNavPoint[], period: PortfolioPeriod) {
+  const sorted = rows.slice().sort((a, b) => a.date.localeCompare(b.date));
+  const summary = summarizePortfolioPeriod(sorted, period);
+  const latest = sorted[sorted.length - 1];
+  return {
+    lens_type: latest.lensType,
+    lens_key: latest.lensType === "overall" ? null : latest.lensKey,
+    label: latest.lensType === "overall" ? "Overall" : latest.lensLabel,
+    return_pct: summary.returnPct,
+    benchmark_return_pct: summary.benchmarkReturnPct,
+    excess_return_pct: summary.excessReturnPct,
+    holdings_count: latest.holdingsCount,
+    period_start: summary.periodStart,
+    period_end: summary.periodEnd,
+    status: summary.status,
+  };
+}
+
+function emptyResponse(track: PortfolioTrack, period: PortfolioPeriod, message?: string) {
+  return {
+    generated_at: new Date().toISOString(),
+    track,
+    period,
+    available: false,
+    message: message || "Portfolio performance history is not available yet.",
+    methodology: {
+      version: PORTFOLIO_METHODOLOGY_VERSION,
+      universe: "Analyzed tickers with a report available in the trailing 90 days",
+      construction: "Up to 20 positive-score stocks, equally weighted, rebalanced monthly",
+      score: "60% implied target return + 40% allocation, confidence-disagreement penalty applied",
+      base_currency: "USD",
+      return_type: "Gross simulated total return; no fees, slippage, tax, or cash interest",
+      benchmark_symbol: PORTFOLIO_BENCHMARK_SYMBOL,
+      benchmark_name: "S&P 500 Total Return",
+      market_data_provider: PORTFOLIO_PROVIDER,
+      public_beta: true,
+    },
+    range: { start: null, end: null },
+    by_model: [],
+    by_valuator: [],
+  };
+}
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const track = parseTrack(url.searchParams.get("track"));
+  const period = parsePeriod(url.searchParams.get("period"));
+  try {
+    const rows = await loadPortfolioNav(track, PORTFOLIO_METHODOLOGY_VERSION);
+    if (!rows.length) return NextResponse.json(emptyResponse(track, period));
+    const summaries = groupByLens(rows)
+      .map((group) => summarizeLens(group, period))
+      .sort((a, b) => {
+        if (a.lens_type === "overall") return -1;
+        if (b.lens_type === "overall") return 1;
+        return a.label.localeCompare(b.label);
+      });
+    const dates = rows.map((row) => row.date).sort();
+    return NextResponse.json({
+      ...emptyResponse(track, period),
+      available: true,
+      message: null,
+      range: { start: dates[0], end: dates[dates.length - 1] },
+      by_model: summaries.filter((row) => row.lens_type === "overall" || row.lens_type === "model"),
+      by_valuator: summaries.filter((row) => row.lens_type === "valuator"),
+    });
+  } catch (error) {
+    console.warn("[portfolio-performance] DB read failed:", error);
+    return NextResponse.json(emptyResponse(track, period));
+  }
+}

--- a/frontend/src/components/portfolio-returns-section.tsx
+++ b/frontend/src/components/portfolio-returns-section.tsx
@@ -91,7 +91,7 @@ function ReturnsTable({ title, rows }: { title: string; rows: PortfolioReturnRow
                 <Link href={rowHref(row)} className="font-semibold text-[color:var(--accent)] underline-offset-2 hover:underline">
                   {row.label}
                 </Link>
-                <p className="mt-1 text-xs text-[color:var(--text-muted)]">{statusLabel(row) || `${row.holdings_count} holdings`}</p>
+                <p className="mt-1 text-xs text-[color:var(--text-muted)]">{statusLabel(row) || `${row.holdings_count} latest holdings`}</p>
               </div>
               <p className={`text-xl font-bold tabular-nums ${returnTone(row.return_pct)}`}>{formatPercent(row.return_pct)}</p>
             </div>
@@ -111,7 +111,7 @@ function ReturnsTable({ title, rows }: { title: string; rows: PortfolioReturnRow
               <th className="px-3 py-2 text-right font-medium">Portfolio return</th>
               <th className="px-3 py-2 text-right font-medium">S&amp;P 500 TR</th>
               <th className="px-3 py-2 text-right font-medium">Excess</th>
-              <th className="px-3 py-2 text-right font-medium">Holdings</th>
+              <th className="px-3 py-2 text-right font-medium">Latest holdings</th>
               <th className="px-3 py-2 text-right font-medium">Start</th>
             </tr>
           </thead>
@@ -197,7 +197,7 @@ export function PortfolioReturnsSection() {
       ) : (
         <div className="mt-4 grid items-start gap-4 xl:grid-cols-2">
           <ReturnsTable title="Models" rows={data.by_model} />
-          <ReturnsTable title="Personas" rows={data.by_valuator} />
+          <ReturnsTable title="Valuators" rows={data.by_valuator} />
         </div>
       )}
 
@@ -205,7 +205,7 @@ export function PortfolioReturnsSection() {
         {track === "paper"
           ? "Paper records each portfolio from the day it is created, and its holdings are never rewritten later. "
           : "Backtest reconstructs what each portfolio would have held at earlier month-ends, using only information available at the time. "}
-        The 90-day rule is about report freshness, not the holding period: at each month-end, only stocks analyzed during the previous 90 days can enter the ranking. This is our recently analyzed universe, not the full S&amp;P 500. Returns are simulated before fees, taxes, slippage, or cash interest. Prices and FX come from yfinance; missing data is shown as unavailable.
+        The 90-day rule is about report freshness, not the holding period: at each month-end, only stocks analyzed during the previous 90 days can enter the ranking. This is our recently analyzed universe, not the full S&amp;P 500. Latest holdings is the count at the most recent frozen rebalance, so it can differ from today&apos;s live Discovery ranking. Returns are simulated before fees, taxes, slippage, or cash interest. Prices and FX come from yfinance; missing data is shown as unavailable.
       </p>
     </section>
   );

--- a/frontend/src/components/portfolio-returns-section.tsx
+++ b/frontend/src/components/portfolio-returns-section.tsx
@@ -55,10 +55,9 @@ function formatPercent(value: number | null): string {
 }
 
 function formatDate(value: string | null): string {
-  if (!value) return "N/A";
-  const date = new Date(`${value}T00:00:00Z`);
-  if (!Number.isFinite(date.getTime())) return "N/A";
-  return date.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "2-digit", timeZone: "UTC" });
+  if (!value || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return "N/A";
+  const [year, month, day] = value.split("-");
+  return `${day}/${month}/${year}`;
 }
 
 function returnTone(value: number | null): string {
@@ -203,8 +202,10 @@ export function PortfolioReturnsSection() {
       )}
 
       <p className="mt-4 text-xs leading-relaxed text-[color:var(--text-muted)]">
-        {track === "paper" ? "Forward Paper uses immutable portfolio snapshots from launch. " : "Reconstructed Backtest uses only reports and prices available at each historical cutoff. "}
-        Universe: analyzed tickers with reports in the trailing 90 days—not the full S&amp;P 500. Gross simulated total returns exclude fees, slippage, taxes, and cash interest. Adjusted prices and FX are sourced from yfinance for research/personal-use beta evaluation; missing or stale market data is never silently filled.
+        {track === "paper"
+          ? "Paper records each portfolio from the day it is created, and its holdings are never rewritten later. "
+          : "Backtest reconstructs what each portfolio would have held at earlier month-ends, using only information available at the time. "}
+        The 90-day rule is about report freshness, not the holding period: at each month-end, only stocks analyzed during the previous 90 days can enter the ranking. This is our recently analyzed universe, not the full S&amp;P 500. Returns are simulated before fees, taxes, slippage, or cash interest. Prices and FX come from yfinance; missing data is shown as unavailable.
       </p>
     </section>
   );

--- a/frontend/src/components/portfolio-returns-section.tsx
+++ b/frontend/src/components/portfolio-returns-section.tsx
@@ -79,12 +79,24 @@ function statusLabel(row: PortfolioReturnRow): string | null {
   return null;
 }
 
+function sortRowsByReturn(rows: PortfolioReturnRow[]): PortfolioReturnRow[] {
+  return rows.slice().sort((a, b) => {
+    const aReturn = typeof a.return_pct === "number" && Number.isFinite(a.return_pct) ? a.return_pct : null;
+    const bReturn = typeof b.return_pct === "number" && Number.isFinite(b.return_pct) ? b.return_pct : null;
+    if (aReturn === null && bReturn === null) return a.label.localeCompare(b.label);
+    if (aReturn === null) return 1;
+    if (bReturn === null) return -1;
+    return bReturn - aReturn || a.label.localeCompare(b.label);
+  });
+}
+
 function ReturnsTable({ title, rows }: { title: string; rows: PortfolioReturnRow[] }) {
+  const sortedRows = sortRowsByReturn(rows);
   return (
     <section className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
       <h3 className="mb-3 text-sm font-semibold uppercase tracking-[0.16em] text-[color:var(--text-secondary)]">{title}</h3>
       <div className="space-y-2 md:hidden">
-        {rows.map((row) => (
+        {sortedRows.map((row) => (
           <article key={`${row.lens_type}:${row.lens_key || "overall"}:mobile`} className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-3">
             <div className="flex items-start justify-between gap-3">
               <div>
@@ -116,7 +128,7 @@ function ReturnsTable({ title, rows }: { title: string; rows: PortfolioReturnRow
             </tr>
           </thead>
           <tbody>
-            {rows.map((row) => (
+            {sortedRows.map((row) => (
               <tr key={`${row.lens_type}:${row.lens_key || "overall"}`} className="border-b border-[color:var(--border-subtle)] last:border-b-0">
                 <td className="px-3 py-2">
                   <Link href={rowHref(row)} className="font-medium text-[color:var(--accent)] underline-offset-2 hover:underline">{row.label}</Link>

--- a/frontend/src/components/portfolio-returns-section.tsx
+++ b/frontend/src/components/portfolio-returns-section.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+type PortfolioTrack = "paper" | "backtest";
+type PortfolioPeriod = "1m" | "3m" | "6m" | "1y" | "all";
+type PortfolioStatus = "ok" | "insufficient_history" | "no_positions" | "stale_market_data";
+
+type PortfolioReturnRow = {
+  lens_type: "overall" | "model" | "valuator";
+  lens_key: string | null;
+  label: string;
+  return_pct: number | null;
+  benchmark_return_pct: number | null;
+  excess_return_pct: number | null;
+  holdings_count: number;
+  period_start: string | null;
+  period_end: string | null;
+  status: PortfolioStatus;
+};
+
+type PortfolioPerformancePayload = {
+  generated_at: string;
+  track: PortfolioTrack;
+  period: PortfolioPeriod;
+  available: boolean;
+  message: string | null;
+  methodology: {
+    version: string;
+    universe: string;
+    construction: string;
+    return_type: string;
+    benchmark_name: string;
+    market_data_provider: string;
+    public_beta: boolean;
+  };
+  range: { start: string | null; end: string | null };
+  by_model: PortfolioReturnRow[];
+  by_valuator: PortfolioReturnRow[];
+};
+
+const PERIODS: Array<{ value: PortfolioPeriod; label: string }> = [
+  { value: "all", label: "Since Inception" },
+  { value: "1m", label: "1M" },
+  { value: "3m", label: "3M" },
+  { value: "6m", label: "6M" },
+  { value: "1y", label: "1Y" },
+];
+
+function formatPercent(value: number | null): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) return "N/A";
+  const sign = value > 0 ? "+" : "";
+  return `${sign}${value.toFixed(2)}%`;
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return "N/A";
+  const date = new Date(`${value}T00:00:00Z`);
+  if (!Number.isFinite(date.getTime())) return "N/A";
+  return date.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "2-digit", timeZone: "UTC" });
+}
+
+function returnTone(value: number | null): string {
+  if (typeof value !== "number" || !Number.isFinite(value) || Math.abs(value) < 0.005) {
+    return "text-[color:var(--text-primary)]";
+  }
+  return value > 0 ? "text-[color:var(--success)]" : "text-[color:var(--danger)]";
+}
+
+function rowHref(row: PortfolioReturnRow): string {
+  if (row.lens_type === "overall") return "/discovery?lens_type=overall";
+  return `/discovery?lens_type=${row.lens_type}&lens_key=${encodeURIComponent(row.lens_key || row.label)}`;
+}
+
+function statusLabel(row: PortfolioReturnRow): string | null {
+  if (row.status === "insufficient_history") return "Full period unavailable";
+  if (row.status === "no_positions") return "No positive positions";
+  if (row.status === "stale_market_data") return "Market data incomplete";
+  return null;
+}
+
+function ReturnsTable({ title, rows }: { title: string; rows: PortfolioReturnRow[] }) {
+  return (
+    <section className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
+      <h3 className="mb-3 text-sm font-semibold uppercase tracking-[0.16em] text-[color:var(--text-secondary)]">{title}</h3>
+      <div className="space-y-2 md:hidden">
+        {rows.map((row) => (
+          <article key={`${row.lens_type}:${row.lens_key || "overall"}:mobile`} className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-3">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <Link href={rowHref(row)} className="font-semibold text-[color:var(--accent)] underline-offset-2 hover:underline">
+                  {row.label}
+                </Link>
+                <p className="mt-1 text-xs text-[color:var(--text-muted)]">{statusLabel(row) || `${row.holdings_count} holdings`}</p>
+              </div>
+              <p className={`text-xl font-bold tabular-nums ${returnTone(row.return_pct)}`}>{formatPercent(row.return_pct)}</p>
+            </div>
+            <dl className="mt-3 grid grid-cols-3 gap-2 text-xs">
+              <div><dt className="text-[color:var(--text-muted)]">S&amp;P 500 TR</dt><dd className="mt-1 tabular-nums text-[color:var(--text-primary)]">{formatPercent(row.benchmark_return_pct)}</dd></div>
+              <div><dt className="text-[color:var(--text-muted)]">Excess</dt><dd className={`mt-1 tabular-nums ${returnTone(row.excess_return_pct)}`}>{formatPercent(row.excess_return_pct)}</dd></div>
+              <div><dt className="text-[color:var(--text-muted)]">Start</dt><dd className="mt-1 text-[color:var(--text-primary)]">{formatDate(row.period_start)}</dd></div>
+            </dl>
+          </article>
+        ))}
+      </div>
+      <div className="hidden overflow-x-auto rounded-lg border border-[color:var(--border-subtle)] md:block">
+        <table className="w-full min-w-[780px] text-sm">
+          <thead className="bg-[color:var(--surface)] text-[color:var(--text-muted)]">
+            <tr className="border-b border-[color:var(--border-subtle)]">
+              <th className="px-3 py-2 text-left font-medium">Portfolio</th>
+              <th className="px-3 py-2 text-right font-medium">Portfolio return</th>
+              <th className="px-3 py-2 text-right font-medium">S&amp;P 500 TR</th>
+              <th className="px-3 py-2 text-right font-medium">Excess</th>
+              <th className="px-3 py-2 text-right font-medium">Holdings</th>
+              <th className="px-3 py-2 text-right font-medium">Start</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={`${row.lens_type}:${row.lens_key || "overall"}`} className="border-b border-[color:var(--border-subtle)] last:border-b-0">
+                <td className="px-3 py-2">
+                  <Link href={rowHref(row)} className="font-medium text-[color:var(--accent)] underline-offset-2 hover:underline">{row.label}</Link>
+                  {statusLabel(row) ? <p className="text-xs text-[color:var(--text-muted)]">{statusLabel(row)}</p> : null}
+                </td>
+                <td className={`px-3 py-2 text-right font-semibold tabular-nums ${returnTone(row.return_pct)}`}>{formatPercent(row.return_pct)}</td>
+                <td className="px-3 py-2 text-right tabular-nums text-[color:var(--text-primary)]">{formatPercent(row.benchmark_return_pct)}</td>
+                <td className={`px-3 py-2 text-right tabular-nums ${returnTone(row.excess_return_pct)}`}>{formatPercent(row.excess_return_pct)}</td>
+                <td className="px-3 py-2 text-right tabular-nums text-[color:var(--text-secondary)]">{row.holdings_count}</td>
+                <td className="px-3 py-2 text-right text-[color:var(--text-secondary)]">{formatDate(row.period_start)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {!rows.length ? <p className="text-sm text-[color:var(--text-muted)]">No portfolio history is available yet.</p> : null}
+    </section>
+  );
+}
+
+export function PortfolioReturnsSection() {
+  const [track, setTrack] = useState<PortfolioTrack>("paper");
+  const [period, setPeriod] = useState<PortfolioPeriod>("all");
+  const [data, setData] = useState<PortfolioPerformancePayload | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      try {
+        const response = await fetch(`/api/portfolio-performance?track=${track}&period=${period}`, { cache: "no-store" });
+        const payload = (await response.json()) as PortfolioPerformancePayload;
+        if (!cancelled) setData(payload);
+      } catch {
+        if (!cancelled) setData(null);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    load();
+    return () => { cancelled = true; };
+  }, [period, track]);
+
+  return (
+    <section className="mb-6 rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-overlay)] p-4 sm:p-5">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 className="font-display text-xl text-[color:var(--text-primary)]">Portfolio Returns</h2>
+            <span className="rounded-full border border-[color:var(--warning)] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--warning)]">Public Beta</span>
+          </div>
+          <p className="mt-1 max-w-3xl text-sm text-[color:var(--text-muted)]">Monthly Top 20 positive-score portfolios, equal weighted and measured in USD against the S&amp;P 500 Total Return Index.</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <div className="inline-flex rounded-lg border border-[color:var(--border-strong)] bg-[color:var(--surface)] p-1" aria-label="Portfolio track">
+            {(["paper", "backtest"] as const).map((value) => (
+              <button key={value} type="button" onClick={() => setTrack(value)} disabled={loading && track !== value} className={`rounded-md px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.12em] transition disabled:cursor-not-allowed disabled:text-[color:var(--text-disabled)] ${track === value ? "bg-[color:var(--accent)] text-[color:var(--text-on-accent)]" : "text-[color:var(--text-secondary)] hover:text-[color:var(--text-primary)]"}`}>
+                {value === "paper" ? "Paper" : "Backtest"}
+              </button>
+            ))}
+          </div>
+          <select aria-label="Return period" value={period} onChange={(event) => setPeriod(event.target.value as PortfolioPeriod)} disabled={loading} className="rounded-lg border border-[color:var(--border-strong)] bg-[color:var(--surface)] px-3 py-2 text-xs font-semibold text-[color:var(--text-primary)] disabled:cursor-not-allowed disabled:text-[color:var(--text-disabled)]">
+            {PERIODS.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+          </select>
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="mt-4 grid gap-3 lg:grid-cols-2">
+          <div className="h-40 animate-pulse rounded-xl bg-[color:var(--border-subtle)]" />
+          <div className="h-40 animate-pulse rounded-xl bg-[color:var(--border-subtle)]" />
+        </div>
+      ) : !data?.available ? (
+        <div className="mt-4 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4 text-sm text-[color:var(--text-muted)]">
+          {data?.message || "Portfolio performance history is not available yet."}
+        </div>
+      ) : (
+        <div className="mt-4 grid items-start gap-4 xl:grid-cols-2">
+          <ReturnsTable title="Models" rows={data.by_model} />
+          <ReturnsTable title="Personas" rows={data.by_valuator} />
+        </div>
+      )}
+
+      <p className="mt-4 text-xs leading-relaxed text-[color:var(--text-muted)]">
+        {track === "paper" ? "Forward Paper uses immutable portfolio snapshots from launch. " : "Reconstructed Backtest uses only reports and prices available at each historical cutoff. "}
+        Universe: analyzed tickers with reports in the trailing 90 days—not the full S&amp;P 500. Gross simulated total returns exclude fees, slippage, taxes, and cash interest. Adjusted prices and FX are sourced from yfinance for research/personal-use beta evaluation; missing or stale market data is never silently filled.
+      </p>
+    </section>
+  );
+}

--- a/frontend/src/components/portfolio-returns-section.tsx
+++ b/frontend/src/components/portfolio-returns-section.tsx
@@ -181,7 +181,7 @@ export function PortfolioReturnsSection() {
             <h2 className="font-display text-xl text-[color:var(--text-primary)]">Portfolio Returns</h2>
             <span className="rounded-full border border-[color:var(--warning)] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--warning)]">Public Beta</span>
           </div>
-          <p className="mt-1 max-w-3xl text-sm text-[color:var(--text-muted)]">Monthly Top 20 positive-score portfolios, equal weighted and measured in USD against the S&amp;P 500 Total Return Index.</p>
+          <p className="mt-1 max-w-3xl text-sm text-[color:var(--text-muted)]">Monthly Top 20 positive-score portfolios, equal weighted and measured in USD against the full S&amp;P 500 Total Return Index.</p>
         </div>
         <div className="flex flex-wrap gap-2">
           <div className="inline-flex rounded-lg border border-[color:var(--border-strong)] bg-[color:var(--surface)] p-1" aria-label="Portfolio track">
@@ -217,7 +217,7 @@ export function PortfolioReturnsSection() {
         {track === "paper"
           ? "Paper records each portfolio from the day it is created, and its holdings are never rewritten later. "
           : "Backtest reconstructs what each portfolio would have held at earlier month-ends, using only information available at the time. "}
-        The 90-day rule is about report freshness, not the holding period: at each month-end, only stocks analyzed during the previous 90 days can enter the ranking. This is our recently analyzed universe, not the full S&amp;P 500. Latest holdings is the count at the most recent frozen rebalance, so it can differ from today&apos;s live Discovery ranking. Returns are simulated before fees, taxes, slippage, or cash interest. Prices and FX come from yfinance; missing data is shown as unavailable.
+        Benchmark: every portfolio is compared with the full S&amp;P 500 Total Return Index, including reinvested dividends. Portfolio selection: only stocks we analyzed during the previous 90 days can enter our ranking. That limitation affects what we can select for our portfolios; it does not narrow the S&amp;P 500 benchmark. Latest holdings is the count at the most recent frozen rebalance, so it can differ from today&apos;s live Discovery ranking. Returns are simulated before fees, taxes, slippage, or cash interest. Prices and FX come from yfinance; missing data is shown as unavailable.
       </p>
     </section>
   );

--- a/frontend/src/components/shell/sidebar.tsx
+++ b/frontend/src/components/shell/sidebar.tsx
@@ -33,7 +33,7 @@ const GLOBAL_NAV: NavItem[] = [
   { href: "/compare", label: "Compare", icon: GitCompareArrows },
   { href: "/screeners", label: "Screeners", icon: ScanSearch },
   { href: "/discovery", label: "Discovery", icon: Compass },
-  { href: "/hit-rate", label: "Hit Rate", icon: Target },
+  { href: "/hit-rate", label: "Track Record", icon: Target },
 ];
 
 type SidebarProps = {

--- a/frontend/src/lib/discovery-engine.test.ts
+++ b/frontend/src/lib/discovery-engine.test.ts
@@ -1,0 +1,116 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { DashboardPayload } from "./dashboard-types";
+import {
+  prepareDiscoveryUniverse,
+  scoreDiscoveryCandidates,
+  selectPositiveTopN,
+  type DiscoverySourceReport,
+  type ScoredDiscoveryCandidate,
+} from "./discovery-engine";
+
+function payload(ticker: string, target: number, allocationPct: number): DashboardPayload {
+  return {
+    ticker,
+    header: { company_name: `${ticker} Corp` },
+    valuation_hub: {
+      consensus: { current_price: 100, mean_target_price: target, cv: 0 },
+      method_tabs: [{
+        name: "DCF",
+        target_price: target + 10,
+        investment_amount: 10_000,
+        key_metric_means: {},
+        outputs: [{
+          output_id: 1,
+          persona: "Warren Buffett",
+          target_price: target + 5,
+          investment_amount: 8_000,
+          key_numeric_values: [],
+          reason_sections: [],
+        }],
+      }],
+      method_blocks: [],
+      all_values: { metric_means: [], source_values: [] },
+    },
+    decision_card: {
+      action: "BUY",
+      position_size_pct_of_notional: allocationPct,
+      mean_investment_amount: allocationPct * 1_000,
+      rationale: "",
+    },
+    red_flag_shield: [],
+    analysis_matrix: {
+      executive_summary_markdown: "",
+      key_insights: [],
+      bull_insights: [],
+      red_flag_insights: [],
+      swot: { strengths: [], weaknesses: [], opportunities: [], threats: [] },
+    },
+    dream_team: [],
+    forecast_forensic_matrix: {
+      current_revenue: null,
+      target_revenue: null,
+      current_earnings: null,
+      target_earnings: null,
+      forensic_flags: [],
+    },
+    artifacts: {},
+  };
+}
+
+test("historical discovery excludes future reports and anchors the 90-day window to as-of", () => {
+  const asOfMs = Date.parse("2026-08-01T23:59:59Z");
+  const reports: DiscoverySourceReport[] = [
+    { ticker: "AAA", generatedAt: "2026-04-01T12:00:00Z", payload: payload("AAA", 110, 5), reportId: "old" },
+    { ticker: "AAA", generatedAt: "2026-07-01T12:00:00Z", payload: payload("AAA", 120, 10), reportId: "visible" },
+    { ticker: "AAA", generatedAt: "2026-08-02T00:00:00Z", payload: payload("AAA", 300, 50), reportId: "future" },
+  ];
+  const universe = prepareDiscoveryUniverse({
+    reports,
+    priceByTicker: new Map([["AAA", 100]]),
+    asOfMs,
+  });
+  assert.equal(universe.tickers.length, 1);
+  assert.equal(universe.tickers[0].summary.coverage.reports_in_window, 1);
+  assert.deepEqual(universe.tickers[0].sourceReportIds, ["visible"]);
+
+  const overall = scoreDiscoveryCandidates(universe, { type: "overall", key: null, label: "Overall" });
+  assert.equal(overall.length, 1);
+  assert.ok(Math.abs(Number(overall[0].row.points_score) - 16) < 1e-9);
+
+  assert.deepEqual(universe.models, ["Scenario DCF"]);
+  const model = scoreDiscoveryCandidates(universe, { type: "model", key: "Scenario DCF", label: "Scenario DCF" });
+  assert.ok(Math.abs(Number(model[0].row.points_score) - 22) < 1e-9);
+
+  const persona = scoreDiscoveryCandidates(universe, { type: "valuator", key: "Warren Buffett", label: "Warren Buffett" });
+  assert.ok(Math.abs(Number(persona[0].row.points_score) - 18.2) < 1e-9);
+});
+
+function candidate(ticker: string, score: number): ScoredDiscoveryCandidate {
+  return {
+    sourceReportIds: [],
+    row: {
+      ticker,
+      company_name: ticker,
+      margin_safety_pct: 0,
+      overvaluation_pct: 0,
+      dispersion: 0,
+      return_pct: 0,
+      investment_allocation_pct: 0,
+      confidence_cv: 0,
+      points_score: score,
+      updated_at: "2026-08-01T00:00:00Z",
+    },
+  };
+}
+
+test("Top N keeps only positive scores and uses ticker as a deterministic tie-breaker", () => {
+  const selected = selectPositiveTopN([
+    candidate("ZZZ", 5),
+    candidate("AAA", 5),
+    candidate("NEG", -1),
+    candidate("ZERO", 0),
+  ], 20);
+  assert.deepEqual(selected.map((item) => item.row.ticker), ["AAA", "ZZZ"]);
+});

--- a/frontend/src/lib/discovery-engine.ts
+++ b/frontend/src/lib/discovery-engine.ts
@@ -1,0 +1,289 @@
+import type { DiscoveryRow } from "@/lib/dashboard-types";
+import {
+  computeTickerSummaryAggregation,
+  filterReportsByWindow,
+  type SummarySourceReport,
+  type TickerSummaryAggregation,
+} from "@/lib/ticker-summary-aggregate";
+
+export type DiscoveryLensType = "overall" | "model" | "valuator";
+
+export type DiscoveryLensSelection = {
+  type: DiscoveryLensType;
+  key: string | null;
+  label: string;
+};
+
+export type DiscoverySourceReport = SummarySourceReport & {
+  reportId?: string;
+};
+
+export type PreparedDiscoveryTicker = {
+  ticker: string;
+  summary: TickerSummaryAggregation;
+  current: number;
+  latestUpdatedAt: string;
+  companyName: string;
+  sourceReportIds: string[];
+};
+
+export type PreparedDiscoveryUniverse = {
+  tickers: PreparedDiscoveryTicker[];
+  models: string[];
+  valuators: string[];
+  asOfMs: number;
+};
+
+export type ScoredDiscoveryCandidate = {
+  row: DiscoveryRow;
+  sourceReportIds: string[];
+};
+
+export type RankedDiscoveryRows = {
+  all: DiscoveryRow[];
+  topUndervalued: DiscoveryRow[];
+  topOvervalued: DiscoveryRow[];
+  topConviction: DiscoveryRow[];
+  topHighestAllocation: DiscoveryRow[];
+  topLowestAllocation: DiscoveryRow[];
+  topScores: DiscoveryRow[];
+  lowestScores: DiscoveryRow[];
+};
+
+function safeNum(value: unknown): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function safeNumOrNull(value: unknown): number | null {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function average(values: number[]): number {
+  if (!values.length) return 0;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function reportMs(value: string): number {
+  const parsed = Date.parse(String(value || ""));
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function meanCurrentPrice(reports: SummarySourceReport[]): number | null {
+  const values = reports
+    .map((report) => safeNumOrNull(report.payload.valuation_hub?.consensus?.current_price))
+    .filter((value): value is number => typeof value === "number" && Number.isFinite(value) && value > 0);
+  return values.length ? average(values) : null;
+}
+
+function combinedScore(investmentPct?: number | null, targetReturnPct?: number | null): number | null {
+  const hasInvestment = typeof investmentPct === "number" && Number.isFinite(investmentPct);
+  const hasTarget = typeof targetReturnPct === "number" && Number.isFinite(targetReturnPct);
+  if (!hasInvestment && !hasTarget) return null;
+  if (hasInvestment && hasTarget) return (0.4 * Number(investmentPct)) + (0.6 * Number(targetReturnPct));
+  return hasInvestment ? Number(investmentPct) : Number(targetReturnPct);
+}
+
+function confidenceAdjustedScore(baseScore?: number | null, overallCv?: number | null): number | null {
+  if (typeof baseScore !== "number" || !Number.isFinite(baseScore)) return null;
+  const cv = typeof overallCv === "number" && Number.isFinite(overallCv) ? Math.max(0, overallCv) : 0;
+  return baseScore / (1 + Math.pow(cv, 1.3));
+}
+
+function metricsForLens(
+  prepared: PreparedDiscoveryTicker,
+  lens: DiscoveryLensSelection,
+): { target: number | null; allocation: number | null } | null {
+  if (lens.type === "overall") {
+    return {
+      target: safeNumOrNull(prepared.summary.overview.mean_target_price),
+      allocation:
+        typeof prepared.summary.overview.mean_allocation_pct === "number" &&
+        Number.isFinite(prepared.summary.overview.mean_allocation_pct)
+          ? prepared.summary.overview.mean_allocation_pct
+          : null,
+    };
+  }
+  if (!lens.key) return null;
+  const pool = lens.type === "model" ? prepared.summary.by_model : prepared.summary.by_valuator;
+  const row = pool.find((entry) => String(entry.label || "").trim() === lens.key);
+  if (!row) return null;
+  return {
+    target: safeNumOrNull(row.mean_target_price),
+    allocation:
+      typeof row.mean_allocation_pct === "number" && Number.isFinite(row.mean_allocation_pct)
+        ? row.mean_allocation_pct
+        : null,
+  };
+}
+
+export function normalizeDiscoveryLensType(value: string | null | undefined): DiscoveryLensType {
+  const raw = String(value || "").trim().toLowerCase();
+  if (raw === "model" || raw === "valuator") return raw;
+  return "overall";
+}
+
+export function resolveDiscoveryLens(
+  lensType: DiscoveryLensType,
+  lensKey: string | null,
+  models: string[],
+  valuators: string[],
+): DiscoveryLensSelection {
+  if (lensType === "model") {
+    const selected = lensKey && models.includes(lensKey) ? lensKey : models[0] || null;
+    return selected
+      ? { type: "model", key: selected, label: `Model: ${selected}` }
+      : { type: "overall", key: null, label: "Overall" };
+  }
+  if (lensType === "valuator") {
+    const selected = lensKey && valuators.includes(lensKey) ? lensKey : valuators[0] || null;
+    return selected
+      ? { type: "valuator", key: selected, label: `Valuator: ${selected}` }
+      : { type: "overall", key: null, label: "Overall" };
+  }
+  return { type: "overall", key: null, label: "Overall" };
+}
+
+export function prepareDiscoveryUniverse(args: {
+  reports: DiscoverySourceReport[];
+  priceByTicker: Map<string, number | null>;
+  asOfMs: number;
+  window?: "3m";
+}): PreparedDiscoveryUniverse {
+  const window = args.window || "3m";
+  const byTicker = new Map<string, DiscoverySourceReport[]>();
+  for (const report of args.reports) {
+    const ticker = String(report.ticker || "").trim().toUpperCase();
+    if (!ticker || reportMs(report.generatedAt) > args.asOfMs) continue;
+    if (!byTicker.has(ticker)) byTicker.set(ticker, []);
+    byTicker.get(ticker)!.push({ ...report, ticker });
+  }
+
+  const models = new Set<string>();
+  const valuators = new Set<string>();
+  const tickers: PreparedDiscoveryTicker[] = [];
+
+  for (const [ticker, sourceReports] of byTicker.entries()) {
+    const windowReports = filterReportsByWindow(sourceReports, window, args.asOfMs);
+    if (!windowReports.length) continue;
+    const summary = computeTickerSummaryAggregation(sourceReports, window, args.asOfMs);
+    for (const row of summary.by_model) {
+      const label = String(row.label || "").trim();
+      if (label && label.toLowerCase() !== "overall") models.add(label);
+    }
+    for (const row of summary.by_valuator) {
+      const label = String(row.label || "").trim();
+      if (label) valuators.add(label);
+    }
+
+    const suppliedCurrent = safeNumOrNull(args.priceByTicker.get(ticker));
+    const fallbackCurrent = meanCurrentPrice(windowReports);
+    const current = suppliedCurrent && suppliedCurrent > 0 ? suppliedCurrent : fallbackCurrent;
+    if (!current) continue;
+
+    const latest = windowReports.slice().sort((a, b) => reportMs(b.generatedAt) - reportMs(a.generatedAt))[0];
+    tickers.push({
+      ticker,
+      summary,
+      current,
+      latestUpdatedAt: latest?.generatedAt || new Date(args.asOfMs).toISOString(),
+      companyName: latest?.payload?.header?.company_name || ticker,
+      sourceReportIds: Array.from(
+        new Set(windowReports.map((report) => String((report as DiscoverySourceReport).reportId || "").trim()).filter(Boolean)),
+      ),
+    });
+  }
+
+  return {
+    tickers,
+    models: Array.from(models).sort((a, b) => a.localeCompare(b)),
+    valuators: Array.from(valuators).sort((a, b) => a.localeCompare(b)),
+    asOfMs: args.asOfMs,
+  };
+}
+
+export function scoreDiscoveryCandidates(
+  universe: PreparedDiscoveryUniverse,
+  lens: DiscoveryLensSelection,
+): ScoredDiscoveryCandidate[] {
+  const candidates: ScoredDiscoveryCandidate[] = [];
+  for (const prepared of universe.tickers) {
+    const metrics = metricsForLens(prepared, lens);
+    if (!metrics) continue;
+    const meanTarget = safeNum(metrics.target);
+    if (!meanTarget) continue;
+    const returnPct = ((meanTarget - prepared.current) / prepared.current) * 100;
+    const confidenceCv = safeNumOrNull(prepared.summary.overview.mean_disagreement_score);
+    const positionPct = metrics.allocation;
+    const baseScore = combinedScore(positionPct, returnPct);
+    const misaligned =
+      typeof positionPct === "number" &&
+      Number.isFinite(positionPct) &&
+      Math.abs(positionPct) > 1e-9 &&
+      Math.abs(returnPct) > 1e-9 &&
+      positionPct * returnPct < 0;
+    const penalizedCv = confidenceCv === null ? null : misaligned ? Math.abs(confidenceCv) * 1.5 : Math.abs(confidenceCv);
+    const adjustedScore = confidenceAdjustedScore(baseScore, penalizedCv);
+    candidates.push({
+      row: {
+        ticker: prepared.ticker,
+        company_name: prepared.companyName,
+        margin_safety_pct: returnPct,
+        overvaluation_pct: ((prepared.current - meanTarget) / prepared.current) * 100,
+        dispersion: confidenceCv ?? Number.POSITIVE_INFINITY,
+        return_pct: returnPct,
+        investment_allocation_pct: positionPct,
+        confidence_cv: confidenceCv ?? Number.POSITIVE_INFINITY,
+        points_score: adjustedScore,
+        updated_at: prepared.latestUpdatedAt,
+      },
+      sourceReportIds: prepared.sourceReportIds,
+    });
+  }
+  return candidates;
+}
+
+export function selectPositiveTopN(
+  candidates: ScoredDiscoveryCandidate[],
+  limit: number = 20,
+): ScoredDiscoveryCandidate[] {
+  return candidates
+    .filter(({ row }) => typeof row.points_score === "number" && Number.isFinite(row.points_score) && Number(row.points_score) > 0)
+    .sort((a, b) => {
+      const scoreDiff = Number(b.row.points_score) - Number(a.row.points_score);
+      return Math.abs(scoreDiff) > 1e-12 ? scoreDiff : a.row.ticker.localeCompare(b.row.ticker);
+    })
+    .slice(0, Math.max(0, limit));
+}
+
+export function rankDiscoveryRows(candidates: ScoredDiscoveryCandidate[]): RankedDiscoveryRows {
+  const rows = candidates.map((candidate) => candidate.row);
+  return {
+    all: rows,
+    topUndervalued: rows.filter((row) => row.return_pct > 0).sort((a, b) => b.return_pct - a.return_pct).slice(0, 20),
+    topOvervalued: rows.filter((row) => row.return_pct < 0).sort((a, b) => a.return_pct - b.return_pct).slice(0, 20),
+    topConviction: [...rows].sort((a, b) => a.confidence_cv - b.confidence_cv).slice(0, 20),
+    topHighestAllocation: rows
+      .filter((row) => typeof row.investment_allocation_pct === "number" && Number(row.investment_allocation_pct) > 0)
+      .sort((a, b) => Number(b.investment_allocation_pct) - Number(a.investment_allocation_pct))
+      .slice(0, 20),
+    topLowestAllocation: rows
+      .filter((row) => typeof row.investment_allocation_pct === "number" && Number(row.investment_allocation_pct) < 0)
+      .sort((a, b) => Number(a.investment_allocation_pct) - Number(b.investment_allocation_pct))
+      .slice(0, 20),
+    topScores: selectPositiveTopN(candidates).map((candidate) => candidate.row),
+    lowestScores: rows
+      .filter((row) => typeof row.points_score === "number" && Number.isFinite(row.points_score) && Number(row.points_score) < 0)
+      .sort((a, b) => Number(a.points_score) - Number(b.points_score))
+      .slice(0, 20),
+  };
+}
+
+export function allDiscoveryLenses(universe: PreparedDiscoveryUniverse): DiscoveryLensSelection[] {
+  return [
+    { type: "overall", key: null, label: "Overall" },
+    ...universe.models.map((key) => ({ type: "model" as const, key, label: key })),
+    ...universe.valuators.map((key) => ({ type: "valuator" as const, key, label: key })),
+  ];
+}

--- a/frontend/src/lib/portfolio-db.ts
+++ b/frontend/src/lib/portfolio-db.ts
@@ -1,0 +1,397 @@
+import { randomUUID } from "node:crypto";
+
+import type { DashboardPayload } from "@/lib/dashboard-types";
+import { getSql } from "@/lib/db";
+import type {
+  MarketPricePoint,
+  PortfolioNavPoint,
+  PortfolioSnapshotDefinition,
+  PortfolioTrack,
+} from "@/lib/portfolio-performance-engine";
+
+export type PortfolioReportInput = {
+  id: string;
+  ticker: string;
+  generatedAt: string;
+  createdAt: string;
+  deletedAt: string | null;
+  sourceRunId: string | null;
+  currency: string;
+  dashboard: DashboardPayload;
+};
+
+export type StoredPortfolioNavPoint = PortfolioNavPoint & {
+  lensType: "overall" | "model" | "valuator";
+  lensKey: string;
+  lensLabel: string;
+  methodologyVersion: string;
+};
+
+type SnapshotRow = {
+  id: string;
+  track: PortfolioTrack;
+  lens_type: "overall" | "model" | "valuator";
+  lens_key: string;
+  lens_label: string;
+  cutoff_at: string;
+  execution_date: string;
+  methodology_version: string;
+  candidate_count: number;
+  status: "ready" | "no_positions";
+};
+
+type HoldingRow = {
+  snapshot_id: string;
+  rank: number;
+  ticker: string;
+  score: number;
+  weight: number;
+  currency: string;
+  source_report_ids: string[] | null;
+  entry_date: string;
+  entry_price_usd: number;
+};
+
+function requireSql() {
+  const sql = getSql();
+  if (!sql) throw new Error("DATABASE_URL is required for portfolio performance.");
+  return sql;
+}
+
+export async function acquirePortfolioRefreshLock(lockKey: string, owner: string): Promise<boolean> {
+  const sql = requireSql();
+  await sql`
+    DELETE FROM portfolio_refresh_locks
+     WHERE lock_key = ${lockKey}
+       AND acquired_at < now() - interval '2 hours';
+  `;
+  const rows = (await sql`
+    INSERT INTO portfolio_refresh_locks (lock_key, owner)
+    VALUES (${lockKey}, ${owner})
+    ON CONFLICT (lock_key) DO NOTHING
+    RETURNING lock_key;
+  `) as Array<{ lock_key: string }>;
+  return rows.length > 0;
+}
+
+export async function releasePortfolioRefreshLock(lockKey: string, owner: string): Promise<void> {
+  const sql = requireSql();
+  await sql`DELETE FROM portfolio_refresh_locks WHERE lock_key = ${lockKey} AND owner = ${owner};`;
+}
+
+export async function listPortfolioReportInputs(args: {
+  earliestGeneratedAt: string;
+  latestGeneratedAt: string;
+}): Promise<PortfolioReportInput[]> {
+  const sql = requireSql();
+  const rows = (await sql`
+    SELECT r.id::text AS id,
+           r.ticker,
+           r.generated_at::text AS generated_at,
+           r.created_at::text AS created_at,
+           r.deleted_at::text AS deleted_at,
+           r.source_run_id,
+           COALESCE(NULLIF(t.currency, ''), NULLIF(a.dashboard->'header'->>'currency', ''), 'USD') AS currency,
+           a.dashboard
+      FROM reports r
+      JOIN report_artifacts a ON a.report_id = r.id
+      JOIN tickers t ON t.symbol = r.ticker
+     WHERE r.generated_at >= ${args.earliestGeneratedAt}::timestamptz
+       AND r.generated_at <= ${args.latestGeneratedAt}::timestamptz
+     ORDER BY r.generated_at;
+  `) as Array<{
+    id: string;
+    ticker: string;
+    generated_at: string;
+    created_at: string;
+    deleted_at: string | null;
+    source_run_id: string | null;
+    currency: string;
+    dashboard: DashboardPayload;
+  }>;
+  return rows.map((row) => ({
+    id: row.id,
+    ticker: String(row.ticker || "").toUpperCase(),
+    generatedAt: new Date(row.generated_at).toISOString(),
+    createdAt: new Date(row.created_at).toISOString(),
+    deletedAt: row.deleted_at ? new Date(row.deleted_at).toISOString() : null,
+    sourceRunId: row.source_run_id,
+    currency: String(row.currency || "USD").toUpperCase(),
+    dashboard: row.dashboard,
+  }));
+}
+
+export async function upsertMarketPrices(points: MarketPricePoint[], source: string): Promise<void> {
+  const sql = requireSql();
+  const chunkSize = 100;
+  for (let index = 0; index < points.length; index += chunkSize) {
+    const chunk = points.slice(index, index + chunkSize);
+    await sql.transaction((tx) =>
+      chunk.map((point) => tx`
+        INSERT INTO market_prices_daily (
+          symbol, price_date, adjusted_close_local, currency,
+          fx_to_usd, adjusted_close_usd, source, fetched_at
+        ) VALUES (
+          ${point.symbol}, ${point.date}::date, ${point.adjustedCloseLocal}, ${point.currency},
+          ${point.fxToUsd}, ${point.adjustedCloseUsd}, ${source}, now()
+        )
+        ON CONFLICT (symbol, price_date, source) DO UPDATE SET
+          adjusted_close_local = EXCLUDED.adjusted_close_local,
+          currency = EXCLUDED.currency,
+          fx_to_usd = EXCLUDED.fx_to_usd,
+          adjusted_close_usd = EXCLUDED.adjusted_close_usd,
+          fetched_at = now();
+      `),
+    );
+  }
+}
+
+export async function loadMarketPrices(args: {
+  symbols: string[];
+  startDate: string;
+  endDate: string;
+  source: string;
+}): Promise<Map<string, MarketPricePoint[]>> {
+  if (!args.symbols.length) return new Map();
+  const sql = requireSql();
+  const rows = (await sql`
+    SELECT symbol, price_date::text AS price_date,
+           adjusted_close_local::float8 AS adjusted_close_local,
+           currency,
+           fx_to_usd::float8 AS fx_to_usd,
+           adjusted_close_usd::float8 AS adjusted_close_usd
+      FROM market_prices_daily
+     WHERE symbol = ANY(${args.symbols}::text[])
+       AND price_date BETWEEN ${args.startDate}::date AND ${args.endDate}::date
+       AND source = ${args.source}
+     ORDER BY symbol, price_date;
+  `) as Array<{
+    symbol: string;
+    price_date: string;
+    adjusted_close_local: number;
+    currency: string;
+    fx_to_usd: number;
+    adjusted_close_usd: number;
+  }>;
+  const grouped = new Map<string, MarketPricePoint[]>();
+  for (const row of rows) {
+    if (!grouped.has(row.symbol)) grouped.set(row.symbol, []);
+    grouped.get(row.symbol)!.push({
+      symbol: row.symbol,
+      date: row.price_date,
+      adjustedCloseLocal: Number(row.adjusted_close_local),
+      currency: row.currency,
+      fxToUsd: Number(row.fx_to_usd),
+      adjustedCloseUsd: Number(row.adjusted_close_usd),
+    });
+  }
+  return grouped;
+}
+
+export async function insertPortfolioSnapshot(
+  snapshot: Omit<PortfolioSnapshotDefinition, "id">,
+): Promise<PortfolioSnapshotDefinition> {
+  const sql = requireSql();
+  const lensKey = snapshot.lens.key || "overall";
+  const existing = (await sql`
+    SELECT id::text AS id
+      FROM portfolio_snapshots
+     WHERE track = ${snapshot.track}
+       AND lens_type = ${snapshot.lens.type}
+       AND lens_key = ${lensKey}
+       AND cutoff_at = ${snapshot.cutoffAt}::timestamptz
+       AND methodology_version = ${snapshot.methodologyVersion}
+     LIMIT 1;
+  `) as Array<{ id: string }>;
+  if (existing[0]) {
+    const loaded = await loadPortfolioSnapshots(snapshot.track, snapshot.methodologyVersion);
+    const found = loaded.find((row) => row.id === existing[0].id);
+    if (!found) throw new Error(`Portfolio snapshot ${existing[0].id} exists but could not be loaded.`);
+    return found;
+  }
+
+  const id = randomUUID();
+  const status = snapshot.holdings.length ? "ready" : "no_positions";
+  const cashWeight = snapshot.holdings.length ? 0 : 1;
+  await sql.transaction((tx) => [
+    tx`
+      INSERT INTO portfolio_snapshots (
+        id, track, lens_type, lens_key, lens_label, cutoff_at, execution_date,
+        methodology_version, candidate_count, selected_count, cash_weight, status
+      ) VALUES (
+        ${id}::uuid, ${snapshot.track}, ${snapshot.lens.type}, ${lensKey}, ${snapshot.lens.label},
+        ${snapshot.cutoffAt}::timestamptz, ${snapshot.executionDate}::date,
+        ${snapshot.methodologyVersion}, ${snapshot.candidateCount}, ${snapshot.holdings.length},
+        ${cashWeight}, ${status}
+      );
+    `,
+    ...snapshot.holdings.map((holding) => tx`
+      INSERT INTO portfolio_holdings (
+        snapshot_id, rank, ticker, score, weight, currency,
+        source_report_ids, entry_date, entry_price_usd
+      ) VALUES (
+        ${id}::uuid, ${holding.rank}, ${holding.ticker}, ${holding.score}, ${holding.weight},
+        ${holding.currency}, ${holding.sourceReportIds}::uuid[], ${holding.entryDate}::date,
+        ${holding.entryPriceUsd}
+      );
+    `),
+  ]);
+  return { ...snapshot, id, status };
+}
+
+export async function loadPortfolioSnapshots(
+  track: PortfolioTrack,
+  methodologyVersion: string,
+): Promise<PortfolioSnapshotDefinition[]> {
+  const sql = requireSql();
+  const snapshotRows = (await sql`
+    SELECT id::text AS id, track, lens_type, lens_key, lens_label,
+           cutoff_at::text AS cutoff_at, execution_date::text AS execution_date,
+           methodology_version, candidate_count, status
+      FROM portfolio_snapshots
+     WHERE track = ${track}
+       AND methodology_version = ${methodologyVersion}
+       AND status IN ('ready', 'no_positions')
+     ORDER BY execution_date, lens_type, lens_key;
+  `) as SnapshotRow[];
+  if (!snapshotRows.length) return [];
+  const ids = snapshotRows.map((row) => row.id);
+  const holdingRows = (await sql`
+    SELECT snapshot_id::text AS snapshot_id, rank, ticker,
+           score::float8 AS score, weight::float8 AS weight, currency,
+           source_report_ids::text[] AS source_report_ids,
+           entry_date::text AS entry_date,
+           entry_price_usd::float8 AS entry_price_usd
+      FROM portfolio_holdings
+     WHERE snapshot_id = ANY(${ids}::uuid[])
+     ORDER BY snapshot_id, rank;
+  `) as HoldingRow[];
+  const bySnapshot = new Map<string, HoldingRow[]>();
+  for (const holding of holdingRows) {
+    if (!bySnapshot.has(holding.snapshot_id)) bySnapshot.set(holding.snapshot_id, []);
+    bySnapshot.get(holding.snapshot_id)!.push(holding);
+  }
+  return snapshotRows.map((row) => ({
+    id: row.id,
+    track: row.track,
+    lens: {
+      type: row.lens_type,
+      key: row.lens_type === "overall" ? null : row.lens_key,
+      label: row.lens_label,
+    },
+    cutoffAt: new Date(row.cutoff_at).toISOString(),
+    executionDate: row.execution_date,
+    methodologyVersion: row.methodology_version,
+    candidateCount: Number(row.candidate_count),
+    status: row.status,
+    holdings: (bySnapshot.get(row.id) || []).map((holding) => ({
+      rank: Number(holding.rank),
+      ticker: holding.ticker,
+      score: Number(holding.score),
+      weight: Number(holding.weight),
+      currency: holding.currency,
+      sourceReportIds: holding.source_report_ids || [],
+      entryDate: holding.entry_date,
+      entryPriceUsd: Number(holding.entry_price_usd),
+    })),
+  }));
+}
+
+export async function deletePortfolioTrack(
+  track: PortfolioTrack,
+  methodologyVersion: string,
+): Promise<void> {
+  if (track !== "backtest") throw new Error("Paper portfolio snapshots are immutable and cannot be deleted.");
+  const sql = requireSql();
+  await sql.transaction((tx) => [
+    tx`
+      DELETE FROM portfolio_nav_daily
+       WHERE track = ${track} AND methodology_version = ${methodologyVersion};
+    `,
+    tx`
+      DELETE FROM portfolio_snapshots
+       WHERE track = ${track} AND methodology_version = ${methodologyVersion};
+    `,
+  ]);
+}
+
+export async function upsertPortfolioNav(args: {
+  track: PortfolioTrack;
+  lensType: "overall" | "model" | "valuator";
+  lensKey: string;
+  methodologyVersion: string;
+  points: PortfolioNavPoint[];
+}): Promise<void> {
+  if (!args.points.length) return;
+  const sql = requireSql();
+  const chunkSize = 100;
+  for (let index = 0; index < args.points.length; index += chunkSize) {
+    const chunk = args.points.slice(index, index + chunkSize);
+    await sql.transaction((tx) =>
+      chunk.map((point) => tx`
+        INSERT INTO portfolio_nav_daily (
+          track, lens_type, lens_key, methodology_version, nav_date,
+          snapshot_id, nav, benchmark_nav, holdings_count, status, updated_at
+        ) VALUES (
+          ${args.track}, ${args.lensType}, ${args.lensKey}, ${args.methodologyVersion},
+          ${point.date}::date, ${point.snapshotId}::uuid, ${point.nav}, ${point.benchmarkNav},
+          ${point.holdingsCount}, ${point.status}, now()
+        )
+        ON CONFLICT (track, lens_type, lens_key, methodology_version, nav_date) DO UPDATE SET
+          snapshot_id = EXCLUDED.snapshot_id,
+          nav = EXCLUDED.nav,
+          benchmark_nav = EXCLUDED.benchmark_nav,
+          holdings_count = EXCLUDED.holdings_count,
+          status = EXCLUDED.status,
+          updated_at = now();
+      `),
+    );
+  }
+}
+
+export async function loadPortfolioNav(
+  track: PortfolioTrack,
+  methodologyVersion: string,
+): Promise<StoredPortfolioNavPoint[]> {
+  const sql = requireSql();
+  const rows = (await sql`
+    SELECT n.lens_type,
+           n.lens_key,
+           COALESCE(s.lens_label, n.lens_key) AS lens_label,
+           n.methodology_version,
+           n.nav_date::text AS nav_date,
+           n.snapshot_id::text AS snapshot_id,
+           n.nav::float8 AS nav,
+           n.benchmark_nav::float8 AS benchmark_nav,
+           n.holdings_count,
+           n.status
+      FROM portfolio_nav_daily n
+      LEFT JOIN portfolio_snapshots s ON s.id = n.snapshot_id
+     WHERE n.track = ${track}
+       AND n.methodology_version = ${methodologyVersion}
+     ORDER BY n.lens_type, n.lens_key, n.nav_date;
+  `) as Array<{
+    lens_type: "overall" | "model" | "valuator";
+    lens_key: string;
+    lens_label: string;
+    methodology_version: string;
+    nav_date: string;
+    snapshot_id: string;
+    nav: number;
+    benchmark_nav: number;
+    holdings_count: number;
+    status: PortfolioNavPoint["status"];
+  }>;
+  return rows.map((row) => ({
+    lensType: row.lens_type,
+    lensKey: row.lens_key,
+    lensLabel: row.lens_label,
+    methodologyVersion: row.methodology_version,
+    date: row.nav_date,
+    snapshotId: row.snapshot_id,
+    nav: Number(row.nav),
+    benchmarkNav: Number(row.benchmark_nav),
+    holdingsCount: Number(row.holdings_count),
+    status: row.status,
+  }));
+}

--- a/frontend/src/lib/portfolio-db.ts
+++ b/frontend/src/lib/portfolio-db.ts
@@ -84,22 +84,7 @@ export async function listPortfolioReportInputs(args: {
   latestGeneratedAt: string;
 }): Promise<PortfolioReportInput[]> {
   const sql = requireSql();
-  const rows = (await sql`
-    SELECT r.id::text AS id,
-           r.ticker,
-           r.generated_at::text AS generated_at,
-           r.created_at::text AS created_at,
-           r.deleted_at::text AS deleted_at,
-           r.source_run_id,
-           COALESCE(NULLIF(t.currency, ''), NULLIF(a.dashboard->'header'->>'currency', ''), 'USD') AS currency,
-           a.dashboard
-      FROM reports r
-      JOIN report_artifacts a ON a.report_id = r.id
-      JOIN tickers t ON t.symbol = r.ticker
-     WHERE r.generated_at >= ${args.earliestGeneratedAt}::timestamptz
-       AND r.generated_at <= ${args.latestGeneratedAt}::timestamptz
-     ORDER BY r.generated_at;
-  `) as Array<{
+  type ReportRow = {
     id: string;
     ticker: string;
     generated_at: string;
@@ -108,7 +93,31 @@ export async function listPortfolioReportInputs(args: {
     source_run_id: string | null;
     currency: string;
     dashboard: DashboardPayload;
-  }>;
+  };
+  const rows: ReportRow[] = [];
+  const pageSize = 20;
+  for (let offset = 0; ; offset += pageSize) {
+    const page = (await sql`
+      SELECT r.id::text AS id,
+             r.ticker,
+             r.generated_at::text AS generated_at,
+             r.created_at::text AS created_at,
+             r.deleted_at::text AS deleted_at,
+             r.source_run_id,
+             COALESCE(NULLIF(t.currency, ''), NULLIF(a.dashboard->'header'->>'currency', ''), 'USD') AS currency,
+             a.dashboard
+        FROM reports r
+        JOIN report_artifacts a ON a.report_id = r.id
+        JOIN tickers t ON t.symbol = r.ticker
+       WHERE r.generated_at >= ${args.earliestGeneratedAt}::timestamptz
+         AND r.generated_at <= ${args.latestGeneratedAt}::timestamptz
+       ORDER BY r.generated_at, r.id
+       LIMIT ${pageSize}
+      OFFSET ${offset};
+    `) as ReportRow[];
+    rows.push(...page);
+    if (page.length < pageSize) break;
+  }
   return rows.map((row) => ({
     id: row.id,
     ticker: String(row.ticker || "").toUpperCase(),

--- a/frontend/src/lib/portfolio-performance-engine.test.ts
+++ b/frontend/src/lib/portfolio-performance-engine.test.ts
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { ScoredDiscoveryCandidate } from "./discovery-engine";
+import {
+  buildHoldingsForSnapshot,
+  computePortfolioNavSeries,
+  firstBenchmarkDateAfter,
+  firstExecutionDateForCandidates,
+  summarizePortfolioPeriod,
+  type MarketPricePoint,
+  type PortfolioSnapshotDefinition,
+} from "./portfolio-performance-engine";
+
+function price(symbol: string, date: string, adjustedCloseUsd: number, currency = "USD"): MarketPricePoint {
+  return { symbol, date, adjustedCloseLocal: adjustedCloseUsd, currency, fxToUsd: 1, adjustedCloseUsd };
+}
+
+function candidate(ticker: string, score: number): ScoredDiscoveryCandidate {
+  return {
+    sourceReportIds: [],
+    row: {
+      ticker,
+      company_name: ticker,
+      margin_safety_pct: score,
+      overvaluation_pct: -score,
+      dispersion: 0,
+      return_pct: score,
+      investment_allocation_pct: score,
+      confidence_cv: 0,
+      points_score: score,
+      updated_at: "2026-05-01T00:00:00Z",
+    },
+  };
+}
+
+test("snapshot construction selects at most 20 positive names with equal 1/N weights", () => {
+  const candidates = Array.from({ length: 23 }, (_, index) => candidate(`T${String(index).padStart(2, "0")}`, 23 - index));
+  candidates.push(candidate("NEG", -1));
+  const priceBySymbol = new Map<string, MarketPricePoint[]>();
+  const currencyByTicker = new Map<string, string>();
+  for (const item of candidates) {
+    priceBySymbol.set(item.row.ticker, [price(item.row.ticker, "2026-05-04", 100)]);
+    currencyByTicker.set(item.row.ticker, "USD");
+  }
+  const holdings = buildHoldingsForSnapshot({ candidates, executionDate: "2026-05-04", priceBySymbol, currencyByTicker });
+  assert.equal(holdings.length, 20);
+  assert.ok(holdings.every((holding) => Math.abs(holding.weight - 0.05) < 1e-12));
+  assert.equal(holdings[0].ticker, "T00");
+  assert.equal(holdings[19].ticker, "T19");
+
+  const three = buildHoldingsForSnapshot({
+    candidates: candidates.slice(0, 3),
+    executionDate: "2026-05-04",
+    priceBySymbol,
+    currencyByTicker,
+  });
+  assert.equal(three.length, 3);
+  assert.ok(three.every((holding) => Math.abs(holding.weight - (1 / 3)) < 1e-12));
+
+  const cash = buildHoldingsForSnapshot({
+    candidates: [candidate("NEG", -1)],
+    executionDate: "2026-05-04",
+    priceBySymbol,
+    currencyByTicker,
+  });
+  assert.deepEqual(cash, []);
+});
+
+function snapshot(args: { id: string; executionDate: string; ticker: string; entryPrice: number }): PortfolioSnapshotDefinition {
+  return {
+    id: args.id,
+    track: "backtest",
+    lens: { type: "overall", key: null, label: "Overall" },
+    cutoffAt: `${args.executionDate}T00:00:00Z`,
+    executionDate: args.executionDate,
+    methodologyVersion: "test",
+    candidateCount: 1,
+    status: "ready",
+    holdings: [{
+      rank: 1,
+      ticker: args.ticker,
+      score: 1,
+      weight: 1,
+      currency: "USD",
+      sourceReportIds: [],
+      entryDate: args.executionDate,
+      entryPriceUsd: args.entryPrice,
+    }],
+  };
+}
+
+test("NAV starts flat at the execution close and rebalances only on the next snapshot date", () => {
+  const benchmark = [
+    price("^SP500TR", "2026-05-04", 200),
+    price("^SP500TR", "2026-05-05", 202),
+    price("^SP500TR", "2026-05-06", 204),
+    price("^SP500TR", "2026-05-07", 206),
+  ];
+  const prices = new Map<string, MarketPricePoint[]>([
+    ["AAA", [price("AAA", "2026-05-04", 100), price("AAA", "2026-05-05", 110), price("AAA", "2026-05-06", 121)]],
+    ["BBB", [price("BBB", "2026-05-06", 50), price("BBB", "2026-05-07", 55)]],
+  ]);
+  const nav = computePortfolioNavSeries({
+    snapshots: [
+      snapshot({ id: "s1", executionDate: "2026-05-04", ticker: "AAA", entryPrice: 100 }),
+      snapshot({ id: "s2", executionDate: "2026-05-06", ticker: "BBB", entryPrice: 50 }),
+    ],
+    priceBySymbol: prices,
+    benchmarkPoints: benchmark,
+  });
+  assert.equal(nav[0].nav, 100);
+  assert.ok(Math.abs(nav[1].nav - 110) < 1e-9);
+  assert.ok(Math.abs(nav[2].nav - 121) < 1e-9);
+  assert.equal(nav[2].snapshotId, "s2");
+  assert.ok(Math.abs(nav[3].nav - 133.1) < 1e-9);
+});
+
+test("benchmark execution is the first session after cutoff and stale points taint the period", () => {
+  const benchmark = [price("^SP500TR", "2026-05-01", 100), price("^SP500TR", "2026-05-04", 101)];
+  assert.equal(firstBenchmarkDateAfter(benchmark, "2026-05-01"), "2026-05-04");
+
+  const nav = computePortfolioNavSeries({
+    snapshots: [snapshot({ id: "s1", executionDate: "2026-05-01", ticker: "AAA", entryPrice: 100 })],
+    priceBySymbol: new Map([["AAA", [price("AAA", "2026-05-01", 100), price("AAA", "2026-05-08", 108)]]]),
+    benchmarkPoints: [
+      price("^SP500TR", "2026-05-01", 100),
+      price("^SP500TR", "2026-05-07", 101),
+      price("^SP500TR", "2026-05-08", 102),
+    ],
+  });
+  assert.equal(nav[1].status, "stale_market_data");
+  assert.equal(nav[2].status, "ok");
+  assert.equal(summarizePortfolioPeriod(nav, "all").status, "stale_market_data");
+  assert.equal(summarizePortfolioPeriod(nav, "3m").status, "insufficient_history");
+});
+
+test("execution waits for a common valid session across different market holidays", () => {
+  const candidates = [candidate("US", 10), candidate("IL", 9)];
+  const benchmark = [
+    price("^SP500TR", "2026-05-04", 100),
+    price("^SP500TR", "2026-05-05", 101),
+  ];
+  const executionDate = firstExecutionDateForCandidates({
+    candidates,
+    cutoffDate: "2026-05-01",
+    benchmarkPoints: benchmark,
+    priceBySymbol: new Map([
+      ["US", [price("US", "2026-05-04", 50), price("US", "2026-05-05", 51)]],
+      ["IL", [price("IL", "2026-05-05", 200, "ILS")]],
+    ]),
+  });
+  assert.equal(executionDate, "2026-05-05");
+});
+
+test("NAV recomputation uses one current adjusted-price basis after a split revision", () => {
+  const nav = computePortfolioNavSeries({
+    snapshots: [snapshot({ id: "s1", executionDate: "2026-05-04", ticker: "AAA", entryPrice: 100 })],
+    priceBySymbol: new Map([["AAA", [
+      price("AAA", "2026-05-04", 50),
+      price("AAA", "2026-05-05", 55),
+    ]]]),
+    benchmarkPoints: [
+      price("^SP500TR", "2026-05-04", 200),
+      price("^SP500TR", "2026-05-05", 202),
+    ],
+  });
+  assert.equal(nav[0].nav, 100);
+  assert.ok(Math.abs(nav[1].nav - 110) < 1e-9);
+});

--- a/frontend/src/lib/portfolio-performance-engine.ts
+++ b/frontend/src/lib/portfolio-performance-engine.ts
@@ -1,0 +1,293 @@
+import {
+  selectPositiveTopN,
+  type DiscoveryLensSelection,
+  type ScoredDiscoveryCandidate,
+} from "@/lib/discovery-engine";
+
+export const PORTFOLIO_METHODOLOGY_VERSION = "top20-positive-equal-v1";
+export const PORTFOLIO_BENCHMARK_SYMBOL = "^SP500TR";
+export const PORTFOLIO_PROVIDER = "yfinance";
+export const MAX_MARKET_DATA_AGE_DAYS = 5;
+
+export type PortfolioTrack = "backtest" | "paper";
+export type PortfolioPeriod = "1m" | "3m" | "6m" | "1y" | "all";
+export type PortfolioDataStatus = "ok" | "no_positions" | "stale_market_data";
+
+export type MarketPricePoint = {
+  symbol: string;
+  date: string;
+  adjustedCloseLocal: number;
+  currency: string;
+  fxToUsd: number;
+  adjustedCloseUsd: number;
+};
+
+export type PortfolioHoldingDefinition = {
+  rank: number;
+  ticker: string;
+  score: number;
+  weight: number;
+  currency: string;
+  sourceReportIds: string[];
+  entryDate: string;
+  entryPriceUsd: number;
+};
+
+export type PortfolioSnapshotDefinition = {
+  id: string;
+  track: PortfolioTrack;
+  lens: DiscoveryLensSelection;
+  cutoffAt: string;
+  executionDate: string;
+  methodologyVersion: string;
+  candidateCount: number;
+  status: "ready" | "no_positions";
+  holdings: PortfolioHoldingDefinition[];
+};
+
+export type PortfolioNavPoint = {
+  date: string;
+  snapshotId: string;
+  nav: number;
+  benchmarkNav: number;
+  holdingsCount: number;
+  status: PortfolioDataStatus;
+};
+
+export type PortfolioPeriodSummary = {
+  returnPct: number | null;
+  benchmarkReturnPct: number | null;
+  excessReturnPct: number | null;
+  periodStart: string | null;
+  periodEnd: string | null;
+  status: PortfolioDataStatus | "insufficient_history";
+};
+
+function dateMs(value: string): number {
+  const parsed = Date.parse(`${value}T00:00:00Z`);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function ageDays(later: string, earlier: string): number {
+  return Math.floor((dateMs(later) - dateMs(earlier)) / (24 * 60 * 60 * 1000));
+}
+
+export function latestPriceOnOrBefore(
+  points: MarketPricePoint[],
+  targetDate: string,
+  maxAgeDays: number = MAX_MARKET_DATA_AGE_DAYS,
+): MarketPricePoint | null {
+  const eligible = points
+    .filter((point) => point.date <= targetDate)
+    .sort((a, b) => b.date.localeCompare(a.date));
+  const selected = eligible[0] || null;
+  if (!selected || ageDays(targetDate, selected.date) > maxAgeDays) return null;
+  return selected;
+}
+
+export function firstBenchmarkDateAfter(points: MarketPricePoint[], cutoffDate: string): string | null {
+  return points
+    .map((point) => point.date)
+    .filter((value) => value > cutoffDate)
+    .sort((a, b) => a.localeCompare(b))[0] || null;
+}
+
+function priceOnDate(points: MarketPricePoint[], date: string): MarketPricePoint | null {
+  return points.find((point) => point.date === date) || null;
+}
+
+export function firstExecutionDateForCandidates(args: {
+  candidates: ScoredDiscoveryCandidate[];
+  cutoffDate: string;
+  benchmarkPoints: MarketPricePoint[];
+  priceBySymbol: Map<string, MarketPricePoint[]>;
+  limit?: number;
+}): string | null {
+  const selected = selectPositiveTopN(args.candidates, args.limit || 20);
+  const benchmarkDates = args.benchmarkPoints
+    .map((point) => point.date)
+    .filter((date) => date > args.cutoffDate)
+    .sort((a, b) => a.localeCompare(b));
+  if (!selected.length) return benchmarkDates[0] || null;
+  return benchmarkDates.find((date) => selected.every((candidate) => (
+    priceOnDate(args.priceBySymbol.get(candidate.row.ticker) || [], date) !== null
+  ))) || null;
+}
+
+export function buildHoldingsForSnapshot(args: {
+  candidates: ScoredDiscoveryCandidate[];
+  executionDate: string;
+  priceBySymbol: Map<string, MarketPricePoint[]>;
+  currencyByTicker: Map<string, string>;
+  limit?: number;
+}): PortfolioHoldingDefinition[] {
+  const ranked = selectPositiveTopN(args.candidates, args.limit || 20);
+  const selected: Array<Omit<PortfolioHoldingDefinition, "rank" | "weight">> = [];
+  for (const candidate of ranked) {
+    const ticker = candidate.row.ticker;
+    const price = priceOnDate(args.priceBySymbol.get(ticker) || [], args.executionDate);
+    const currency = String(args.currencyByTicker.get(ticker) || "").trim().toUpperCase();
+    if (!price || !currency) {
+      throw new Error(`Missing execution price or currency for ${ticker} on ${args.executionDate}.`);
+    }
+    selected.push({
+      ticker,
+      score: Number(candidate.row.points_score),
+      currency,
+      sourceReportIds: candidate.sourceReportIds,
+      entryDate: args.executionDate,
+      entryPriceUsd: price.adjustedCloseUsd,
+    });
+  }
+  const weight = selected.length ? 1 / selected.length : 0;
+  return selected.map((holding, index) => ({ ...holding, rank: index + 1, weight }));
+}
+
+export function computePortfolioNavSeries(args: {
+  snapshots: PortfolioSnapshotDefinition[];
+  priceBySymbol: Map<string, MarketPricePoint[]>;
+  benchmarkPoints: MarketPricePoint[];
+  throughDate?: string;
+}): PortfolioNavPoint[] {
+  const snapshots = args.snapshots
+    .slice()
+    .sort((a, b) => a.executionDate.localeCompare(b.executionDate));
+  if (!snapshots.length) return [];
+  const throughDate = args.throughDate || "9999-12-31";
+  const benchmark = args.benchmarkPoints
+    .filter((point) => point.date >= snapshots[0].executionDate && point.date <= throughDate)
+    .sort((a, b) => a.date.localeCompare(b.date));
+  if (!benchmark.length || benchmark[0].date !== snapshots[0].executionDate) return [];
+
+  const output: PortfolioNavPoint[] = [];
+  let activeSnapshot: PortfolioSnapshotDefinition = snapshots[0];
+  let snapshotIndex = 1;
+  let nav = 100;
+  let benchmarkNav = 100;
+  let lastBenchmarkPrice = benchmark[0].adjustedCloseUsd;
+  let holdingValues = new Map<string, number>();
+  let lastHoldingPrices = new Map<string, number>();
+
+  const activate = (snapshot: PortfolioSnapshotDefinition) => {
+    activeSnapshot = snapshot;
+    holdingValues = new Map();
+    lastHoldingPrices = new Map();
+    for (const holding of snapshot.holdings) {
+      const currentAdjustedEntry = priceOnDate(
+        args.priceBySymbol.get(holding.ticker) || [],
+        snapshot.executionDate,
+      )?.adjustedCloseUsd;
+      holdingValues.set(holding.ticker, nav * holding.weight);
+      lastHoldingPrices.set(holding.ticker, currentAdjustedEntry || holding.entryPriceUsd);
+    }
+  };
+
+  activate(activeSnapshot);
+
+  for (let index = 0; index < benchmark.length; index += 1) {
+    const benchmarkPoint = benchmark[index];
+    const date = benchmarkPoint.date;
+    if (index > 0) {
+      benchmarkNav *= benchmarkPoint.adjustedCloseUsd / lastBenchmarkPrice;
+      lastBenchmarkPrice = benchmarkPoint.adjustedCloseUsd;
+    }
+
+    let pointStatus: PortfolioDataStatus = activeSnapshot.holdings.length ? "ok" : "no_positions";
+    if (activeSnapshot.holdings.length) {
+      const nextValues = new Map<string, number>();
+      const nextPrices = new Map<string, number>();
+      let stale = false;
+      for (const holding of activeSnapshot.holdings) {
+        const currentPrice = latestPriceOnOrBefore(args.priceBySymbol.get(holding.ticker) || [], date);
+        const previousPrice = lastHoldingPrices.get(holding.ticker);
+        const previousValue = holdingValues.get(holding.ticker);
+        if (!currentPrice || !previousPrice || previousValue === undefined) {
+          stale = true;
+          break;
+        }
+        nextValues.set(holding.ticker, previousValue * (currentPrice.adjustedCloseUsd / previousPrice));
+        nextPrices.set(holding.ticker, currentPrice.adjustedCloseUsd);
+      }
+      if (!stale) {
+        holdingValues = nextValues;
+        lastHoldingPrices = nextPrices;
+        nav = Array.from(holdingValues.values()).reduce((sum, value) => sum + value, 0);
+      } else {
+        pointStatus = "stale_market_data";
+      }
+    }
+
+    const pendingSnapshot = snapshots[snapshotIndex];
+    if (pendingSnapshot && pendingSnapshot.executionDate === date) {
+      activate(pendingSnapshot);
+      snapshotIndex += 1;
+      if (pointStatus !== "stale_market_data") {
+        pointStatus = activeSnapshot.holdings.length ? "ok" : "no_positions";
+      }
+    }
+    output.push({
+      date,
+      snapshotId: activeSnapshot.id,
+      nav,
+      benchmarkNav,
+      holdingsCount: activeSnapshot.holdings.length,
+      status: pointStatus,
+    });
+  }
+  return output;
+}
+
+function subtractPeriod(dateValue: string, period: Exclude<PortfolioPeriod, "all">): string {
+  const date = new Date(`${dateValue}T00:00:00Z`);
+  if (period === "1y") date.setUTCFullYear(date.getUTCFullYear() - 1);
+  else date.setUTCMonth(date.getUTCMonth() - Number(period.replace("m", "")));
+  return date.toISOString().slice(0, 10);
+}
+
+export function summarizePortfolioPeriod(
+  points: PortfolioNavPoint[],
+  period: PortfolioPeriod,
+): PortfolioPeriodSummary {
+  const sorted = points.slice().sort((a, b) => a.date.localeCompare(b.date));
+  const end = sorted[sorted.length - 1];
+  if (!end) {
+    return {
+      returnPct: null,
+      benchmarkReturnPct: null,
+      excessReturnPct: null,
+      periodStart: null,
+      periodEnd: null,
+      status: "insufficient_history",
+    };
+  }
+  let start = sorted[0];
+  if (period !== "all") {
+    const boundary = subtractPeriod(end.date, period);
+    if (sorted[0].date > boundary) {
+      return {
+        returnPct: null,
+        benchmarkReturnPct: null,
+        excessReturnPct: null,
+        periodStart: null,
+        periodEnd: end.date,
+        status: "insufficient_history",
+      };
+    }
+    start = sorted.filter((point) => point.date <= boundary).slice(-1)[0] || sorted[0];
+  }
+  const returnPct = start.nav > 0 ? ((end.nav / start.nav) - 1) * 100 : null;
+  const benchmarkReturnPct = start.benchmarkNav > 0 ? ((end.benchmarkNav / start.benchmarkNav) - 1) * 100 : null;
+  const periodPoints = sorted.filter((point) => point.date >= start.date && point.date <= end.date);
+  const status = periodPoints.some((point) => point.status === "stale_market_data")
+    ? "stale_market_data"
+    : end.status;
+  return {
+    returnPct,
+    benchmarkReturnPct,
+    excessReturnPct:
+      returnPct === null || benchmarkReturnPct === null ? null : returnPct - benchmarkReturnPct,
+    periodStart: start.date,
+    periodEnd: end.date,
+    status,
+  };
+}

--- a/frontend/src/lib/reports-db.ts
+++ b/frontend/src/lib/reports-db.ts
@@ -593,17 +593,17 @@ export async function listDashboardsForDiscovery(): Promise<
  * pages like Hit Rate.
  */
 export async function listAllDashboardsForHitRate(): Promise<
-  { ticker: string; generated_at: string; dashboard: unknown; source_run_id: string | null }[]
+  { id: string; ticker: string; generated_at: string; dashboard: unknown; source_run_id: string | null }[]
 > {
   const sql = getSql();
   if (!sql) return [];
   const rows = (await sql`
-    SELECT r.ticker, r.generated_at, r.source_run_id, a.dashboard
+    SELECT r.id::text AS id, r.ticker, r.generated_at, r.source_run_id, a.dashboard
       FROM reports r
       JOIN report_artifacts a ON a.report_id = r.id
      WHERE r.deleted_at IS NULL
      ORDER BY r.generated_at DESC;
-  `) as unknown as { ticker: string; generated_at: string; dashboard: unknown; source_run_id: string | null }[];
+  `) as unknown as { id: string; ticker: string; generated_at: string; dashboard: unknown; source_run_id: string | null }[];
   return filterExcludedTickers(rows, (row) => row.ticker);
 }
 

--- a/frontend/src/lib/ticker-summary-aggregate.ts
+++ b/frontend/src/lib/ticker-summary-aggregate.ts
@@ -383,8 +383,9 @@ export function filterReportsByWindow(
 export function computeTickerSummaryAggregation(
   reports: SummarySourceReport[],
   window: SummaryWindow,
+  nowMs: number = Date.now(),
 ): TickerSummaryAggregation {
-  const filtered = filterReportsByWindow(reports, window);
+  const filtered = filterReportsByWindow(reports, window, nowMs);
   const overviewAcc = createMeanAccumulator();
   const modelMap = new Map<string, MeanAccumulator>();
   const valuatorMap = new Map<string, MeanAccumulator>();

--- a/scripts/portfolio_prices.py
+++ b/scripts/portfolio_prices.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+import sys
+from datetime import date
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from ai_hedge.portfolio_prices import fetch_price_bundle  # noqa: E402
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+        start = date.fromisoformat(str(payload["start"]))
+        end = date.fromisoformat(str(payload["end"]))
+        instruments = payload.get("instruments") or []
+        workers = int(payload.get("workers") or 8)
+        result = fetch_price_bundle(
+            instruments,
+            start=start,
+            end=end,
+            repo_root=ROOT,
+            workers=workers,
+        )
+        print(json.dumps(result, ensure_ascii=False, allow_nan=False))
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        print(json.dumps({"error": f"{type(exc).__name__}: {exc}"}), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/ai_hedge/db/migrations/006_portfolio_performance.sql
+++ b/src/ai_hedge/db/migrations/006_portfolio_performance.sql
@@ -1,0 +1,129 @@
+-- Point-in-time Top-20 model/persona portfolios and their USD total-return NAV.
+
+CREATE TABLE IF NOT EXISTS portfolio_snapshots (
+    id                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    track                 text NOT NULL CHECK (track IN ('backtest', 'paper')),
+    lens_type             text NOT NULL CHECK (lens_type IN ('overall', 'model', 'valuator')),
+    lens_key              text NOT NULL,
+    lens_label            text NOT NULL,
+    cutoff_at             timestamptz NOT NULL,
+    execution_date        date,
+    methodology_version   text NOT NULL,
+    universe_name         text NOT NULL DEFAULT 'analyzed_reports_90d',
+    provider              text NOT NULL DEFAULT 'yfinance',
+    candidate_count       int NOT NULL DEFAULT 0 CHECK (candidate_count >= 0),
+    selected_count        int NOT NULL DEFAULT 0 CHECK (selected_count BETWEEN 0 AND 20),
+    cash_weight           numeric NOT NULL DEFAULT 0 CHECK (cash_weight BETWEEN 0 AND 1),
+    status                text NOT NULL DEFAULT 'building'
+                          CHECK (status IN ('building', 'ready', 'no_positions', 'stale_market_data')),
+    created_at            timestamptz NOT NULL DEFAULT now(),
+    updated_at            timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (track, lens_type, lens_key, cutoff_at, methodology_version)
+);
+
+CREATE INDEX IF NOT EXISTS portfolio_snapshots_lookup_idx
+    ON portfolio_snapshots (track, methodology_version, lens_type, lens_key, cutoff_at DESC);
+
+CREATE TABLE IF NOT EXISTS portfolio_holdings (
+    snapshot_id          uuid NOT NULL REFERENCES portfolio_snapshots(id) ON DELETE CASCADE,
+    rank                 int NOT NULL CHECK (rank BETWEEN 1 AND 20),
+    ticker               text NOT NULL REFERENCES tickers(symbol),
+    score                numeric NOT NULL,
+    weight               numeric NOT NULL CHECK (weight > 0 AND weight <= 1),
+    currency             text NOT NULL,
+    source_report_ids    uuid[] NOT NULL DEFAULT '{}',
+    entry_date           date,
+    entry_price_usd      numeric,
+    created_at           timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (snapshot_id, rank),
+    UNIQUE (snapshot_id, ticker)
+);
+
+CREATE INDEX IF NOT EXISTS portfolio_holdings_ticker_idx
+    ON portfolio_holdings (ticker, snapshot_id);
+
+CREATE OR REPLACE FUNCTION prevent_paper_snapshot_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF OLD.track = 'paper' THEN
+        RAISE EXCEPTION 'paper portfolio snapshots are immutable';
+    END IF;
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS portfolio_snapshots_paper_immutable ON portfolio_snapshots;
+CREATE TRIGGER portfolio_snapshots_paper_immutable
+BEFORE UPDATE OR DELETE ON portfolio_snapshots
+FOR EACH ROW EXECUTE FUNCTION prevent_paper_snapshot_mutation();
+
+CREATE OR REPLACE FUNCTION prevent_paper_holding_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    snapshot_track text;
+BEGIN
+    SELECT track INTO snapshot_track
+      FROM portfolio_snapshots
+     WHERE id = OLD.snapshot_id;
+    IF snapshot_track = 'paper' THEN
+        RAISE EXCEPTION 'paper portfolio holdings are immutable';
+    END IF;
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS portfolio_holdings_paper_immutable ON portfolio_holdings;
+CREATE TRIGGER portfolio_holdings_paper_immutable
+BEFORE UPDATE OR DELETE ON portfolio_holdings
+FOR EACH ROW EXECUTE FUNCTION prevent_paper_holding_mutation();
+
+CREATE TABLE IF NOT EXISTS market_prices_daily (
+    symbol                  text NOT NULL,
+    price_date              date NOT NULL,
+    adjusted_close_local    numeric NOT NULL CHECK (adjusted_close_local > 0),
+    currency                text NOT NULL,
+    fx_to_usd               numeric NOT NULL CHECK (fx_to_usd > 0),
+    adjusted_close_usd      numeric NOT NULL CHECK (adjusted_close_usd > 0),
+    source                  text NOT NULL,
+    fetched_at              timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (symbol, price_date, source)
+);
+
+CREATE INDEX IF NOT EXISTS market_prices_daily_date_idx
+    ON market_prices_daily (price_date DESC, symbol);
+
+CREATE TABLE IF NOT EXISTS portfolio_nav_daily (
+    track                   text NOT NULL CHECK (track IN ('backtest', 'paper')),
+    lens_type               text NOT NULL CHECK (lens_type IN ('overall', 'model', 'valuator')),
+    lens_key                text NOT NULL,
+    methodology_version     text NOT NULL,
+    nav_date                date NOT NULL,
+    snapshot_id             uuid REFERENCES portfolio_snapshots(id) ON DELETE SET NULL,
+    nav                     numeric NOT NULL CHECK (nav >= 0),
+    benchmark_nav           numeric NOT NULL CHECK (benchmark_nav >= 0),
+    holdings_count          int NOT NULL DEFAULT 0 CHECK (holdings_count BETWEEN 0 AND 20),
+    status                  text NOT NULL
+                            CHECK (status IN ('ok', 'no_positions', 'stale_market_data')),
+    created_at              timestamptz NOT NULL DEFAULT now(),
+    updated_at              timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (track, lens_type, lens_key, methodology_version, nav_date)
+);
+
+CREATE INDEX IF NOT EXISTS portfolio_nav_daily_lookup_idx
+    ON portfolio_nav_daily (track, methodology_version, lens_type, lens_key, nav_date DESC);
+
+CREATE TABLE IF NOT EXISTS portfolio_refresh_locks (
+    lock_key       text PRIMARY KEY,
+    owner          text NOT NULL,
+    acquired_at    timestamptz NOT NULL DEFAULT now()
+);

--- a/src/ai_hedge/portfolio_prices.py
+++ b/src/ai_hedge/portfolio_prices.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import math
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Any, Iterable
+
+import yfinance as yf
+
+
+BENCHMARK_SYMBOL = "^SP500TR"
+PROVIDER_NAME = "yfinance"
+MAX_FX_AGE_DAYS = 5
+
+
+@dataclass(frozen=True)
+class FxSpec:
+    symbol: str
+    operation: str
+
+
+FX_SPECS: dict[str, FxSpec] = {
+    "ILS": FxSpec("ILS=X", "divide"),
+    "CAD": FxSpec("CAD=X", "divide"),
+    "GBP": FxSpec("GBPUSD=X", "multiply"),
+}
+
+
+def normalize_currency(currency: object) -> str:
+    normalized = str(currency or "").strip().upper()
+    if normalized == "ILA":
+        return "ILS"
+    if normalized in {"GBX", "GBP"}:
+        return "GBP"
+    return normalized
+
+
+def quote_unit_scale_to_currency(symbol: str, currency: str) -> float:
+    normalized_symbol = str(symbol or "").strip().upper()
+    normalized_currency = normalize_currency(currency)
+    if normalized_currency == "ILS" and normalized_symbol.endswith(".TA"):
+        return 0.01  # Yahoo quotes Tel Aviv prices in agorot.
+    if normalized_currency == "GBP" and normalized_symbol.endswith(".L"):
+        return 0.01  # Yahoo normally quotes London prices in pence.
+    return 1.0
+
+
+def _safe_float(value: object) -> float | None:
+    try:
+        parsed = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    return parsed if math.isfinite(parsed) and parsed > 0 else None
+
+
+def fx_rate_to_usd(currency: str, quote: object | None) -> float | None:
+    normalized = normalize_currency(currency)
+    if normalized == "USD":
+        return 1.0
+    spec = FX_SPECS.get(normalized)
+    parsed = _safe_float(quote)
+    if spec is None or parsed is None:
+        return None
+    return 1.0 / parsed if spec.operation == "divide" else parsed
+
+
+def _date_key(value: object) -> date | None:
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    try:
+        return datetime.fromisoformat(str(value)).date()
+    except ValueError:
+        return None
+
+
+def _history_to_map(history: Any) -> dict[date, float]:
+    if history is None or getattr(history, "empty", True):
+        return {}
+    try:
+        closes = history["Close"]
+    except Exception:
+        return {}
+    output: dict[date, float] = {}
+    for idx, value in closes.items():
+        key = _date_key(idx)
+        parsed = _safe_float(value)
+        if key is not None and parsed is not None:
+            output[key] = parsed
+    return output
+
+
+def fetch_adjusted_closes(symbol: str, start: date, end: date) -> dict[date, float]:
+    ticker = yf.Ticker(symbol)
+    history = ticker.history(
+        start=start.isoformat(),
+        end=(end + timedelta(days=1)).isoformat(),
+        interval="1d",
+        auto_adjust=True,
+        actions=False,
+        raise_errors=False,
+    )
+    return _history_to_map(history)
+
+
+def _last_quote_on_or_before(
+    quotes: dict[date, float],
+    target: date,
+    *,
+    max_age_days: int,
+) -> tuple[float, date] | None:
+    eligible = [quote_date for quote_date in quotes if quote_date <= target]
+    if not eligible:
+        return None
+    quote_date = max(eligible)
+    if (target - quote_date).days > max_age_days:
+        return None
+    return quotes[quote_date], quote_date
+
+
+def build_usd_rows(
+    symbol: str,
+    currency: str,
+    local_closes: dict[date, float],
+    fx_closes: dict[date, float] | None = None,
+    *,
+    max_fx_age_days: int = MAX_FX_AGE_DAYS,
+) -> list[dict[str, object]]:
+    normalized_currency = normalize_currency(currency)
+    quote_scale = quote_unit_scale_to_currency(symbol, normalized_currency)
+    rows: list[dict[str, object]] = []
+    for price_date in sorted(local_closes):
+        local_close = local_closes[price_date]
+        fx_quote_date: date | None = price_date
+        if normalized_currency == "USD":
+            fx_to_usd = 1.0
+        else:
+            matched = _last_quote_on_or_before(
+                fx_closes or {},
+                price_date,
+                max_age_days=max_fx_age_days,
+            )
+            if matched is None:
+                continue
+            quote, fx_quote_date = matched
+            fx_to_usd = fx_rate_to_usd(normalized_currency, quote)
+        if fx_to_usd is None:
+            continue
+        rows.append(
+            {
+                "symbol": symbol,
+                "date": price_date.isoformat(),
+                "adjusted_close_local": local_close,
+                "currency": normalized_currency,
+                "fx_to_usd": fx_to_usd,
+                "adjusted_close_usd": local_close * quote_scale * fx_to_usd,
+                "fx_quote_date": fx_quote_date.isoformat() if fx_quote_date else None,
+            }
+        )
+    return rows
+
+
+def _configure_cache(repo_root: Path) -> None:
+    cache_dir = repo_root / ".yfinance_cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    if hasattr(yf, "set_tz_cache_location"):
+        yf.set_tz_cache_location(str(cache_dir))
+
+
+def fetch_price_bundle(
+    instruments: Iterable[dict[str, object]],
+    *,
+    start: date,
+    end: date,
+    repo_root: Path,
+    workers: int = 8,
+) -> dict[str, object]:
+    _configure_cache(repo_root)
+    normalized: list[tuple[str, str]] = []
+    for instrument in instruments:
+        symbol = str(instrument.get("symbol") or "").strip().upper()
+        currency = normalize_currency(instrument.get("currency"))
+        if symbol and currency:
+            normalized.append((symbol, currency))
+    normalized.append((BENCHMARK_SYMBOL, "USD"))
+    normalized = list(dict.fromkeys(normalized))
+
+    fx_symbols = {
+        FX_SPECS[currency].symbol
+        for _, currency in normalized
+        if currency != "USD" and currency in FX_SPECS
+    }
+    download_symbols = [symbol for symbol, _ in normalized] + sorted(fx_symbols)
+    histories: dict[str, dict[date, float]] = {}
+    errors: list[dict[str, str]] = []
+    max_workers = max(1, min(int(workers or 8), 16))
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = {
+            executor.submit(fetch_adjusted_closes, symbol, start, end): symbol
+            for symbol in download_symbols
+        }
+        for future in as_completed(futures):
+            symbol = futures[future]
+            try:
+                histories[symbol] = future.result()
+                if not histories[symbol]:
+                    errors.append({"symbol": symbol, "error": "no_data"})
+            except Exception as exc:  # noqa: BLE001
+                histories[symbol] = {}
+                errors.append({"symbol": symbol, "error": f"{type(exc).__name__}: {exc}"})
+
+    assets: dict[str, list[dict[str, object]]] = {}
+    for symbol, currency in normalized:
+        spec = FX_SPECS.get(currency)
+        fx_closes = histories.get(spec.symbol, {}) if spec else None
+        assets[symbol] = build_usd_rows(
+            symbol,
+            currency,
+            histories.get(symbol, {}),
+            fx_closes,
+        )
+
+    return {
+        "provider": PROVIDER_NAME,
+        "benchmark_symbol": BENCHMARK_SYMBOL,
+        "start": start.isoformat(),
+        "end": end.isoformat(),
+        "assets": assets,
+        "errors": errors,
+    }

--- a/tests/test_portfolio_prices.py
+++ b/tests/test_portfolio_prices.py
@@ -1,0 +1,46 @@
+from datetime import date
+
+import pytest
+
+from ai_hedge.portfolio_prices import build_usd_rows, fx_rate_to_usd
+
+
+def test_fx_conversion_directions_for_ils_cad_and_gbp() -> None:
+    assert fx_rate_to_usd("ILS", 4) == pytest.approx(0.25)
+    assert fx_rate_to_usd("CAD", 1.25) == pytest.approx(0.8)
+    assert fx_rate_to_usd("GBP", 1.3) == pytest.approx(1.3)
+    assert fx_rate_to_usd("USD", None) == 1
+
+
+def test_usd_rows_apply_historical_fx_without_using_future_quotes() -> None:
+    rows = build_usd_rows(
+        "TEST.TA",
+        "ILS",
+        {date(2026, 5, 3): 400, date(2026, 5, 4): 440},
+        {date(2026, 5, 2): 4, date(2026, 5, 4): 4.4},
+    )
+    assert rows[0]["adjusted_close_usd"] == pytest.approx(1)
+    assert rows[0]["fx_quote_date"] == "2026-05-02"
+    assert rows[1]["adjusted_close_usd"] == pytest.approx(1)
+
+
+def test_london_pence_are_normalized_to_pounds_before_fx() -> None:
+    rows = build_usd_rows(
+        "TEST.L",
+        "GBP",
+        {date(2026, 5, 4): 1_000},
+        {date(2026, 5, 4): 1.25},
+    )
+    assert rows[0]["adjusted_close_local"] == 1_000
+    assert rows[0]["adjusted_close_usd"] == pytest.approx(12.5)
+
+
+def test_stale_fx_is_not_silently_filled() -> None:
+    rows = build_usd_rows(
+        "TEST.TO",
+        "CAD",
+        {date(2026, 5, 10): 100},
+        {date(2026, 5, 4): 1.25},
+        max_fx_age_days=5,
+    )
+    assert rows == []


### PR DESCRIPTION
## Summary

- add point-in-time Top 20 portfolios for Overall, canonical valuation models, and personas with separate reconstructed Backtest and immutable Forward Paper tracks
- persist monthly holdings, adjusted local/USD market data, FX, and daily portfolio/benchmark NAV; refresh idempotently inside Fly with a weekday workflow and explicit backfill controls
- add the portfolio-performance API and a responsive, light/dark-safe Portfolio Returns section above Hit Rate with period/track selectors and S&P 500 Total Return comparison

## Preview

URL: https://pr-125-hedge-in-a-box-site.fly.dev/hit-rate

Preview data:

- Backtest: 71 immutable monthly snapshots, 2026-05-01 through 2026-08-18
- Paper: 18 immutable inception snapshots, execution date 2026-08-18
- API: 8 Model rows (including Overall) and 10 Persona rows

## Test plan

- [x] `npm run test:portfolio` (7 TypeScript tests)
- [x] `python -m pytest tests/test_portfolio_prices.py tests/test_db_writer_user_attribution.py -q` (7 Python tests)
- [x] targeted ESLint for every touched TypeScript/TSX file
- [x] `npm run build`
- [x] live yfinance smoke check for USD total-return rows across ILS/agorot, GBP/pence, CAD, and `^SP500TR`
- [x] preview migration + Backtest/Paper backfill completed on the isolated Neon branch
- [x] repeated the complete refresh: snapshot counts remained exactly 71 Backtest / 18 Paper
- [x] live API checked for `all`, `1m`, `3m`, `6m`, and `1y`; incomplete periods return `N/A`/`insufficient_history` rather than partial returns
- [x] live preview HTML contains Portfolio Returns, Public Beta, Paper/Backtest, Since Inception, and S&P 500 controls/disclosure
- [ ] manual visual viewport/theme pass (in-app browser control was unavailable in this session; token-only light/dark styles and responsive breakpoints passed build/lint review)

## Notes for reviewer

- Methodology version: `top20-positive-equal-v1`. Backtest and Paper are never linked into one series. Database triggers prevent Paper snapshot/holding updates or deletes.
- Gross simulated returns exclude fees, slippage, tax, and cash interest. yfinance is disclosed in-product as a Public Beta research/personal-use source.
- Discovery and portfolio construction now share the exact scoring engine; `legacy_port.py` is unchanged.
- Repo-wide `npm run lint` still fails on pre-existing React hook/compiler findings in Discovery, Dream Team, Shell, and other untouched files. The targeted lint set is clean and the production Next build passes TypeScript.