### PR TITLE
Fix portfolio production bootstrap recovery

### DIFF
--- a/.github/workflows/portfolio-performance.yml
+++ b/.github/workflows/portfolio-performance.yml
@@ -2,8 +2,9 @@ name: Portfolio Performance Refresh
 
 on:
   schedule:
-    # Weekdays after the US close, with enough margin for delayed market data.
-    - cron: '30 23 * * 1-5'
+    # Tuesday-Saturday UTC = Monday-Friday US sessions. Waiting until 21:30 ET
+    # gives Yahoo several hours to publish the just-closed session.
+    - cron: '30 1 * * 2-6'
   workflow_dispatch:
     inputs:
       track:
@@ -16,6 +17,10 @@ on:
           - backtest
       through:
         description: Optional inclusive end date (YYYY-MM-DD)
+        type: string
+        required: false
+      paper_cutoff:
+        description: Optional Paper cutoff to create or repair (YYYY-MM-DD)
         type: string
         required: false
       start_cutoff:
@@ -64,6 +69,7 @@ jobs:
         env:
           INPUT_TRACK: ${{ github.event.inputs.track }}
           INPUT_THROUGH: ${{ github.event.inputs.through }}
+          INPUT_PAPER_CUTOFF: ${{ github.event.inputs.paper_cutoff }}
           INPUT_START_CUTOFF: ${{ github.event.inputs.start_cutoff }}
           INPUT_REPLACE: ${{ github.event.inputs.replace_backtest }}
         run: |
@@ -81,7 +87,19 @@ jobs:
             fi
             COMMAND="$COMMAND --through $INPUT_THROUGH"
           fi
-          if [ "$TRACK" = "backtest" ]; then
+          if [ "$TRACK" = "paper" ]; then
+            if [ -n "${INPUT_PAPER_CUTOFF:-}" ]; then
+              if ! [[ "$INPUT_PAPER_CUTOFF" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+                echo "::error::paper_cutoff must use YYYY-MM-DD"
+                exit 1
+              fi
+              COMMAND="$COMMAND --paper-cutoff $INPUT_PAPER_CUTOFF"
+            fi
+          else
+            if [ -n "${INPUT_PAPER_CUTOFF:-}" ]; then
+              echo "::error::paper_cutoff is only valid for the paper track"
+              exit 1
+            fi
             START_CUTOFF="${INPUT_START_CUTOFF:-2026-04-30}"
             if ! [[ "$START_CUTOFF" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
               echo "::error::start_cutoff must use YYYY-MM-DD"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "eslint",
     "portfolio:refresh": "tsx scripts/refresh-portfolio-performance.ts",
-    "test:portfolio": "tsx --test src/lib/discovery-engine.test.ts src/lib/portfolio-performance-engine.test.ts"
+    "test:portfolio": "tsx --test src/lib/discovery-engine.test.ts src/lib/portfolio-performance-engine.test.ts src/lib/portfolio-refresh-policy.test.ts"
   },
   "dependencies": {
     "@neondatabase/serverless": "^1.1.0",

--- a/frontend/scripts/refresh-portfolio-performance.ts
+++ b/frontend/scripts/refresh-portfolio-performance.ts
@@ -34,6 +34,7 @@ import {
   type PortfolioSnapshotDefinition,
   type PortfolioTrack,
 } from "../src/lib/portfolio-performance-engine";
+import { planPaperCutoffs } from "../src/lib/portfolio-refresh-policy";
 
 type PriceBundle = {
   provider: string;
@@ -272,17 +273,19 @@ async function main() {
     let cutoffs: string[];
     if (args.track === "backtest") {
       cutoffs = monthlyCutoffDates(args.startCutoff, previousMonthEnd(new Date(`${args.throughDate}T23:59:59Z`)));
-    } else if (!existing.length) {
-      cutoffs = [args.paperCutoff || previousNyCalendarDay(now)];
     } else {
       const existingCutoffDates = Array.from(new Set(
         existing.map((snapshot) => nyDateString(new Date(snapshot.cutoffAt))),
       )).sort();
-      const latestCutoffDate = existingCutoffDates[existingCutoffDates.length - 1];
-      cutoffs = Array.from(new Set([
-        ...existingCutoffDates,
-        ...monthlyCutoffDates(addDays(latestCutoffDate, 1), previousMonthEnd(now)),
-      ])).sort();
+      const latestCutoffDate = existingCutoffDates[existingCutoffDates.length - 1] || null;
+      cutoffs = planPaperCutoffs({
+        explicitCutoff: args.paperCutoff,
+        existingCutoffDates,
+        defaultInitialCutoff: previousNyCalendarDay(now),
+        newMonthlyCutoffs: latestCutoffDate
+          ? monthlyCutoffDates(addDays(latestCutoffDate, 1), previousMonthEnd(now))
+          : [],
+      });
     }
 
     const allCutoffDates = [...cutoffs, ...existing.map((snapshot) => nyDateString(new Date(snapshot.cutoffAt)))];
@@ -408,7 +411,7 @@ async function main() {
       });
     }
     if (priceBundle.errors?.length) {
-      console.warn(`[portfolio] provider returned ${priceBundle.errors.length} symbol warnings.`);
+      console.warn(`[portfolio] provider warnings: ${JSON.stringify(priceBundle.errors)}`);
     }
     console.log(`[portfolio] refreshed ${args.track}: ${existing.length} snapshots, ${fetchedPoints.length} price rows.`);
   } finally {

--- a/frontend/src/lib/portfolio-refresh-policy.test.ts
+++ b/frontend/src/lib/portfolio-refresh-policy.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { planPaperCutoffs } from "./portfolio-refresh-policy";
+
+test("an explicit Paper cutoff can repair a partially initialized track", () => {
+  assert.deepEqual(planPaperCutoffs({
+    explicitCutoff: "2026-08-17",
+    existingCutoffDates: ["2026-08-18"],
+    defaultInitialCutoff: "2026-08-19",
+    newMonthlyCutoffs: [],
+  }), ["2026-08-17"]);
+});
+
+test("a new Paper track uses the safe initial cutoff", () => {
+  assert.deepEqual(planPaperCutoffs({
+    explicitCutoff: null,
+    existingCutoffDates: [],
+    defaultInitialCutoff: "2026-08-18",
+    newMonthlyCutoffs: [],
+  }), ["2026-08-18"]);
+});
+
+test("ongoing Paper refreshes retry existing cutoffs and add new month ends", () => {
+  assert.deepEqual(planPaperCutoffs({
+    explicitCutoff: null,
+    existingCutoffDates: ["2026-08-18", "2026-07-31"],
+    defaultInitialCutoff: "2026-08-19",
+    newMonthlyCutoffs: ["2026-08-31", "2026-08-31"],
+  }), ["2026-07-31", "2026-08-18", "2026-08-31"]);
+});

--- a/frontend/src/lib/portfolio-refresh-policy.ts
+++ b/frontend/src/lib/portfolio-refresh-policy.ts
@@ -1,0 +1,13 @@
+export function planPaperCutoffs(args: {
+  explicitCutoff: string | null;
+  existingCutoffDates: string[];
+  defaultInitialCutoff: string;
+  newMonthlyCutoffs: string[];
+}): string[] {
+  if (args.explicitCutoff) return [args.explicitCutoff];
+  if (!args.existingCutoffDates.length) return [args.defaultInitialCutoff];
+  return Array.from(new Set([
+    ...args.existingCutoffDates,
+    ...args.newMonthlyCutoffs,
+  ])).sort();
+}


### PR DESCRIPTION
## Summary

- allow an explicit Paper cutoff to repair a partially initialized production track without deleting immutable snapshots
- move the weekday refresh to 01:30 UTC Tuesday-Saturday, giving US closing data several additional hours to settle
- expose provider warning details and add focused regression tests for initial, recovery, and ongoing Paper cutoff planning

## Preview

URL: https://pr-127-hedge-in-a-box-site.fly.dev

Verified `/api/health` and the portfolio API. The isolated preview showed the production-derived Backtest dataset (8 Model rows, 10 Valuator rows, 2026-05-01 through 2026-08-19) and reproduced the partial Paper state that this recovery fixed.

## Test plan

- [x] `npm run test:portfolio` (10 passed)
- [x] targeted ESLint for the changed TypeScript files
- [x] `python -m pytest tests/test_portfolio_prices.py -q --basetemp=.tmp/pytest-portfolio-bootstrap` (4 passed)
- [x] `npm run build`
- [x] workflow YAML parse and `git diff --check`
- [x] preview health/API verification
- [x] production deploy succeeded
- [x] production Paper recovery with cutoff `2026-08-17`: 17 missing snapshots inserted, 18 total, 1,153 price rows refreshed

## Notes for reviewer

The recovery path only inserts missing immutable Paper snapshots. It does not update or delete existing Paper history. The production recovery logged one non-blocking provider warning for `MLTM.TA` (`no_data`).