### PR TITLE
Fix Nasdaq workspace progress and TradingAgents targets

### DIFF
--- a/frontend/src/app/(app)/reports/page.tsx
+++ b/frontend/src/app/(app)/reports/page.tsx
@@ -43,7 +43,7 @@ export default async function ReportsPage({
   const userId = session?.user?.id || null;
   const signedIn = Boolean(userId);
 
-  const tab = resolveTab(params.tab, signedIn);
+  const tab = workspace === "nasdaq100" ? "community" : resolveTab(params.tab, signedIn);
   const query = String(params.q || "");
 
   return (
@@ -51,13 +51,15 @@ export default async function ReportsPage({
       <header className="mb-6">
         <h1 className="font-display text-3xl text-zinc-100">Reports</h1>
         <p className="mt-1 text-xs uppercase tracking-[0.18em] text-zinc-500">
-          {tab === "mine" ? "Reports you've generated" : "Public reports from the community"}
+          {workspace === "nasdaq100"
+            ? "Nasdaq 100 universe reports"
+            : tab === "mine" ? "Reports you've generated" : "Public reports from the community"}
         </p>
       </header>
 
-      <ReportsTabs active={tab} signedIn={signedIn} initialQuery={query} workspace={workspace} />
+      <ReportsTabs key={workspace} active={tab} signedIn={signedIn} initialQuery={query} workspace={workspace} />
 
-      {tab === "community" ? (
+      {workspace === "nasdaq100" || tab === "community" ? (
         <CommunityTabContent query={query} signedIn={signedIn} workspace={workspace} />
       ) : (
         <MineTabContent userId={userId} signedIn={signedIn} query={query} workspace={workspace} />
@@ -96,7 +98,7 @@ async function CommunityTabContent({
 
   return (
     <CommunityList
-      key={query.trim().toLowerCase() || "all-reports"}
+      key={`${workspace}:${query.trim().toLowerCase() || "all-reports"}`}
       initialRows={rows}
       initialHasMore={hasMore}
       query={query}

--- a/frontend/src/app/api/nasdaq100/runs/route.ts
+++ b/frontend/src/app/api/nasdaq100/runs/route.ts
@@ -34,9 +34,10 @@ export async function GET(request: Request) {
   try {
     await reconcileStaleNasdaqRuns();
     const authorized = hasNasdaqRunAuthorization(request, admin.email);
+    const includeUniverse = new URL(request.url).searchParams.get("include_universe") !== "0";
     const [runs, universe] = await Promise.all([
       listNasdaqRuns(),
-      authorized ? loadNasdaqUniverse() : Promise.resolve(null),
+      authorized && includeUniverse ? loadNasdaqUniverse() : Promise.resolve(null),
     ]);
     return NextResponse.json({
       isAdmin: true,

--- a/frontend/src/components/reports/reports-tabs.tsx
+++ b/frontend/src/components/reports/reports-tabs.tsx
@@ -65,41 +65,43 @@ export function ReportsTabs({
   }
 
   return (
-    <div className="mb-6 grid gap-3 sm:grid-cols-[auto_minmax(0,1fr)] sm:items-center">
-      <nav className="flex w-full rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-1 sm:w-auto">
-        {TAB_ORDER.map((t) => {
-          const params = new URLSearchParams(searchString);
-          params.delete("workspace");
-          params.set("tab", t.key);
-          const isActive = t.key === active;
-          const disabled = t.key === "mine" && !signedIn;
-          if (disabled) {
+    <div className={`mb-6 grid gap-3 sm:items-center ${workspace === "nasdaq100" ? "sm:grid-cols-1" : "sm:grid-cols-[auto_minmax(0,1fr)]"}`}>
+      {workspace === "analysis" ? (
+        <nav className="flex w-full rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-1 sm:w-auto">
+          {TAB_ORDER.map((t) => {
+            const params = new URLSearchParams(searchString);
+            params.delete("workspace");
+            params.set("tab", t.key);
+            const isActive = t.key === active;
+            const disabled = t.key === "mine" && !signedIn;
+            if (disabled) {
+              return (
+                <span
+                  key={t.key}
+                  className="flex-1 cursor-not-allowed rounded-lg px-3 py-1.5 text-center text-xs font-semibold uppercase tracking-[0.14em] text-[color:var(--text-disabled)] sm:flex-none"
+                  title="Sign in to see your reports"
+                >
+                  {t.label}
+                </span>
+              );
+            }
             return (
-              <span
+              <Link
                 key={t.key}
-                className="flex-1 cursor-not-allowed rounded-lg px-3 py-1.5 text-center text-xs font-semibold uppercase tracking-[0.14em] text-[color:var(--text-disabled)] sm:flex-none"
-                title="Sign in to see your reports"
+                href={`${workspacePath(workspace, "/reports")}?${params.toString()}`}
+                scroll={false}
+                className={`flex-1 rounded-lg px-3 py-1.5 text-center text-xs font-semibold uppercase tracking-[0.14em] transition sm:flex-none ${
+                  isActive
+                    ? "bg-[color:var(--accent)] text-[color:var(--text-on-accent)]"
+                    : "text-[color:var(--text-muted)] hover:text-[color:var(--text-primary)]"
+                }`}
               >
                 {t.label}
-              </span>
+              </Link>
             );
-          }
-          return (
-            <Link
-              key={t.key}
-              href={`${workspacePath(workspace, "/reports")}?${params.toString()}`}
-              scroll={false}
-              className={`flex-1 rounded-lg px-3 py-1.5 text-center text-xs font-semibold uppercase tracking-[0.14em] transition sm:flex-none ${
-                isActive
-                  ? "bg-[color:var(--accent)] text-[color:var(--text-on-accent)]"
-                  : "text-[color:var(--text-muted)] hover:text-[color:var(--text-primary)]"
-              }`}
-            >
-              {t.label}
-            </Link>
-          );
-        })}
-      </nav>
+          })}
+        </nav>
+      ) : null}
 
       <form
         role="search"

--- a/frontend/src/components/shell/app-shell.tsx
+++ b/frontend/src/components/shell/app-shell.tsx
@@ -10,6 +10,7 @@ import { ToastProvider } from "@/components/shell/toast";
 import { NewRunProvider } from "@/components/shell/new-run-context";
 import { NewRunModal } from "@/components/shell/new-run-modal";
 import { NasdaqRunProvider } from "@/components/shell/nasdaq-run-context";
+import { NasdaqRunIndicator } from "@/components/shell/nasdaq-run-indicator";
 import { useWorkspace, WorkspaceProvider } from "@/components/shell/workspace-context";
 import type { Workspace } from "@/lib/workspace";
 
@@ -17,7 +18,7 @@ const COLLAPSE_KEY = "hib-sidebar-v1";
 
 function WorkspaceActiveRunIndicator() {
   const { workspace } = useWorkspace();
-  return workspace === "analysis" ? <ActiveRunIndicator /> : null;
+  return workspace === "analysis" ? <ActiveRunIndicator /> : <NasdaqRunIndicator />;
 }
 
 export function AppShell({ children, initialWorkspace }: { children: ReactNode; initialWorkspace: Workspace }) {

--- a/frontend/src/components/shell/nasdaq-run-context.tsx
+++ b/frontend/src/components/shell/nasdaq-run-context.tsx
@@ -26,16 +26,25 @@ export function NasdaqRunProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (workspace !== "nasdaq100") return;
     let canceled = false;
-    fetch("/api/nasdaq100/runs", { cache: "no-store" })
-      .then(async (response) => await response.json() as NasdaqRunsResponse)
-      .then((payload) => {
-        if (!canceled) setAccess(payload);
-      })
-      .catch(() => {
-        if (!canceled) setAccess(null);
-      });
+
+    const poll = () => {
+      fetch("/api/nasdaq100/runs?include_universe=0", { cache: "no-store" })
+        .then(async (response) => await response.json() as NasdaqRunsResponse)
+        .then((payload) => {
+          if (canceled) return;
+          setAccess((current) => ({
+            ...payload,
+            universe: payload.universe ?? current?.universe,
+          }));
+        })
+        .catch(() => undefined);
+    };
+
+    poll();
+    const timer = window.setInterval(poll, 5_000);
     return () => {
       canceled = true;
+      window.clearInterval(timer);
     };
   }, [workspace]);
 

--- a/frontend/src/components/shell/nasdaq-run-indicator.tsx
+++ b/frontend/src/components/shell/nasdaq-run-indicator.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+
+import { useNasdaqRunModal } from "@/components/shell/nasdaq-run-context";
+
+function safePct(value: number | undefined): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(100, value));
+}
+
+export function NasdaqRunIndicator() {
+  const { liveRun, open } = useNasdaqRunModal();
+  if (!liveRun) return null;
+
+  const leadingPct = safePct(liveRun.leadingProgressPct);
+  const leadingLabel = liveRun.leadingTicker
+    ? `${liveRun.leadingTicker} ${leadingPct.toFixed(1)}%`
+    : "Waiting for the next report";
+
+  return (
+    <div className="px-3 pt-2 sm:px-6" role="status" aria-live="polite">
+      <div className="hib-active-run-banner mx-auto flex max-w-[1500px] items-center rounded-xl border px-3 py-2 text-xs backdrop-blur-md">
+        <div className="w-full">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+            <span className="inline-flex items-center gap-2 font-medium uppercase tracking-[0.12em]">
+              <Loader2 size={14} className="animate-spin" />
+              Nasdaq 100 run
+            </span>
+            <span className="hib-active-run-text font-semibold">
+              {liveRun.completedCount} / {liveRun.requestedCount} reports complete
+            </span>
+            <span className="hib-active-run-text">Most advanced: {leadingLabel}</span>
+          </div>
+          <div className="mt-1.5 flex items-center gap-3">
+            <div
+              className="h-1.5 flex-1 overflow-hidden rounded-full bg-white/10"
+              role="progressbar"
+              aria-label={`Most advanced report: ${leadingLabel}`}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-valuenow={Math.round(leadingPct)}
+            >
+              <div
+                className="h-full rounded-full bg-emerald-300 transition-all duration-500"
+                style={{ width: `${leadingPct}%` }}
+              />
+            </div>
+            <button
+              type="button"
+              onClick={open}
+              className="rounded border border-[color:var(--border-strong)] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.08em] text-[color:var(--text-primary)] transition hover:border-[color:var(--accent)]"
+            >
+              Details
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/shell/nasdaq-run-modal.tsx
+++ b/frontend/src/components/shell/nasdaq-run-modal.tsx
@@ -21,6 +21,8 @@ export type NasdaqRunSummary = {
   completedCount: number;
   failedCount: number;
   activeCount: number;
+  leadingTicker: string;
+  leadingProgressPct: number;
   concurrency: number;
   estimatedCostPerAttemptUsd: number;
   estimatedCostUsd: number;
@@ -98,6 +100,14 @@ export function NasdaqRunModal({
   }, [onData]);
 
   const data = loadedData ?? initialData;
+
+  useEffect(() => {
+    if (!open) return;
+    const timer = window.setTimeout(() => {
+      void refresh().catch(() => undefined);
+    }, 0);
+    return () => window.clearTimeout(timer);
+  }, [open, refresh]);
 
   useEffect(() => {
     if (!open || !data?.runs?.some((run) => run.status === "queued" || run.status === "running")) return;

--- a/frontend/src/components/shell/sidebar.tsx
+++ b/frontend/src/components/shell/sidebar.tsx
@@ -106,18 +106,21 @@ export function Sidebar({ collapsed, onToggle, mobile = false, onMobileClose }: 
             <button
               type="button"
               onClick={workspace === "analysis" ? handleNewAnalysis : handleNasdaqRun}
-              aria-label={workspace === "analysis" ? "Start a new analysis" : "Run Nasdaq 100 universe"}
-              title={workspace === "analysis" ? "Start a new analysis" : "Run Nasdaq 100 universe"}
+              aria-label={workspace === "analysis" ? "Start a new analysis" : "Run Nasdaq100"}
+              title={workspace === "analysis" ? "Start a new analysis" : "Run Nasdaq100"}
               className={`hib-run-btn flex items-center gap-2 rounded-lg border border-emerald-400/60 bg-emerald-500/20 px-3 py-2 text-xs font-semibold uppercase tracking-[0.14em] text-emerald-100 transition hover:bg-emerald-500/30 ${
                 collapsedDesktop ? "h-9 w-9 justify-center px-0" : "w-full justify-center"
               }`}
             >
               {workspace === "analysis" ? <Plus size={14} /> : <Play size={14} />}
-              {!collapsedDesktop ? <span>{workspace === "analysis" ? "New Analysis" : "Run"}</span> : null}
+              {!collapsedDesktop ? <span>{workspace === "analysis" ? "New Analysis" : "Run Nasdaq100"}</span> : null}
             </button>
             {workspace === "nasdaq100" && nasdaqLiveRun && !collapsedDesktop ? (
               <p className="mt-1 text-center text-[10px] text-[color:var(--text-muted)]">
                 {nasdaqLiveRun.completedCount}/{nasdaqLiveRun.requestedCount} complete
+                {nasdaqLiveRun.leadingTicker
+                  ? ` · ${nasdaqLiveRun.leadingTicker} ${nasdaqLiveRun.leadingProgressPct.toFixed(0)}%`
+                  : ""}
               </p>
             ) : null}
           </div>

--- a/frontend/src/lib/nasdaq-runs-db.ts
+++ b/frontend/src/lib/nasdaq-runs-db.ts
@@ -25,6 +25,8 @@ export type NasdaqRunSummary = {
   completedCount: number;
   failedCount: number;
   activeCount: number;
+  leadingTicker: string;
+  leadingProgressPct: number;
   concurrency: number;
   estimatedCostPerAttemptUsd: number;
   estimatedCostUsd: number;
@@ -56,6 +58,8 @@ type RunRow = {
   completed_count: number;
   failed_count: number;
   active_count: number;
+  leading_ticker?: string | null;
+  leading_progress_pct?: number | null;
   concurrency: number;
   estimated_cost_per_attempt_usd: number;
   estimated_cost_usd: number;
@@ -98,6 +102,8 @@ function toSummary(row: RunRow): NasdaqRunSummary {
     completedCount: Number(row.completed_count || 0),
     failedCount: Number(row.failed_count || 0),
     activeCount: Number(row.active_count || 0),
+    leadingTicker: String(row.leading_ticker || ""),
+    leadingProgressPct: Math.max(0, Math.min(100, Number(row.leading_progress_pct || 0))),
     concurrency: Number(row.concurrency || 1),
     estimatedCostPerAttemptUsd: Number(row.estimated_cost_per_attempt_usd || 0),
     estimatedCostUsd: Number(row.estimated_cost_usd || 0),
@@ -194,6 +200,8 @@ export async function listNasdaqRuns(limit = 5): Promise<NasdaqRunSummary[]> {
            requested_count, completed_count, failed_count,
            (SELECT count(*)::int FROM nasdaq_universe_run_items item
              WHERE item.run_id = nasdaq_universe_runs.id AND item.status = 'running') AS active_count,
+           progress.leading_ticker,
+           coalesce(progress.leading_progress_pct, 0)::float8 AS leading_progress_pct,
            concurrency, estimated_cost_per_attempt_usd::float8,
            estimated_cost_usd::float8, observed_cost_usd::float8,
            budget_limit_usd::float8, stop_requested_at::text,
@@ -202,6 +210,22 @@ export async function listNasdaqRuns(limit = 5): Promise<NasdaqRunSummary[]> {
            finished_at::text AS finished_at,
            error
       FROM nasdaq_universe_runs
+      LEFT JOIN LATERAL (
+        SELECT site_run.ticker AS leading_ticker,
+               CASE WHEN site_run.llm_total_estimated > 0
+                 THEN least(
+                   100.0,
+                   greatest(0.0, site_run.llm_completed::float8 * 100.0 / site_run.llm_total_estimated)
+                 )
+                 ELSE 0.0
+               END AS leading_progress_pct
+          FROM site_runs site_run
+         WHERE site_run.batch_id = nasdaq_universe_runs.id
+           AND site_run.workspace = 'nasdaq100'
+           AND site_run.status IN ('queued', 'running')
+         ORDER BY leading_progress_pct DESC, site_run.created_at DESC
+         LIMIT 1
+      ) progress ON true
      ORDER BY created_at DESC
      LIMIT ${safeLimit};
   `) as unknown as RunRow[];

--- a/src/ai_hedge/trading_agents_adapter.py
+++ b/src/ai_hedge/trading_agents_adapter.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 
-ADAPTER_VERSION = "2026-08-19.v5"
+ADAPTER_VERSION = "2026-08-22.v6"
 CONFIG_VERSION = "deepseek-v0.2.4-fundamentals-news-social"
 REUSE_WINDOW_DAYS = 7
 SELECTED_ANALYSTS = ["fundamentals", "news", "social"]
@@ -33,13 +33,16 @@ _TACTICAL_CONTEXT_LINE_RE = re.compile(
     flags=re.IGNORECASE,
 )
 _PRICE_TARGET_RE = re.compile(
-    r"(?im)^\s*(?:[-*]\s*)?(?:\*\*)?(?:price\s*target|target\s*price)(?:\*\*)?\s*:\s*"
-    r"(?:[A-Z]{3}\s*)?(?:[$€£₪]\s*)?([+-]?\d[\d,]*(?:\.\d+)?)",
+    r"(?im)^\s*(?:[-•]\s*)?[\"']?(?:price[\s_-]*target|target[\s_-]*price)[\"']?"
+    r"\s*(?:\([^\n)]*\))?\s*(?::|=|[-–—])\s*"
+    r"(?:(?:about|around|approx(?:imately)?|[A-Z]{3}|[$€£₪])\s*){0,3}"
+    r"([+-]?\d[\d,]*(?:\.\d+)?)",
 )
 _TIME_HORIZON_RE = re.compile(
-    r"(?im)^\s*(?:[-*]\s*)?(?:\*\*)?(?:time\s*horizon|holding\s*period)(?:\*\*)?\s*:\s*(.+?)\s*$",
+    r"(?im)^\s*(?:[-•]\s*)?[\"']?(?:time[\s_-]*horizon|holding[\s_-]*period)[\"']?"
+    r"\s*(?::|=|[-–—])\s*[\"']?(.+?)[\"']?\s*$",
 )
-_RATING_RE = re.compile(r"(?im)^\s*(?:[-*]\s*)?(?:\*\*)?rating(?:\*\*)?\s*:\s*(.+?)\s*$")
+_RATING_RE = re.compile(r"(?im)^\s*(?:[-•]\s*)?[\"']?rating[\"']?\s*(?::|=|[-–—])\s*[\"']?(.+?)[\"']?\s*$")
 
 CONTEXT_HEADER = "Independent Multi-Agent Research Lens"
 CONTEXT_INTRO = (
@@ -221,34 +224,124 @@ def _clean_markdown_value(value: Any) -> str:
     return re.sub(r"\*+", "", _text(value)).strip()
 
 
-def _extract_final_decision_metadata(final_decision: Any, processed_decision: Any = None) -> Dict[str, Any]:
-    text = _text(final_decision)
-    price_target: Optional[float] = None
-    price_match = _PRICE_TARGET_RE.search(text)
-    if price_match:
+def _structured_decision_mapping(value: Any) -> Dict[str, Any]:
+    if isinstance(value, dict):
+        raw = value
+    else:
+        dump = getattr(value, "model_dump", None)
+        if not callable(dump):
+            return {}
         try:
-            parsed = float(price_match.group(1).replace(",", ""))
+            raw = dump()
+        except Exception:
+            return {}
+    if not isinstance(raw, dict):
+        return {}
+    return {
+        re.sub(r"[\s-]+", "_", str(key).strip().lower()): item
+        for key, item in raw.items()
+    }
+
+
+def _extract_final_decision_metadata(final_decision: Any, processed_decision: Any = None) -> Dict[str, Any]:
+    structured = _structured_decision_mapping(final_decision)
+    price_target: Optional[float] = None
+    structured_target = structured.get("price_target", structured.get("target_price"))
+    if structured_target is not None:
+        try:
+            parsed = float(str(structured_target).replace(",", "").replace("$", "").strip())
             if math.isfinite(parsed) and parsed > 0:
                 price_target = parsed
         except Exception:
             price_target = None
 
-    time_horizon = ""
-    horizon_match = _TIME_HORIZON_RE.search(text)
-    if horizon_match:
-        time_horizon = _clean_markdown_value(horizon_match.group(1))
+    time_horizon = _clean_markdown_value(
+        structured.get("time_horizon", structured.get("holding_period", ""))
+    )
+    rating = _clean_markdown_value(structured.get("rating", ""))
 
-    rating = _clean_markdown_value(processed_decision)
+    for candidate in (final_decision, processed_decision):
+        text = re.sub(r"[*`]", "", _text(candidate))
+        if not text:
+            continue
+        if price_target is None:
+            price_match = _PRICE_TARGET_RE.search(text)
+            if price_match:
+                try:
+                    parsed = float(price_match.group(1).replace(",", ""))
+                    if math.isfinite(parsed) and parsed > 0:
+                        price_target = parsed
+                except Exception:
+                    price_target = None
+        if not time_horizon:
+            horizon_match = _TIME_HORIZON_RE.search(text)
+            if horizon_match:
+                time_horizon = _clean_markdown_value(horizon_match.group(1)).rstrip(",")
+        if not rating:
+            rating_match = _RATING_RE.search(text)
+            if rating_match:
+                rating = _clean_markdown_value(rating_match.group(1)).rstrip(",")
+
     if not rating:
-        rating_match = _RATING_RE.search(text)
-        if rating_match:
-            rating = _clean_markdown_value(rating_match.group(1))
+        rating = _clean_markdown_value(processed_decision)
 
     return {
         "rating": rating,
         "price_target": price_target,
         "time_horizon": time_horizon,
     }
+
+
+def _recover_required_tactical_metadata(
+    llm: Any,
+    ticker: str,
+    state: Dict[str, Any],
+    raw_final_decision: Any,
+) -> Dict[str, Any]:
+    """Retry only the quarantined TradingAgents tactical metadata contract."""
+
+    from pydantic import BaseModel, Field
+    from tradingagents.agents.utils.structured import bind_structured, invoke_structured_or_freetext
+
+    class RequiredTacticalMetadata(BaseModel):
+        rating: str = Field(min_length=1, description="One of Buy, Overweight, Hold, Underweight, or Sell.")
+        price_target: float = Field(gt=0, description="One numeric target in the instrument's quote currency.")
+        time_horizon: str = Field(min_length=1, description="The time horizon for the target.")
+
+    def render(decision: RequiredTacticalMetadata) -> str:
+        return (
+            f"**Rating**: {decision.rating}\n\n"
+            f"**Price Target**: {decision.price_target}\n\n"
+            f"**Time Horizon**: {decision.time_horizon}"
+        )
+
+    risk_debate = state.get("risk_debate_state") if isinstance(state, dict) else {}
+    prompt = f"""The Portfolio Manager decision for {ticker} did not yield every required tactical metadata field.
+Repair the metadata using only the TradingAgents material below. This is a TradingAgents tactical decision; do not use or imitate any AI Hedge valuation target.
+
+Return exactly one rating, one positive numeric price target in {ticker}'s quote currency, and one non-empty time horizon. The price target is required for Buy, Overweight, Hold, Underweight, and Sell.
+
+Previous Portfolio Manager decision:
+{_trim_chars(_text(raw_final_decision), 8_000)}
+
+Research Manager plan:
+{_trim_chars(_text(state.get('investment_plan')), 6_000)}
+
+Trader plan:
+{_trim_chars(_text(state.get('trader_investment_plan')), 6_000)}
+
+Risk debate:
+{_trim_chars(_text(risk_debate), 12_000)}
+""".strip()
+    structured_llm = bind_structured(llm, RequiredTacticalMetadata, "Portfolio Manager metadata repair")
+    repaired = invoke_structured_or_freetext(
+        structured_llm,
+        llm,
+        prompt,
+        render,
+        "Portfolio Manager metadata repair",
+    )
+    return _extract_final_decision_metadata(repaired)
 
 
 def _section(title: str, body: Any) -> str:
@@ -419,6 +512,9 @@ def compact_trading_agents_payload(payload: Dict[str, Any], *, api_key: str = ""
             "rating": _text(payload.get("rating")),
             "price_target": payload.get("price_target"),
             "time_horizon": _text(payload.get("time_horizon")),
+            "metadata_recovery_attempted": bool(payload.get("metadata_recovery_attempted")),
+            "metadata_recovered": bool(payload.get("metadata_recovered")),
+            "metadata_error": _text(payload.get("metadata_error")),
             "valuation_prompt_excluded_fields": [
                 "price_target",
                 "time_horizon",
@@ -531,6 +627,9 @@ def _base_payload(ticker: str, now: Optional[datetime] = None) -> Dict[str, Any]
         "rating": "",
         "price_target": None,
         "time_horizon": "",
+        "metadata_recovery_attempted": False,
+        "metadata_recovered": False,
+        "metadata_error": "",
         "valuation_prompt_excluded_fields": [
             "price_target",
             "time_horizon",
@@ -705,7 +804,29 @@ def run_trading_agents_lens(
             finally:
                 graph_setup.create_portfolio_manager = original_create_portfolio_manager
         state, decision = _propagate_trading_agents_graph(graph, ticker_u, run_date)
-        payload = normalize_trading_agents_state(ticker_u, state if isinstance(state, dict) else {}, decision, now=now)
+        state_dict = state if isinstance(state, dict) else {}
+        payload = normalize_trading_agents_state(ticker_u, state_dict, decision, now=now)
+        if payload.get("price_target") is None or not _text(payload.get("time_horizon")):
+            payload["metadata_recovery_attempted"] = True
+            try:
+                recovered = _recover_required_tactical_metadata(
+                    graph.deep_thinking_llm,
+                    ticker_u,
+                    state_dict,
+                    state_dict.get("final_trade_decision"),
+                )
+                for field in ("rating", "price_target", "time_horizon"):
+                    if payload.get(field) in (None, "") and recovered.get(field) not in (None, ""):
+                        payload[field] = recovered[field]
+                payload["metadata_recovered"] = bool(
+                    payload.get("price_target") is not None and _text(payload.get("time_horizon"))
+                )
+            except Exception as recovery_error:
+                payload["metadata_error"] = f"Metadata repair failed: {recovery_error}"
+            if payload.get("price_target") is None or not _text(payload.get("time_horizon")):
+                payload["metadata_error"] = payload.get("metadata_error") or (
+                    "TradingAgents completed, but required tactical target metadata remained incomplete after repair."
+                )
         payload["trade_date"] = run_date
         payload = compact_trading_agents_payload(payload, api_key=key)
     except Exception as exc:

--- a/tests/test_trading_agents_adapter.py
+++ b/tests/test_trading_agents_adapter.py
@@ -88,6 +88,55 @@ def test_final_decision_metadata_is_preserved_but_excluded_from_valuation_contex
     assert "6-12 months" not in artifact
 
 
+def test_final_decision_metadata_accepts_common_markdown_json_and_range_shapes():
+    markdown = ta._extract_final_decision_metadata(
+        "**Rating:** Hold\n**Price Target:** approximately USD $210-$225\n**Time Horizon:** 6-9 months"
+    )
+    structured = ta._extract_final_decision_metadata(
+        {"rating": "Overweight", "price_target": "1,234.50", "time-horizon": "12 months"}
+    )
+
+    assert markdown == {"rating": "Hold", "price_target": 210.0, "time_horizon": "6-9 months"}
+    assert structured == {"rating": "Overweight", "price_target": 1234.5, "time_horizon": "12 months"}
+
+
+def test_missing_tactical_metadata_repair_requires_numeric_target():
+    class FakeStructured:
+        def __init__(self, schema, owner):
+            self.schema = schema
+            self.owner = owner
+
+        def invoke(self, prompt):
+            self.owner.prompt = prompt
+            return self.schema(rating="Hold", price_target=245.5, time_horizon="9 months")
+
+    class FakeLlm:
+        def __init__(self):
+            self.prompt = ""
+
+        def with_structured_output(self, schema):
+            assert schema.model_fields["price_target"].is_required()
+            return FakeStructured(schema, self)
+
+        def invoke(self, _prompt):
+            raise AssertionError("structured repair should be used")
+
+    llm = FakeLlm()
+    recovered = ta._recover_required_tactical_metadata(
+        llm,
+        "TEST",
+        {
+            "investment_plan": "Balanced plan.",
+            "trader_investment_plan": "Wait for confirmation.",
+            "risk_debate_state": {"history": "Risks and catalysts are balanced."},
+        },
+        "**Rating**: Hold\n**Time Horizon**: 9 months",
+    )
+
+    assert recovered == {"rating": "Hold", "price_target": 245.5, "time_horizon": "9 months"}
+    assert "do not use or imitate any AI Hedge valuation target" in llm.prompt
+
+
 def test_compact_payload_keeps_brief_and_drops_verbose_sections(monkeypatch):
     payload = ta.normalize_trading_agents_state(
         "TEST",


### PR DESCRIPTION
## Summary

- simplify Nasdaq Reports into one universe feed, rename the CTA to `RUN NASDAQ100`, and remount report state when switching workspaces
- add a live Nasdaq run banner with completed/total report counts plus the most advanced active ticker and its LLM progress
- harden TradingAgents tactical-target extraction, retry missing required metadata in an isolated TradingAgents-only call, add diagnostics, and bump the adapter to v6 so incomplete v5 artifacts are not reused

## Preview

URL: https://pr-131-hedge-in-a-box-site.fly.dev

## Test plan

- [x] `python -m pytest tests/test_trading_agents_adapter.py -q --basetemp=.codex-tmp/pytest-tradingagents-v6c` (14 passed)
- [x] `python -m pytest tests/test_nasdaq_execution.py tests/test_nasdaq_worker_server.py tests/test_workspace_isolation.py -q --basetemp=.codex-tmp/pytest-nasdaq-progress-c` (15 passed)
- [x] focused ESLint on all touched frontend files
- [x] `npm run build` (Next.js compile and TypeScript passed)
- [x] local HTTP/API verification: Analysis and Nasdaq report feeds were isolated (458 vs 5 current rows), Nasdaq rendered without visible Mine/Community tabs, and the progress SQL ran against the live schema
- [x] preview HTTP/API/deployed-bundle verification: both report pages returned 200; Analysis showed Mine/Community; Nasdaq hid both tabs, showed the universe subtitle, returned the isolated 5-report feed, and shipped the RUN NASDAQ100 + live-progress banner text

## Notes for reviewer

Live read-only audit on 2026-08-22:

- Latest 8 Analysis reports: both fresh v5 reports extracted targets; the v4 reused report also had a target. The five missing-target reports were legacy v2/v3 artifacts created before the current required-target contract.
- Nasdaq currently has 5 reports, not 8. All five are v5 and have rating + time horizon but no price target.
- The current adapter accepts a required structured target, but TradingAgents falls back to unconstrained free text if structured output fails. The adapter previously neither repaired missing metadata nor validated the invariant after that fallback, and its regex accepted only one narrow Markdown shape. Raw PM prose is intentionally not persisted, so the historical record cannot distinguish structured-call failure from an alternate free-text shape.
- v6 accepts structured mappings and common Markdown/JSON/range shapes, performs one isolated metadata repair only when target/horizon is missing, and records whether repair was attempted/succeeded. Tactical metadata remains excluded from AI Hedge valuation prompts, targets, scores, and consensus.