### PR TITLE
Add portfolio Sharpe and volatility comparisons

### DIFF
--- a/.github/workflows/portfolio-performance.yml
+++ b/.github/workflows/portfolio-performance.yml
@@ -15,6 +15,15 @@ on:
         options:
           - paper
           - backtest
+      workspace:
+        description: Workspace to refresh
+        type: choice
+        required: true
+        default: all
+        options:
+          - all
+          - analysis
+          - nasdaq100
       through:
         description: Optional inclusive end date (YYYY-MM-DD)
         type: string
@@ -38,7 +47,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: portfolio-performance-${{ github.event.inputs.track || 'paper' }}
+  group: portfolio-performance-${{ github.event.inputs.workspace || 'all' }}-${{ github.event.inputs.track || 'paper' }}
   cancel-in-progress: false
 
 env:
@@ -68,6 +77,7 @@ jobs:
       - name: Refresh portfolio data inside Fly
         env:
           INPUT_TRACK: ${{ github.event.inputs.track }}
+          INPUT_WORKSPACE: ${{ github.event.inputs.workspace }}
           INPUT_THROUGH: ${{ github.event.inputs.through }}
           INPUT_PAPER_CUTOFF: ${{ github.event.inputs.paper_cutoff }}
           INPUT_START_CUTOFF: ${{ github.event.inputs.start_cutoff }}
@@ -79,13 +89,18 @@ jobs:
             echo "::error::track must be paper or backtest"
             exit 1
           fi
-          COMMAND="cd /app/frontend && npm run portfolio:refresh -- --workspace analysis --track $TRACK"
-          if [ -n "${INPUT_THROUGH:-}" ]; then
-            if ! [[ "$INPUT_THROUGH" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
-              echo "::error::through must use YYYY-MM-DD"
-              exit 1
-            fi
-            COMMAND="$COMMAND --through $INPUT_THROUGH"
+          WORKSPACE="${INPUT_WORKSPACE:-all}"
+          if [ "$WORKSPACE" = "all" ]; then
+            WORKSPACES="analysis nasdaq100"
+          elif [ "$WORKSPACE" = "analysis" ] || [ "$WORKSPACE" = "nasdaq100" ]; then
+            WORKSPACES="$WORKSPACE"
+          else
+            echo "::error::workspace must be all, analysis, or nasdaq100"
+            exit 1
+          fi
+          if [ -n "${INPUT_THROUGH:-}" ] && ! [[ "$INPUT_THROUGH" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+            echo "::error::through must use YYYY-MM-DD"
+            exit 1
           fi
           if [ "$TRACK" = "paper" ]; then
             if [ -n "${INPUT_PAPER_CUTOFF:-}" ]; then
@@ -93,7 +108,6 @@ jobs:
                 echo "::error::paper_cutoff must use YYYY-MM-DD"
                 exit 1
               fi
-              COMMAND="$COMMAND --paper-cutoff $INPUT_PAPER_CUTOFF"
             fi
           else
             if [ -n "${INPUT_PAPER_CUTOFF:-}" ]; then
@@ -105,16 +119,29 @@ jobs:
               echo "::error::start_cutoff must use YYYY-MM-DD"
               exit 1
             fi
-            COMMAND="$COMMAND --start-cutoff $START_CUTOFF"
-            if [ "${INPUT_REPLACE:-false}" = "true" ]; then
-              COMMAND="$COMMAND --replace-backtest"
-            fi
           fi
-          flyctl ssh console --app "$FLY_APP" --command "sh -lc '$COMMAND'"
+          for TARGET_WORKSPACE in $WORKSPACES; do
+            COMMAND="cd /app/frontend && npm run portfolio:refresh -- --workspace $TARGET_WORKSPACE --track $TRACK"
+            if [ -n "${INPUT_THROUGH:-}" ]; then
+              COMMAND="$COMMAND --through $INPUT_THROUGH"
+            fi
+            if [ "$TRACK" = "paper" ] && [ -n "${INPUT_PAPER_CUTOFF:-}" ]; then
+              COMMAND="$COMMAND --paper-cutoff $INPUT_PAPER_CUTOFF"
+            fi
+            if [ "$TRACK" = "backtest" ]; then
+              COMMAND="$COMMAND --start-cutoff $START_CUTOFF"
+              if [ "${INPUT_REPLACE:-false}" = "true" ]; then
+                COMMAND="$COMMAND --replace-backtest"
+              fi
+            fi
+            flyctl ssh console --app "$FLY_APP" --command "sh -lc '$COMMAND'"
+          done
 
       - name: Refresh backtest alongside scheduled paper tracking
         if: github.event_name == 'schedule'
-        run: >-
-          flyctl ssh console --app "$FLY_APP" --command
-          "sh -lc 'cd /app/frontend && npm run portfolio:refresh --
-          --workspace analysis --track backtest --start-cutoff 2026-04-30'"
+        run: |
+          set -euo pipefail
+          for TARGET_WORKSPACE in analysis nasdaq100; do
+            flyctl ssh console --app "$FLY_APP" --command \
+              "sh -lc 'cd /app/frontend && npm run portfolio:refresh -- --workspace $TARGET_WORKSPACE --track backtest --start-cutoff 2026-04-30'"
+          done

--- a/.github/workflows/preview-site.yml
+++ b/.github/workflows/preview-site.yml
@@ -249,14 +249,14 @@ jobs:
           set -euo pipefail
           if ! gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
             --paginate --jq '.[].filename' \
-            | grep -qx 'src/ai_hedge/db/migrations/006_portfolio_performance.sql'; then
-            echo "Portfolio migration is not part of this PR; skipping preview backfill."
+            | grep -Eq '^(src/ai_hedge/db/migrations/006_portfolio_performance\.sql|frontend/scripts/refresh-portfolio-performance\.ts|frontend/src/app/api/portfolio-performance/route\.ts|frontend/src/components/portfolio-returns-section\.tsx|frontend/src/lib/portfolio-(db|performance-engine|refresh-policy)(\.test)?\.ts)$'; then
+            echo "Portfolio performance code is not part of this PR; skipping preview backfill."
             exit 0
           fi
           flyctl ssh console --app "${{ env.PREVIEW_APP }}" --command \
-            "sh -lc 'cd /app/frontend && npm run portfolio:refresh -- --track backtest --start-cutoff 2026-04-30'"
+            "sh -lc 'cd /app/frontend && npm run portfolio:refresh -- --workspace analysis --track backtest --start-cutoff 2026-04-30'"
           flyctl ssh console --app "${{ env.PREVIEW_APP }}" --command \
-            "sh -lc 'cd /app/frontend && npm run portfolio:refresh -- --track paper --paper-cutoff 2026-08-17'"
+            "sh -lc 'cd /app/frontend && npm run portfolio:refresh -- --workspace analysis --track paper --paper-cutoff 2026-08-17'"
 
       - name: Diagnostics on deploy failure
         if: failure() && steps.deploy.conclusion == 'failure'

--- a/docs/nasdaq100-workspace.md
+++ b/docs/nasdaq100-workspace.md
@@ -1,8 +1,9 @@
 # Nasdaq 100 workspace operations
 
-The Nasdaq 100 workspace is release-based. It intentionally has no scheduler,
-batch runner, or constituent manifest yet. Existing reports remain in the
-Analysis workspace.
+The Nasdaq 100 workspace is release-based. Report publication remains gated by
+explicit release activation, while portfolio tracking starts automatically
+after an active release exists. Existing reports remain in the Analysis
+workspace.
 
 Create a staged release:
 
@@ -24,13 +25,22 @@ release atomically:
 python scripts/report_release.py activate --release <release-uuid-or-key>
 ```
 
-Then refresh the Nasdaq portfolio tracks manually:
+The scheduled Portfolio Performance workflow refreshes both Analysis and
+Nasdaq 100. Nasdaq refreshes exit cleanly while there is no active release;
+after the first activation they begin collecting Paper and Backtest NAV,
+QQQ benchmark history, and the `^IRX` 13-week Treasury yield used by Sharpe.
+The same tracks can also be refreshed manually:
 
 ```powershell
 Set-Location frontend
 npm run portfolio:refresh -- --workspace nasdaq100 --track paper
 npm run portfolio:refresh -- --workspace nasdaq100 --track backtest --start-cutoff 2026-04-30
 ```
+
+The workflow-dispatch form accepts `all`, `analysis`, or `nasdaq100`. Risk
+metrics are calculated from stored daily NAV rather than stored as mutable
+summary values: annualized volatility and Sharpe become visible after at least
+20 daily returns, with the observation count shown in the UI.
 
 ## Dedicated universe worker
 

--- a/frontend/scripts/refresh-portfolio-performance.ts
+++ b/frontend/scripts/refresh-portfolio-performance.ts
@@ -29,6 +29,7 @@ import {
   latestPriceOnOrBefore,
   PORTFOLIO_METHODOLOGY_VERSION,
   PORTFOLIO_PROVIDER,
+  PORTFOLIO_RISK_FREE_SYMBOL,
   portfolioWorkspaceConfig,
   type MarketPricePoint,
   type PortfolioSnapshotDefinition,
@@ -313,7 +314,10 @@ async function main() {
     for (const snapshot of existing) {
       for (const holding of snapshot.holdings) currencyByTicker.set(holding.ticker, holding.currency);
     }
-    const instruments = Array.from(currencyByTicker.entries()).map(([symbol, currency]) => ({ symbol, currency }));
+    const instruments = [
+      ...Array.from(currencyByTicker.entries()).map(([symbol, currency]) => ({ symbol, currency })),
+      { symbol: PORTFOLIO_RISK_FREE_SYMBOL, currency: "USD" },
+    ];
     const priceStart = addDays(earliestCutoff, -10);
     const priceBundle = await runPriceProvider({
       start: priceStart,
@@ -324,7 +328,11 @@ async function main() {
     });
     const fetchedPoints = flattenPriceBundle(priceBundle);
     await upsertMarketPrices(fetchedPoints, PORTFOLIO_PROVIDER);
-    const symbols = Array.from(new Set([...currencyByTicker.keys(), workspaceConfig.benchmarkSymbol]));
+    const symbols = Array.from(new Set([
+      ...currencyByTicker.keys(),
+      workspaceConfig.benchmarkSymbol,
+      PORTFOLIO_RISK_FREE_SYMBOL,
+    ]));
     const priceBySymbol = await loadMarketPrices({
       symbols,
       startDate: priceStart,

--- a/frontend/src/app/api/portfolio-performance/route.ts
+++ b/frontend/src/app/api/portfolio-performance/route.ts
@@ -1,11 +1,16 @@
 import { NextResponse } from "next/server";
 
-import { loadPortfolioNav, type StoredPortfolioNavPoint } from "@/lib/portfolio-db";
+import { loadMarketPrices, loadPortfolioNav, type StoredPortfolioNavPoint } from "@/lib/portfolio-db";
 import {
   PORTFOLIO_METHODOLOGY_VERSION,
   PORTFOLIO_PROVIDER,
+  PORTFOLIO_RISK_FREE_NAME,
+  PORTFOLIO_RISK_FREE_SYMBOL,
+  PORTFOLIO_RISK_MIN_OBSERVATIONS,
+  PORTFOLIO_TRADING_DAYS_PER_YEAR,
   portfolioWorkspaceConfig,
   summarizePortfolioPeriod,
+  type MarketPricePoint,
   type PortfolioPeriod,
   type PortfolioTrack,
 } from "@/lib/portfolio-performance-engine";
@@ -36,9 +41,13 @@ function groupByLens(rows: StoredPortfolioNavPoint[]): StoredPortfolioNavPoint[]
   return Array.from(grouped.values());
 }
 
-function summarizeLens(rows: StoredPortfolioNavPoint[], period: PortfolioPeriod) {
+function summarizeLens(
+  rows: StoredPortfolioNavPoint[],
+  period: PortfolioPeriod,
+  riskFreePoints: MarketPricePoint[],
+) {
   const sorted = rows.slice().sort((a, b) => a.date.localeCompare(b.date));
-  const summary = summarizePortfolioPeriod(sorted, period);
+  const summary = summarizePortfolioPeriod(sorted, period, riskFreePoints);
   const latest = sorted[sorted.length - 1];
   return {
     lens_type: latest.lensType,
@@ -47,6 +56,13 @@ function summarizeLens(rows: StoredPortfolioNavPoint[], period: PortfolioPeriod)
     return_pct: summary.returnPct,
     benchmark_return_pct: summary.benchmarkReturnPct,
     excess_return_pct: summary.excessReturnPct,
+    portfolio_volatility_pct: summary.portfolioVolatilityPct,
+    benchmark_volatility_pct: summary.benchmarkVolatilityPct,
+    portfolio_sharpe: summary.portfolioSharpe,
+    benchmark_sharpe: summary.benchmarkSharpe,
+    risk_observation_count: summary.riskObservationCount,
+    risk_free_observation_count: summary.riskFreeObservationCount,
+    risk_status: summary.riskStatus,
     holdings_count: latest.holdingsCount,
     period_start: summary.periodStart,
     period_end: summary.periodEnd,
@@ -75,12 +91,23 @@ function emptyResponse(workspace: Workspace, track: PortfolioTrack, period: Port
       benchmark_symbol: config.benchmarkSymbol,
       benchmark_name: config.benchmarkName,
       market_data_provider: PORTFOLIO_PROVIDER,
+      risk_free_symbol: PORTFOLIO_RISK_FREE_SYMBOL,
+      risk_free_name: PORTFOLIO_RISK_FREE_NAME,
+      risk_calculation: "Annualized from daily returns; Sharpe uses a daily-matched short-term Treasury yield",
+      annualization_trading_days: PORTFOLIO_TRADING_DAYS_PER_YEAR,
+      minimum_risk_observations: PORTFOLIO_RISK_MIN_OBSERVATIONS,
       public_beta: true,
     },
     range: { start: null, end: null },
     by_model: [],
     by_valuator: [],
   };
+}
+
+function daysBefore(dateValue: string, days: number): string {
+  const date = new Date(`${dateValue}T00:00:00Z`);
+  date.setUTCDate(date.getUTCDate() - days);
+  return date.toISOString().slice(0, 10);
 }
 
 export async function GET(request: Request) {
@@ -92,14 +119,21 @@ export async function GET(request: Request) {
   try {
     const rows = await loadPortfolioNav(workspace, track, PORTFOLIO_METHODOLOGY_VERSION);
     if (!rows.length) return NextResponse.json(emptyResponse(workspace, track, period));
+    const dates = rows.map((row) => row.date).sort();
+    const riskFreePrices = await loadMarketPrices({
+      symbols: [PORTFOLIO_RISK_FREE_SYMBOL],
+      startDate: daysBefore(dates[0], 10),
+      endDate: dates[dates.length - 1],
+      source: PORTFOLIO_PROVIDER,
+    });
+    const riskFreePoints = riskFreePrices.get(PORTFOLIO_RISK_FREE_SYMBOL) || [];
     const summaries = groupByLens(rows)
-      .map((group) => summarizeLens(group, period))
+      .map((group) => summarizeLens(group, period, riskFreePoints))
       .sort((a, b) => {
         if (a.lens_type === "overall") return -1;
         if (b.lens_type === "overall") return 1;
         return a.label.localeCompare(b.label);
       });
-    const dates = rows.map((row) => row.date).sort();
     return NextResponse.json({
       ...emptyResponse(workspace, track, period),
       available: true,

--- a/frontend/src/components/portfolio-returns-section.tsx
+++ b/frontend/src/components/portfolio-returns-section.tsx
@@ -7,6 +7,7 @@ import { useWorkspace } from "@/components/shell/workspace-context";
 type PortfolioTrack = "paper" | "backtest";
 type PortfolioPeriod = "1m" | "3m" | "6m" | "1y" | "all";
 type PortfolioStatus = "ok" | "insufficient_history" | "no_positions" | "stale_market_data";
+type PortfolioRiskStatus = "ok" | "insufficient_history" | "risk_free_unavailable" | "stale_market_data";
 
 type PortfolioReturnRow = {
   lens_type: "overall" | "model" | "valuator";
@@ -15,6 +16,13 @@ type PortfolioReturnRow = {
   return_pct: number | null;
   benchmark_return_pct: number | null;
   excess_return_pct: number | null;
+  portfolio_volatility_pct: number | null;
+  benchmark_volatility_pct: number | null;
+  portfolio_sharpe: number | null;
+  benchmark_sharpe: number | null;
+  risk_observation_count: number;
+  risk_free_observation_count: number;
+  risk_status: PortfolioRiskStatus;
   holdings_count: number;
   period_start: string | null;
   period_end: string | null;
@@ -34,6 +42,11 @@ type PortfolioPerformancePayload = {
     return_type: string;
     benchmark_name: string;
     market_data_provider: string;
+    risk_free_symbol: string;
+    risk_free_name: string;
+    risk_calculation: string;
+    annualization_trading_days: number;
+    minimum_risk_observations: number;
     public_beta: boolean;
   };
   range: { start: string | null; end: string | null };
@@ -53,6 +66,11 @@ function formatPercent(value: number | null): string {
   if (typeof value !== "number" || !Number.isFinite(value)) return "N/A";
   const sign = value > 0 ? "+" : "";
   return `${sign}${value.toFixed(2)}%`;
+}
+
+function formatRatio(value: number | null): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) return "N/A";
+  return value.toFixed(2);
 }
 
 function formatDate(value: string | null): string {
@@ -75,6 +93,18 @@ function statusLabel(row: PortfolioReturnRow): string | null {
   return null;
 }
 
+function riskStatusLabel(row: PortfolioReturnRow, minimumObservations: number): string | null {
+  if (row.risk_status === "insufficient_history") {
+    const remaining = Math.max(0, minimumObservations - row.risk_observation_count);
+    return `Risk metrics need ${remaining} more daily return${remaining === 1 ? "" : "s"}`;
+  }
+  if (row.risk_status === "risk_free_unavailable") {
+    return `Treasury data matched ${row.risk_free_observation_count}/${row.risk_observation_count} days; volatility is available but Sharpe is not`;
+  }
+  if (row.risk_status === "stale_market_data") return "Risk metrics paused because market data is incomplete";
+  return null;
+}
+
 function sortRowsByReturn(rows: PortfolioReturnRow[]): PortfolioReturnRow[] {
   return rows.slice().sort((a, b) => {
     const aReturn = typeof a.return_pct === "number" && Number.isFinite(a.return_pct) ? a.return_pct : null;
@@ -86,7 +116,17 @@ function sortRowsByReturn(rows: PortfolioReturnRow[]): PortfolioReturnRow[] {
   });
 }
 
-function ReturnsTable({ title, rows, benchmarkName }: { title: string; rows: PortfolioReturnRow[]; benchmarkName: string }) {
+function ReturnsTable({
+  title,
+  rows,
+  benchmarkName,
+  minimumObservations,
+}: {
+  title: string;
+  rows: PortfolioReturnRow[];
+  benchmarkName: string;
+  minimumObservations: number;
+}) {
   const { href } = useWorkspace();
   const rowHref = (row: PortfolioReturnRow): string => row.lens_type === "overall"
     ? href("/discovery?lens_type=overall")
@@ -96,51 +136,87 @@ function ReturnsTable({ title, rows, benchmarkName }: { title: string; rows: Por
     <section className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
       <h3 className="mb-3 text-sm font-semibold uppercase tracking-[0.16em] text-[color:var(--text-secondary)]">{title}</h3>
       <div className="space-y-2 md:hidden">
-        {sortedRows.map((row) => (
-          <article key={`${row.lens_type}:${row.lens_key || "overall"}:mobile`} className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-3">
-            <div className="flex items-start justify-between gap-3">
-              <div>
-                <Link href={rowHref(row)} className="font-semibold text-[color:var(--accent)] underline-offset-2 hover:underline">
-                  {row.label}
-                </Link>
-                <p className="mt-1 text-xs text-[color:var(--text-muted)]">{statusLabel(row) || `${row.holdings_count} latest holdings`}</p>
+        {sortedRows.map((row) => {
+          const riskNotice = riskStatusLabel(row, minimumObservations);
+          return (
+            <article key={`${row.lens_type}:${row.lens_key || "overall"}:mobile`} className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-3">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <Link href={rowHref(row)} className="font-semibold text-[color:var(--accent)] underline-offset-2 hover:underline">
+                    {row.label}
+                  </Link>
+                  <p className="mt-1 text-xs text-[color:var(--text-muted)]">{statusLabel(row) || `${row.holdings_count} latest holdings`}</p>
+                </div>
+                <div className="text-right">
+                  <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-[color:var(--text-muted)]">Excess return</p>
+                  <p className={`mt-1 text-lg font-bold tabular-nums ${returnTone(row.excess_return_pct)}`}>{formatPercent(row.excess_return_pct)}</p>
+                </div>
               </div>
-              <p className={`text-xl font-bold tabular-nums ${returnTone(row.return_pct)}`}>{formatPercent(row.return_pct)}</p>
-            </div>
-            <dl className="mt-3 grid grid-cols-3 gap-2 text-xs">
-              <div><dt className="text-[color:var(--text-muted)]">{benchmarkName}</dt><dd className="mt-1 tabular-nums text-[color:var(--text-primary)]">{formatPercent(row.benchmark_return_pct)}</dd></div>
-              <div><dt className="text-[color:var(--text-muted)]">Excess</dt><dd className={`mt-1 tabular-nums ${returnTone(row.excess_return_pct)}`}>{formatPercent(row.excess_return_pct)}</dd></div>
-              <div><dt className="text-[color:var(--text-muted)]">Start</dt><dd className="mt-1 text-[color:var(--text-primary)]">{formatDate(row.period_start)}</dd></div>
-            </dl>
-          </article>
-        ))}
+              <div className="mt-3 grid grid-cols-2 gap-2">
+                <dl className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-3 text-xs">
+                  <dt className="font-semibold uppercase tracking-[0.12em] text-[color:var(--text-secondary)]">Portfolio</dt>
+                  <dd className={`mt-2 text-lg font-bold tabular-nums ${returnTone(row.return_pct)}`}>{formatPercent(row.return_pct)}</dd>
+                  <div className="mt-2 flex items-center justify-between gap-2"><span className="text-[color:var(--text-muted)]">Volatility</span><span className="tabular-nums text-[color:var(--text-primary)]">{formatPercent(row.portfolio_volatility_pct)}</span></div>
+                  <div className="mt-1 flex items-center justify-between gap-2"><span className="text-[color:var(--text-muted)]">Sharpe</span><span className="tabular-nums text-[color:var(--text-primary)]">{formatRatio(row.portfolio_sharpe)}</span></div>
+                </dl>
+                <dl className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-3 text-xs">
+                  <dt className="font-semibold uppercase tracking-[0.12em] text-[color:var(--text-secondary)]">Benchmark</dt>
+                  <dd className="mt-2 text-lg font-bold tabular-nums text-[color:var(--text-primary)]">{formatPercent(row.benchmark_return_pct)}</dd>
+                  <div className="mt-2 flex items-center justify-between gap-2"><span className="text-[color:var(--text-muted)]">Volatility</span><span className="tabular-nums text-[color:var(--text-primary)]">{formatPercent(row.benchmark_volatility_pct)}</span></div>
+                  <div className="mt-1 flex items-center justify-between gap-2"><span className="text-[color:var(--text-muted)]">Sharpe</span><span className="tabular-nums text-[color:var(--text-primary)]">{formatRatio(row.benchmark_sharpe)}</span></div>
+                </dl>
+              </div>
+              <div className="mt-3 flex flex-wrap items-center justify-between gap-2 text-xs text-[color:var(--text-muted)]">
+                <span>{row.risk_observation_count} daily returns</span>
+                <span>Since {formatDate(row.period_start)}</span>
+              </div>
+              {riskNotice ? <p className="mt-2 text-xs leading-relaxed text-[color:var(--warning)]">{riskNotice}</p> : null}
+            </article>
+          );
+        })}
       </div>
       <div className="hidden overflow-x-auto rounded-lg border border-[color:var(--border-subtle)] md:block">
-        <table className="w-full min-w-[780px] text-sm">
+        <table className="w-full min-w-[1080px] text-sm">
           <thead className="bg-[color:var(--surface)] text-[color:var(--text-muted)]">
             <tr className="border-b border-[color:var(--border-subtle)]">
-              <th className="px-3 py-2 text-left font-medium">Portfolio</th>
-              <th className="px-3 py-2 text-right font-medium">Portfolio return</th>
-              <th className="px-3 py-2 text-right font-medium">{benchmarkName}</th>
-              <th className="px-3 py-2 text-right font-medium">Excess</th>
-              <th className="px-3 py-2 text-right font-medium">Latest holdings</th>
-              <th className="px-3 py-2 text-right font-medium">Start</th>
+              <th rowSpan={2} className="px-3 py-2 text-left font-medium">Portfolio</th>
+              <th colSpan={3} className="border-l border-[color:var(--border-subtle)] px-3 py-2 text-center font-semibold text-[color:var(--text-secondary)]">Portfolio</th>
+              <th colSpan={3} className="border-l border-[color:var(--border-subtle)] px-3 py-2 text-center font-semibold text-[color:var(--text-secondary)]">{benchmarkName}</th>
+              <th rowSpan={2} className="border-l border-[color:var(--border-subtle)] px-3 py-2 text-right font-medium">Excess</th>
+              <th rowSpan={2} className="px-3 py-2 text-right font-medium">Days</th>
+            </tr>
+            <tr className="border-b border-[color:var(--border-subtle)] text-[11px] uppercase tracking-[0.08em]">
+              <th className="border-l border-[color:var(--border-subtle)] px-3 py-2 text-right font-medium">Return</th>
+              <th className="px-3 py-2 text-right font-medium">Volatility</th>
+              <th className="px-3 py-2 text-right font-medium">Sharpe</th>
+              <th className="border-l border-[color:var(--border-subtle)] px-3 py-2 text-right font-medium">Return</th>
+              <th className="px-3 py-2 text-right font-medium">Volatility</th>
+              <th className="px-3 py-2 text-right font-medium">Sharpe</th>
             </tr>
           </thead>
           <tbody>
-            {sortedRows.map((row) => (
-              <tr key={`${row.lens_type}:${row.lens_key || "overall"}`} className="border-b border-[color:var(--border-subtle)] last:border-b-0">
-                <td className="px-3 py-2">
-                  <Link href={rowHref(row)} className="font-medium text-[color:var(--accent)] underline-offset-2 hover:underline">{row.label}</Link>
-                  {statusLabel(row) ? <p className="text-xs text-[color:var(--text-muted)]">{statusLabel(row)}</p> : null}
-                </td>
-                <td className={`px-3 py-2 text-right font-semibold tabular-nums ${returnTone(row.return_pct)}`}>{formatPercent(row.return_pct)}</td>
-                <td className="px-3 py-2 text-right tabular-nums text-[color:var(--text-primary)]">{formatPercent(row.benchmark_return_pct)}</td>
-                <td className={`px-3 py-2 text-right tabular-nums ${returnTone(row.excess_return_pct)}`}>{formatPercent(row.excess_return_pct)}</td>
-                <td className="px-3 py-2 text-right tabular-nums text-[color:var(--text-secondary)]">{row.holdings_count}</td>
-                <td className="px-3 py-2 text-right text-[color:var(--text-secondary)]">{formatDate(row.period_start)}</td>
-              </tr>
-            ))}
+            {sortedRows.map((row) => {
+              const riskNotice = riskStatusLabel(row, minimumObservations);
+              return (
+                <tr key={`${row.lens_type}:${row.lens_key || "overall"}`} className="border-b border-[color:var(--border-subtle)] last:border-b-0">
+                  <td className="px-3 py-2">
+                    <Link href={rowHref(row)} className="font-medium text-[color:var(--accent)] underline-offset-2 hover:underline">{row.label}</Link>
+                    <p className="mt-0.5 text-[11px] text-[color:var(--text-muted)]">
+                      {statusLabel(row) || `${row.holdings_count} holdings · since ${formatDate(row.period_start)}`}
+                    </p>
+                    {riskNotice ? <p className="mt-0.5 max-w-56 text-[11px] leading-snug text-[color:var(--warning)]">{riskNotice}</p> : null}
+                  </td>
+                  <td className={`border-l border-[color:var(--border-subtle)] px-3 py-2 text-right font-semibold tabular-nums ${returnTone(row.return_pct)}`}>{formatPercent(row.return_pct)}</td>
+                  <td className="px-3 py-2 text-right tabular-nums text-[color:var(--text-primary)]">{formatPercent(row.portfolio_volatility_pct)}</td>
+                  <td className="px-3 py-2 text-right tabular-nums text-[color:var(--text-primary)]">{formatRatio(row.portfolio_sharpe)}</td>
+                  <td className="border-l border-[color:var(--border-subtle)] px-3 py-2 text-right tabular-nums text-[color:var(--text-primary)]">{formatPercent(row.benchmark_return_pct)}</td>
+                  <td className="px-3 py-2 text-right tabular-nums text-[color:var(--text-primary)]">{formatPercent(row.benchmark_volatility_pct)}</td>
+                  <td className="px-3 py-2 text-right tabular-nums text-[color:var(--text-primary)]">{formatRatio(row.benchmark_sharpe)}</td>
+                  <td className={`border-l border-[color:var(--border-subtle)] px-3 py-2 text-right tabular-nums ${returnTone(row.excess_return_pct)}`}>{formatPercent(row.excess_return_pct)}</td>
+                  <td className="px-3 py-2 text-right tabular-nums text-[color:var(--text-secondary)]">{row.risk_observation_count}</td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       </div>
@@ -177,6 +253,8 @@ export function PortfolioReturnsSection() {
   const benchmarkName = data?.methodology.benchmark_name || (workspace === "nasdaq100"
     ? "Invesco QQQ - total-return proxy"
     : "S&P 500 Total Return");
+  const minimumRiskObservations = data?.methodology.minimum_risk_observations || 20;
+  const riskFreeName = data?.methodology.risk_free_name || "13-week U.S. Treasury Bill yield proxy";
 
   return (
     <section className="mb-6 rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-overlay)] p-4 sm:p-5">
@@ -187,6 +265,11 @@ export function PortfolioReturnsSection() {
             <span className="rounded-full border border-[color:var(--warning)] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--warning)]">Public Beta</span>
           </div>
           <p className="mt-1 max-w-3xl text-sm text-[color:var(--text-muted)]">Monthly Top 20 positive-score portfolios, equal weighted and measured in USD against {benchmarkName}.</p>
+          <div className="mt-3 flex flex-wrap gap-2 text-[11px] font-medium text-[color:var(--text-secondary)]">
+            <span className="rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-2.5 py-1">Annualized daily risk</span>
+            <span className="rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-2.5 py-1">Minimum {minimumRiskObservations} daily returns</span>
+            <span className="rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-2.5 py-1">Risk-free: {riskFreeName}</span>
+          </div>
         </div>
         <div className="flex flex-wrap gap-2">
           <div className="inline-flex rounded-lg border border-[color:var(--border-strong)] bg-[color:var(--surface)] p-1" aria-label="Portfolio track">
@@ -213,8 +296,8 @@ export function PortfolioReturnsSection() {
         </div>
       ) : (
         <div className="mt-4 grid items-start gap-4 xl:grid-cols-2">
-          <ReturnsTable title="Models" rows={data.by_model} benchmarkName={benchmarkName} />
-          <ReturnsTable title="Valuators" rows={data.by_valuator} benchmarkName={benchmarkName} />
+          <ReturnsTable title="Models" rows={data.by_model} benchmarkName={benchmarkName} minimumObservations={minimumRiskObservations} />
+          <ReturnsTable title="Valuators" rows={data.by_valuator} benchmarkName={benchmarkName} minimumObservations={minimumRiskObservations} />
         </div>
       )}
 
@@ -222,7 +305,7 @@ export function PortfolioReturnsSection() {
         {track === "paper"
           ? "Paper records each portfolio from the day it is created, and its holdings are never rewritten later. "
           : "Backtest reconstructs what each portfolio would have held at earlier month-ends, using only information available at the time. "}
-        Benchmark: every portfolio is compared with {benchmarkName}. {workspace === "nasdaq100" ? "QQQ adjusted close is used as an investable total-return proxy; it is not presented as the official XNDX index series. Only reports from a completed, fully covered Nasdaq 100 release can enter the ranking. " : "The Analysis benchmark is the full S&P 500 Total Return Index, including reinvested dividends. Only stocks analyzed during the previous 90 days can enter the ranking; that does not narrow the benchmark. "}Latest holdings is the count at the most recent frozen rebalance, so it can differ from today&apos;s live Discovery ranking. Returns are simulated before fees, taxes, slippage, or cash interest. Prices and FX come from yfinance; missing data is shown as unavailable.
+        Benchmark: every portfolio is compared with {benchmarkName}. {workspace === "nasdaq100" ? "QQQ adjusted close is used as an investable total-return proxy; it is not presented as the official XNDX index series. Only reports from a completed, fully covered Nasdaq 100 release can enter the ranking. " : "The Analysis benchmark is the full S&P 500 Total Return Index, including reinvested dividends. Only stocks analyzed during the previous 90 days can enter the ranking; that does not narrow the benchmark. "}Volatility is the annualized sample standard deviation of daily returns. Sharpe compares daily returns with the daily-matched {riskFreeName} yield and is annualized over 252 trading days; it appears after {minimumRiskObservations} daily returns. Latest holdings is the count at the most recent frozen rebalance, so it can differ from today&apos;s live Discovery ranking. Returns are simulated before fees, taxes, slippage, or cash interest. Prices, Treasury yield, and FX come from yfinance; missing data is shown explicitly.
       </p>
     </section>
   );

--- a/frontend/src/lib/portfolio-performance-engine.test.ts
+++ b/frontend/src/lib/portfolio-performance-engine.test.ts
@@ -7,6 +7,8 @@ import {
   computePortfolioNavSeries,
   firstBenchmarkDateAfter,
   firstExecutionDateForCandidates,
+  PORTFOLIO_RISK_MIN_OBSERVATIONS,
+  PORTFOLIO_TRADING_DAYS_PER_YEAR,
   portfolioWorkspaceConfig,
   summarizePortfolioPeriod,
   type MarketPricePoint,
@@ -146,7 +148,74 @@ test("benchmark execution is the first session after cutoff and stale points tai
   assert.equal(nav[1].status, "stale_market_data");
   assert.equal(nav[2].status, "ok");
   assert.equal(summarizePortfolioPeriod(nav, "all").status, "stale_market_data");
+  assert.equal(summarizePortfolioPeriod(nav, "all").riskStatus, "stale_market_data");
   assert.equal(summarizePortfolioPeriod(nav, "3m").status, "insufficient_history");
+});
+
+test("risk summary annualizes daily volatility and Sharpe against matched Treasury yields", () => {
+  const portfolioReturns = Array.from({ length: PORTFOLIO_RISK_MIN_OBSERVATIONS }, (_, index) => (
+    index % 2 === 0 ? 0.01 : -0.005
+  ));
+  const benchmarkReturns = Array.from({ length: PORTFOLIO_RISK_MIN_OBSERVATIONS }, (_, index) => (
+    index % 2 === 0 ? 0.005 : -0.002
+  ));
+  let nav = 100;
+  let benchmarkNav = 100;
+  const points = [{
+    date: "2026-06-01",
+    snapshotId: "s1",
+    nav,
+    benchmarkNav,
+    holdingsCount: 1,
+    status: "ok" as const,
+  }];
+  for (let index = 0; index < portfolioReturns.length; index += 1) {
+    nav *= 1 + portfolioReturns[index];
+    benchmarkNav *= 1 + benchmarkReturns[index];
+    const date = new Date(Date.UTC(2026, 5, index + 2)).toISOString().slice(0, 10);
+    points.push({ date, snapshotId: "s1", nav, benchmarkNav, holdingsCount: 1, status: "ok" as const });
+  }
+  const riskFree = points.map((point) => price("^IRX", point.date, 5));
+  const summary = summarizePortfolioPeriod(points, "all", riskFree);
+  const sampleStdDev = (values: number[]) => {
+    const average = values.reduce((sum, value) => sum + value, 0) / values.length;
+    return Math.sqrt(values.reduce((sum, value) => sum + ((value - average) ** 2), 0) / (values.length - 1));
+  };
+  const portfolioStdDev = sampleStdDev(portfolioReturns);
+  const benchmarkStdDev = sampleStdDev(benchmarkReturns);
+  const dailyRiskFree = (1.05 ** (1 / PORTFOLIO_TRADING_DAYS_PER_YEAR)) - 1;
+  const average = (values: number[]) => values.reduce((sum, value) => sum + value, 0) / values.length;
+
+  assert.equal(summary.riskStatus, "ok");
+  assert.equal(summary.riskObservationCount, PORTFOLIO_RISK_MIN_OBSERVATIONS);
+  assert.equal(summary.riskFreeObservationCount, PORTFOLIO_RISK_MIN_OBSERVATIONS);
+  assert.ok(Math.abs((summary.portfolioVolatilityPct || 0) - (portfolioStdDev * Math.sqrt(252) * 100)) < 1e-9);
+  assert.ok(Math.abs((summary.benchmarkVolatilityPct || 0) - (benchmarkStdDev * Math.sqrt(252) * 100)) < 1e-9);
+  assert.ok(Math.abs((summary.portfolioSharpe || 0) - (((average(portfolioReturns) - dailyRiskFree) / portfolioStdDev) * Math.sqrt(252))) < 1e-9);
+  assert.ok(Math.abs((summary.benchmarkSharpe || 0) - (((average(benchmarkReturns) - dailyRiskFree) / benchmarkStdDev) * Math.sqrt(252))) < 1e-9);
+});
+
+test("risk summary waits for enough returns and keeps volatility when Treasury data is missing", () => {
+  const points = Array.from({ length: PORTFOLIO_RISK_MIN_OBSERVATIONS + 1 }, (_, index) => ({
+    date: new Date(Date.UTC(2026, 6, index + 1)).toISOString().slice(0, 10),
+    snapshotId: "s1",
+    nav: 100 + index,
+    benchmarkNav: 100 + (index * 0.5),
+    holdingsCount: 1,
+    status: "ok" as const,
+  }));
+  const short = summarizePortfolioPeriod(points.slice(0, PORTFOLIO_RISK_MIN_OBSERVATIONS), "all", []);
+  assert.equal(short.riskStatus, "insufficient_history");
+  assert.equal(short.riskObservationCount, PORTFOLIO_RISK_MIN_OBSERVATIONS - 1);
+  assert.equal(short.portfolioVolatilityPct, null);
+
+  const missingTreasury = summarizePortfolioPeriod(points, "all", []);
+  assert.equal(missingTreasury.riskStatus, "risk_free_unavailable");
+  assert.equal(missingTreasury.riskFreeObservationCount, 0);
+  assert.notEqual(missingTreasury.portfolioVolatilityPct, null);
+  assert.notEqual(missingTreasury.benchmarkVolatilityPct, null);
+  assert.equal(missingTreasury.portfolioSharpe, null);
+  assert.equal(missingTreasury.benchmarkSharpe, null);
 });
 
 test("execution waits for a common valid session across different market holidays", () => {

--- a/frontend/src/lib/portfolio-performance-engine.ts
+++ b/frontend/src/lib/portfolio-performance-engine.ts
@@ -7,12 +7,22 @@ import type { Workspace } from "@/lib/workspace";
 
 export const PORTFOLIO_METHODOLOGY_VERSION = "top20-positive-equal-v1";
 export const PORTFOLIO_BENCHMARK_SYMBOL = "^SP500TR";
+export const PORTFOLIO_RISK_FREE_SYMBOL = "^IRX";
+export const PORTFOLIO_RISK_FREE_NAME = "13-week U.S. Treasury Bill yield proxy";
 export const PORTFOLIO_PROVIDER = "yfinance";
 export const MAX_MARKET_DATA_AGE_DAYS = 5;
+export const MAX_RISK_FREE_DATA_AGE_DAYS = 7;
+export const PORTFOLIO_RISK_MIN_OBSERVATIONS = 20;
+export const PORTFOLIO_TRADING_DAYS_PER_YEAR = 252;
 
 export type PortfolioTrack = "backtest" | "paper";
 export type PortfolioPeriod = "1m" | "3m" | "6m" | "1y" | "all";
 export type PortfolioDataStatus = "ok" | "no_positions" | "stale_market_data";
+export type PortfolioRiskStatus =
+  | "ok"
+  | "insufficient_history"
+  | "risk_free_unavailable"
+  | "stale_market_data";
 
 export function portfolioWorkspaceConfig(workspace: Workspace) {
   return workspace === "nasdaq100"
@@ -76,6 +86,13 @@ export type PortfolioPeriodSummary = {
   returnPct: number | null;
   benchmarkReturnPct: number | null;
   excessReturnPct: number | null;
+  portfolioVolatilityPct: number | null;
+  benchmarkVolatilityPct: number | null;
+  portfolioSharpe: number | null;
+  benchmarkSharpe: number | null;
+  riskObservationCount: number;
+  riskFreeObservationCount: number;
+  riskStatus: PortfolioRiskStatus;
   periodStart: string | null;
   periodEnd: string | null;
   status: PortfolioDataStatus | "insufficient_history";
@@ -262,9 +279,114 @@ function subtractPeriod(dateValue: string, period: Exclude<PortfolioPeriod, "all
   return date.toISOString().slice(0, 10);
 }
 
+function mean(values: number[]): number {
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function sampleStandardDeviation(values: number[]): number | null {
+  if (values.length < 2) return null;
+  const average = mean(values);
+  const variance = values.reduce((sum, value) => sum + ((value - average) ** 2), 0) / (values.length - 1);
+  const standardDeviation = Math.sqrt(variance);
+  return Number.isFinite(standardDeviation) ? standardDeviation : null;
+}
+
+function annualizedVolatilityPct(returns: number[]): number | null {
+  const standardDeviation = sampleStandardDeviation(returns);
+  return standardDeviation === null ? null : standardDeviation * Math.sqrt(PORTFOLIO_TRADING_DAYS_PER_YEAR) * 100;
+}
+
+function annualizedSharpe(returns: number[], dailyRiskFreeReturns: number[]): number | null {
+  if (returns.length !== dailyRiskFreeReturns.length || returns.length < 2) return null;
+  const standardDeviation = sampleStandardDeviation(returns);
+  if (standardDeviation === null || standardDeviation <= Number.EPSILON) return null;
+  const excessReturns = returns.map((value, index) => value - dailyRiskFreeReturns[index]);
+  const sharpe = (mean(excessReturns) / standardDeviation) * Math.sqrt(PORTFOLIO_TRADING_DAYS_PER_YEAR);
+  return Number.isFinite(sharpe) ? sharpe : null;
+}
+
+function dailyRiskFreeReturn(annualYieldPct: number): number | null {
+  if (!Number.isFinite(annualYieldPct) || annualYieldPct < 0) return null;
+  const dailyReturn = ((1 + (annualYieldPct / 100)) ** (1 / PORTFOLIO_TRADING_DAYS_PER_YEAR)) - 1;
+  return Number.isFinite(dailyReturn) ? dailyReturn : null;
+}
+
+function emptyRiskSummary(riskStatus: PortfolioRiskStatus, riskObservationCount = 0) {
+  return {
+    portfolioVolatilityPct: null,
+    benchmarkVolatilityPct: null,
+    portfolioSharpe: null,
+    benchmarkSharpe: null,
+    riskObservationCount,
+    riskFreeObservationCount: 0,
+    riskStatus,
+  };
+}
+
+function dailyReturnSeries(points: PortfolioNavPoint[]) {
+  const portfolioReturns: number[] = [];
+  const benchmarkReturns: number[] = [];
+  const returnDates: string[] = [];
+  for (let index = 1; index < points.length; index += 1) {
+    const previous = points[index - 1];
+    const current = points[index];
+    if (previous.nav <= 0 || current.nav < 0 || previous.benchmarkNav <= 0 || current.benchmarkNav < 0) continue;
+    const portfolioReturn = (current.nav / previous.nav) - 1;
+    const benchmarkReturn = (current.benchmarkNav / previous.benchmarkNav) - 1;
+    if (!Number.isFinite(portfolioReturn) || !Number.isFinite(benchmarkReturn)) continue;
+    portfolioReturns.push(portfolioReturn);
+    benchmarkReturns.push(benchmarkReturn);
+    returnDates.push(current.date);
+  }
+  return { portfolioReturns, benchmarkReturns, returnDates };
+}
+
+function summarizeRisk(
+  points: PortfolioNavPoint[],
+  riskFreePoints: MarketPricePoint[],
+): Pick<
+  PortfolioPeriodSummary,
+  | "portfolioVolatilityPct"
+  | "benchmarkVolatilityPct"
+  | "portfolioSharpe"
+  | "benchmarkSharpe"
+  | "riskObservationCount"
+  | "riskFreeObservationCount"
+  | "riskStatus"
+> {
+  const { portfolioReturns, benchmarkReturns, returnDates } = dailyReturnSeries(points);
+
+  const riskObservationCount = portfolioReturns.length;
+  if (points.some((point) => point.status === "stale_market_data")) {
+    return emptyRiskSummary("stale_market_data", riskObservationCount);
+  }
+  if (riskObservationCount < PORTFOLIO_RISK_MIN_OBSERVATIONS) {
+    return emptyRiskSummary("insufficient_history", riskObservationCount);
+  }
+
+  const dailyRiskFreeReturns: number[] = [];
+  for (const date of returnDates) {
+    const point = latestPriceOnOrBefore(riskFreePoints, date, MAX_RISK_FREE_DATA_AGE_DAYS);
+    const dailyReturn = point ? dailyRiskFreeReturn(point.adjustedCloseLocal) : null;
+    if (dailyReturn === null) break;
+    dailyRiskFreeReturns.push(dailyReturn);
+  }
+  const hasCompleteRiskFreeSeries = dailyRiskFreeReturns.length === riskObservationCount;
+  return {
+    portfolioVolatilityPct: annualizedVolatilityPct(portfolioReturns),
+    benchmarkVolatilityPct: annualizedVolatilityPct(benchmarkReturns),
+    portfolioSharpe: hasCompleteRiskFreeSeries ? annualizedSharpe(portfolioReturns, dailyRiskFreeReturns) : null,
+    benchmarkSharpe: hasCompleteRiskFreeSeries ? annualizedSharpe(benchmarkReturns, dailyRiskFreeReturns) : null,
+    riskObservationCount,
+    riskFreeObservationCount: dailyRiskFreeReturns.length,
+    riskStatus: hasCompleteRiskFreeSeries ? "ok" : "risk_free_unavailable",
+  };
+}
+
 export function summarizePortfolioPeriod(
   points: PortfolioNavPoint[],
   period: PortfolioPeriod,
+  riskFreePoints: MarketPricePoint[] = [],
 ): PortfolioPeriodSummary {
   const sorted = points.slice().sort((a, b) => a.date.localeCompare(b.date));
   const end = sorted[sorted.length - 1];
@@ -273,6 +395,7 @@ export function summarizePortfolioPeriod(
       returnPct: null,
       benchmarkReturnPct: null,
       excessReturnPct: null,
+      ...emptyRiskSummary("insufficient_history"),
       periodStart: null,
       periodEnd: null,
       status: "insufficient_history",
@@ -286,6 +409,7 @@ export function summarizePortfolioPeriod(
         returnPct: null,
         benchmarkReturnPct: null,
         excessReturnPct: null,
+        ...emptyRiskSummary("insufficient_history", dailyReturnSeries(sorted).portfolioReturns.length),
         periodStart: null,
         periodEnd: end.date,
         status: "insufficient_history",
@@ -299,11 +423,13 @@ export function summarizePortfolioPeriod(
   const status = periodPoints.some((point) => point.status === "stale_market_data")
     ? "stale_market_data"
     : end.status;
+  const riskSummary = summarizeRisk(periodPoints, riskFreePoints);
   return {
     returnPct,
     benchmarkReturnPct,
     excessReturnPct:
       returnPct === null || benchmarkReturnPct === null ? null : returnPct - benchmarkReturnPct,
+    ...riskSummary,
     periodStart: start.date,
     periodEnd: end.date,
     status,


### PR DESCRIPTION
## Summary

- add annualized volatility and Sharpe for every portfolio and its benchmark, calculated from daily NAV with a 20-return minimum
- collect the daily `^IRX` 13-week Treasury yield proxy and expose observation counts plus explicit incomplete-data states
- refresh Analysis and Nasdaq 100 portfolio tracks on schedule; Nasdaq remains a safe no-op until an active release exists
- redesign desktop and mobile portfolio performance views into clear Portfolio vs Benchmark metric groups
- run portfolio data bootstrap for preview PRs that touch the relevant engine, API, UI, or refresh files

## Preview

URL: https://pr-132-hedge-in-a-box-site.fly.dev/hit-rate

## Test plan

- [x] `npm run test:portfolio` (20/20 passed)
- [x] targeted ESLint for the performance engine, API route, refresh script, tests, and UI
- [x] `npm run build`
- [x] live provider check for `^IRX` and QQQ (15 August sessions each, no provider errors)
- [x] deployed preview bootstrap collected `^IRX`; Analysis Backtest API returned 77/77 matched days, portfolio volatility 29.19%, portfolio Sharpe 1.93, benchmark volatility 13.15%, and benchmark Sharpe 1.37
- [x] deployed Paper API correctly withheld risk metrics with only 3 daily returns
- [x] deployed Nasdaq API retained the release-gated empty state and identified QQQ plus the Treasury proxy
- [x] preview `/hit-rate` returned HTTP 200; desktop/mobile markup and both-mode token usage passed lint/build review

## Notes for reviewer

- No schema migration is needed. The immutable daily NAV remains the source of truth; risk summaries are derived at read time.
- `^IRX` is stored through the existing market-data cache and is backfilled from the earliest tracked cutoff on refresh.
- Scheduled refreshes now run Paper and Backtest for both workspaces. Nasdaq exits cleanly until an active release is available.
- Sharpe is annualized from daily excess returns over the matched Treasury-yield proxy; volatility is annualized sample standard deviation. Stale NAV suppresses risk metrics rather than treating frozen NAV as zero volatility.
- The in-app visual browser connection was unavailable during verification, so the preview was validated through its deployed page, API payloads, responsive markup, and theme-token/build checks rather than a screenshot pass.