### PR TITLE
Fix TradingAgents brief truncation

### DIFF
--- a/src/ai_hedge/trading_agents_adapter.py
+++ b/src/ai_hedge/trading_agents_adapter.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 
-ADAPTER_VERSION = "2026-08-19.v4"
+ADAPTER_VERSION = "2026-08-19.v5"
 CONFIG_VERSION = "deepseek-v0.2.4-fundamentals-news-social"
 REUSE_WINDOW_DAYS = 7
 SELECTED_ANALYSTS = ["fundamentals", "news", "social"]
@@ -22,7 +22,9 @@ QUICK_THINK_LLM = "deepseek-chat"
 DEEP_THINK_LLM = "deepseek-reasoner"
 SUMMARY_LLM = "deepseek-v4-flash"
 DEEPSEEK_BACKEND_URL = "https://api.deepseek.com/v1"
-COMPACT_BRIEF_MAX_CHARS = 9000
+# The summary prompt allows up to roughly 1,600 words. Keep a modest safety
+# margin above that expected output so the final section is not cut mid-sentence.
+COMPACT_BRIEF_MAX_CHARS = 12_000
 _GRAPH_SETUP_LOCK = threading.Lock()
 
 _TACTICAL_CONTEXT_LINE_RE = re.compile(

--- a/tests/test_trading_agents_adapter.py
+++ b/tests/test_trading_agents_adapter.py
@@ -228,6 +228,26 @@ def test_summarize_uses_observed_legacy_deepseek_wrapper(monkeypatch):
     assert "Do not use any other Markdown headers or subheaders" in calls[0]["prompt"]
 
 
+def test_summarize_preserves_brief_above_legacy_character_limit(monkeypatch):
+    brief = ("Earlier evidence. " * 550) + (
+        "\n\n### What Valuators Should Watch\n"
+        "Operating margin trajectory near 22%: continued gross-margin discipline."
+    )
+    assert 9_000 < len(brief) < ta.COMPACT_BRIEF_MAX_CHARS
+    monkeypatch.setattr(legacy, "deepseek_simple_text", lambda **_kwargs: brief)
+    payload = ta.normalize_trading_agents_state(
+        "TEST",
+        {"fundamentals_report": "fundamental point"},
+        decision="committee output",
+    )
+
+    result = ta._summarize_trading_agents_payload(payload, api_key="key")
+
+    assert result == brief
+    assert result.endswith("continued gross-margin discipline.")
+    assert "[Truncated]" not in result
+
+
 def test_reuse_accepts_fresh_success_with_matching_config(tmp_path):
     now = datetime(2026, 5, 27, tzinfo=timezone.utc)
     old_dir = tmp_path / "outputs" / "_site_runs" / "old" / "TEST"
@@ -253,23 +273,24 @@ def test_reuse_accepts_fresh_success_with_matching_config(tmp_path):
     assert found[0] == artifact.resolve()
 
 
-def test_reuse_rejects_stale_failure_and_config_mismatch(tmp_path):
+def test_reuse_rejects_stale_failure_and_version_mismatches(tmp_path):
     now = datetime(2026, 5, 27, tzinfo=timezone.utc)
     new_dir = tmp_path / "outputs" / "_site_runs" / "new" / "TEST"
     new_dir.mkdir(parents=True)
     cases = [
-        ("stale", "success", now - timedelta(days=10), ta.CONFIG_VERSION),
-        ("failed", "unavailable", now - timedelta(days=1), ta.CONFIG_VERSION),
-        ("config", "success", now - timedelta(days=1), "old-config"),
+        ("stale", "success", now - timedelta(days=10), ta.ADAPTER_VERSION, ta.CONFIG_VERSION),
+        ("failed", "unavailable", now - timedelta(days=1), ta.ADAPTER_VERSION, ta.CONFIG_VERSION),
+        ("adapter", "success", now - timedelta(days=1), "old-adapter", ta.CONFIG_VERSION),
+        ("config", "success", now - timedelta(days=1), ta.ADAPTER_VERSION, "old-config"),
     ]
-    for name, status, generated_at, config_version in cases:
+    for name, status, generated_at, adapter_version, config_version in cases:
         directory = tmp_path / "outputs" / "_site_runs" / name / "TEST"
         directory.mkdir(parents=True)
         payload = {
             "status": status,
             "ticker": "TEST",
             "generated_at": generated_at.isoformat(),
-            "adapter_version": ta.ADAPTER_VERSION,
+            "adapter_version": adapter_version,
             "config_version": config_version,
             "selected_analysts": ta.SELECTED_ANALYSTS,
         }


### PR DESCRIPTION
## Summary

- raise the TradingAgents compact-brief safety cap from 9,000 to 12,000 characters so the final `What Valuators Should Watch` section is not cut at the legacy boundary
- bump the adapter version so recent cached v4 artifacts containing `[Truncated]` are not reused on the next run
- add regression coverage for a complete brief beyond 9,000 characters and for rejecting old adapter artifacts

## Preview

URL: https://pr-126-hedge-in-a-box-site.fly.dev

Verified the deployed preview responds successfully on `/reports` and `/dashboard/ITRN`. A fresh TradingAgents run was intentionally left for reviewer testing to avoid triggering an unnecessary paid analysis.

## Test plan

- [x] `python -m pytest tests/test_trading_agents_adapter.py -q --basetemp=.tmp/pytest-tradingagents-output-v5b` (12 passed)
- [x] `python -m py_compile src/ai_hedge/trading_agents_adapter.py tests/test_trading_agents_adapter.py`
- [x] `git diff --check`
- [x] deployed preview: `/reports` returned 200 and `/dashboard/ITRN` returned 200 with the ticker rendered

## Notes for reviewer

The `[Truncated]` marker came from the adapter's own character slicing, not from the dashboard. The 12,000-character cap retains a safety guard while leaving margin above the prompt's typical 1,000–1,600-word output. The adapter version bump forces the next run to skip recent v4 cached artifacts.