### PR TITLE
Add IBKR Paper portfolio automation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,15 @@ VALUATION_BLOCK_WORKERS=3
 DATABASE_URL=
 DATABASE_URL_UNPOOLED=
 
+# IBKR Paper trading control plane. Broker login and 2FA never belong here;
+# they stay inside IB Gateway on the executor VM.
+TRADING_CONTROL_ENABLED=0
+IBKR_LIVE_TRADING_ENABLED=0
+TRADING_ACCOUNT_FINGERPRINT_KEY=
+TRADING_MONITOR_TOKEN=
+TRADING_TELEGRAM_BOT_TOKEN=
+TRADING_TELEGRAM_CHAT_ID=
+
 # Site auth (Next.js / Auth.js v5). Set these in frontend/.env.local for dev
 # and as Fly secrets for the hedge-in-a-box-site app for prod.
 # AUTH_SECRET            -- openssl rand -base64 32

--- a/.github/workflows/trading-monitor.yml
+++ b/.github/workflows/trading-monitor.yml
@@ -1,0 +1,33 @@
+name: Trading Executor Monitor
+
+on:
+  schedule:
+    - cron: '*/10 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: trading-executor-monitor
+  cancel-in-progress: true
+
+jobs:
+  heartbeat:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check executor heartbeats
+        env:
+          TRADING_MONITOR_TOKEN: ${{ secrets.TRADING_MONITOR_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${TRADING_MONITOR_TOKEN:-}" ]; then
+            echo "::error::TRADING_MONITOR_TOKEN repository secret is required."
+            exit 1
+          fi
+          curl --fail-with-body --silent --show-error \
+            --retry 2 --retry-all-errors \
+            -X POST \
+            -H "Authorization: Bearer ${TRADING_MONITOR_TOKEN}" \
+            https://hedge-in-a-box.com/api/trading/monitor

--- a/docs/ibkr-paper-trading.md
+++ b/docs/ibkr-paper-trading.md
@@ -1,0 +1,71 @@
+# Interactive Brokers Paper trading operations
+
+## Runtime architecture
+
+The production site is the control plane. Portfolio Refresh records immutable
+Paper snapshots, a separate eligibility record, and at most one rebalance plan
+for each linked strategy and snapshot. Neon stores user ownership, masked broker
+identity, device-secret hashes, commands, fills, alerts, and audit events.
+
+The Windows VM is the execution plane. IB Gateway listens only on
+`127.0.0.1:4002`; the executor makes outbound HTTPS requests to the site. Pairing
+returns a device secret exactly once. Subsequent request bodies use HMAC-SHA256
+with a five-minute timestamp window and a one-use nonce. IBKR login and 2FA stay
+inside IB Gateway.
+
+Live is intentionally unavailable in this release. `IBKR_LIVE_TRADING_ENABLED`
+remains off and the executor itself rejects Live mode and port `4001`.
+
+## Production secrets
+
+Set these only on the production Fly app and, for the monitor token, as the
+matching GitHub Actions repository secret:
+
+- `TRADING_ACCOUNT_FINGERPRINT_KEY`: random secret used to identify the paired
+  account without storing its number. Existing `AUTH_SECRET` is a fallback, but
+  a dedicated key is preferred.
+- `TRADING_MONITOR_TOKEN`: random bearer token for the scheduled heartbeat
+  monitor.
+- `TRADING_TELEGRAM_BOT_TOKEN` and `TRADING_TELEGRAM_CHAT_ID`: trading alert
+  destination.
+
+Preview environments deliberately receive none of these. Even though the
+Trading page and branched demo data are visible, `AUTH_BYPASS_PREVIEW=1` forces
+all mutations and executor endpoints to return disabled.
+
+## Snapshot and execution lifecycle
+
+1. The existing daily Portfolio Refresh updates NAV. It creates a new Paper Top
+   20 snapshot only for the monthly cutoff policy.
+2. The refresh writes eligibility separately so the frozen snapshot and
+   holdings are never rewritten. Backtests, Analysis, empty targets, and any run
+   with provider warnings are ineligible.
+3. For an armed Nasdaq-100 strategy, a unique plan is enqueued for the new
+   snapshot. Re-running the refresh cannot create a duplicate plan.
+4. The executor reconciles the account, positions, open orders, and executions,
+   then pulls commands. It acts only Monday-Friday between 10:00 and 15:30 New
+   York time.
+5. It resolves unique USD stock contracts, fetches fresh NBBO, checks manual
+   overlap and settled cash, sizes at 98% of the fixed budget, and submits WhatIf
+   for the complete sell-and-buy set. One failure blocks every order.
+6. Sells execute first. Buys start only after every sell completes. Partial work
+   is persisted and retried next session without reusing the same command
+   revision.
+7. Paper research performance remains on Portfolio Returns. Actual orders,
+   fills, fees, lag, and strategy-owned quantities remain on Trading.
+
+## Activation checklist
+
+- Apply migration `011_ibkr_paper_trading.sql` and confirm every new table and
+  unique constraint exists.
+- Configure production secrets and confirm the monitor workflow receives HTTP
+  200.
+- Use a dedicated IBKR Paper username where account policy permits it.
+- Pair the VM, verify heartbeat, and first run with local execution disabled.
+- Verify contract resolution and fresh NBBO for all 20 target symbols.
+- Verify WhatIf and a low-budget Paper order cycle with Telegram alerts.
+- Complete one full monthly Paper rebalance, including sells, buys, a forced
+  partial/retry, duplicate execution callback, and executor restart.
+- Do not design or enable a Live connection record until that full gate has
+  passed. Paper is never converted into Live; Live will require a new pairing
+  and a separate explicit UI confirmation.

--- a/docs/ibkr-paper-trading.md
+++ b/docs/ibkr-paper-trading.md
@@ -45,27 +45,36 @@ all mutations and executor endpoints to return disabled.
    snapshot. Re-running the refresh cannot create a duplicate plan.
 4. The executor reconciles the account, positions, open orders, and individual
    `ExecId` fills, reports recovered broker state, and only then pulls commands.
-   It acts only Monday-Friday between 10:00 and 15:30 New York time.
+   It acquires a single-writer server lease before connecting to Gateway and
+   acts only Monday-Friday between 10:00 and 15:30 New York time. A per-connection
+   SQLite WAL journal preserves order intents, executions, and outbound events
+   across a process or control-plane restart.
 5. It resolves unique USD stock contracts, fetches fresh NBBO, checks manual
-   overlap and settled cash, and sizes at 98% of the fixed budget. Every one of
+   positions/open orders and settled cash, and sizes at 98% of the lesser of
+   the fixed budget or strategy equity. Every one of
    the snapshot's N targets must receive a tradable quantity (`N/N`), regardless
    of whether N is 20 or smaller; otherwise the complete plan is blocked.
-6. Every submitted phase passes WhatIf. Sells execute first. Buys start only
+6. Every real attempt passes WhatIf and a retry may never worsen the preflight
+   limit. Sells execute first. Buys start only
    after every sell completes and IBKR reports enough settled USD cash. Sale
-   proceeds from the same day and margin buying power are not counted. A plan
-   can wait until a later session in `awaiting_settlement`.
+   proceeds from the same day and margin buying power are not counted. The
+   correction-aware strategy cash ledger also prevents unrelated account cash
+   from refilling losses. A plan can wait until a later session in
+   `awaiting_settlement`.
 7. Paper research performance remains on Portfolio Returns. Actual orders,
    fills, fees, lag, and strategy-owned quantities remain on Trading.
 
 ## Activation checklist
 
 - Apply migrations `011_ibkr_paper_trading.sql` and
-  `012_ibkr_trading_hardening.sql`, then confirm every new table, status, and
-  unique constraint exists.
+  `012_ibkr_trading_hardening.sql` and `013_ibkr_executor_durability.sql`, then
+  confirm every new table, status, lease, cash-ledger, and correction field exists.
 - Configure production secrets and confirm the monitor workflow receives HTTP
   200.
 - Use a dedicated IBKR Paper username where account policy permits it.
 - Pair the VM, verify heartbeat, and first run with local execution disabled.
+- Verify a second local process and a second executor instance are rejected,
+  then verify Pause/kill switch cancels only system orders.
 - Verify contract resolution, fresh NBBO, and full `N/N` coverage for every
   target symbol in the selected snapshot.
 - Verify WhatIf and a low-budget Paper order cycle with Telegram alerts.

--- a/docs/ibkr-paper-trading.md
+++ b/docs/ibkr-paper-trading.md
@@ -35,34 +35,39 @@ all mutations and executor endpoints to return disabled.
 
 ## Snapshot and execution lifecycle
 
-1. The existing daily Portfolio Refresh updates NAV. It creates a new Paper Top
-   20 snapshot only for the monthly cutoff policy.
+1. The existing daily Portfolio Refresh updates NAV. It creates a new Paper
+   snapshot of up to 20 positive-score names only for the monthly cutoff policy;
+   fewer names are a valid methodology result.
 2. The refresh writes eligibility separately so the frozen snapshot and
    holdings are never rewritten. Backtests, Analysis, empty targets, and any run
    with provider warnings are ineligible.
 3. For an armed Nasdaq-100 strategy, a unique plan is enqueued for the new
    snapshot. Re-running the refresh cannot create a duplicate plan.
-4. The executor reconciles the account, positions, open orders, and executions,
-   then pulls commands. It acts only Monday-Friday between 10:00 and 15:30 New
-   York time.
+4. The executor reconciles the account, positions, open orders, and individual
+   `ExecId` fills, reports recovered broker state, and only then pulls commands.
+   It acts only Monday-Friday between 10:00 and 15:30 New York time.
 5. It resolves unique USD stock contracts, fetches fresh NBBO, checks manual
-   overlap and settled cash, sizes at 98% of the fixed budget, and submits WhatIf
-   for the complete sell-and-buy set. One failure blocks every order.
-6. Sells execute first. Buys start only after every sell completes. Partial work
-   is persisted and retried next session without reusing the same command
-   revision.
+   overlap and settled cash, and sizes at 98% of the fixed budget. Every one of
+   the snapshot's N targets must receive a tradable quantity (`N/N`), regardless
+   of whether N is 20 or smaller; otherwise the complete plan is blocked.
+6. Every submitted phase passes WhatIf. Sells execute first. Buys start only
+   after every sell completes and IBKR reports enough settled USD cash. Sale
+   proceeds from the same day and margin buying power are not counted. A plan
+   can wait until a later session in `awaiting_settlement`.
 7. Paper research performance remains on Portfolio Returns. Actual orders,
    fills, fees, lag, and strategy-owned quantities remain on Trading.
 
 ## Activation checklist
 
-- Apply migration `011_ibkr_paper_trading.sql` and confirm every new table and
+- Apply migrations `011_ibkr_paper_trading.sql` and
+  `012_ibkr_trading_hardening.sql`, then confirm every new table, status, and
   unique constraint exists.
 - Configure production secrets and confirm the monitor workflow receives HTTP
   200.
 - Use a dedicated IBKR Paper username where account policy permits it.
 - Pair the VM, verify heartbeat, and first run with local execution disabled.
-- Verify contract resolution and fresh NBBO for all 20 target symbols.
+- Verify contract resolution, fresh NBBO, and full `N/N` coverage for every
+  target symbol in the selected snapshot.
 - Verify WhatIf and a low-budget Paper order cycle with Telegram alerts.
 - Complete one full monthly Paper rebalance, including sells, buys, a forced
   partial/retry, duplicate execution callback, and executor restart.

--- a/fly.site.toml
+++ b/fly.site.toml
@@ -16,6 +16,9 @@ kill_timeout = "1m0s"
   NODE_ENV = "production"
   PYTHONUNBUFFERED = "1"
   PYTHON_EXECUTABLE = "python3"
+  # Paper control plane only. AUTH_BYPASS_PREVIEW forces all mutations off in PR previews.
+  TRADING_CONTROL_ENABLED = "1"
+  IBKR_LIVE_TRADING_ENABLED = "0"
 
 [[mounts]]
   source = "site_data_fra"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "eslint",
     "portfolio:refresh": "tsx scripts/refresh-portfolio-performance.ts",
-    "test:portfolio": "tsx --test src/lib/discovery-engine.test.ts src/lib/nasdaq-execution-policy.test.ts src/lib/nasdaq-run-policy.test.ts src/lib/portfolio-performance-engine.test.ts src/lib/portfolio-refresh-policy.test.ts src/lib/workspace.test.ts"
+    "test:portfolio": "tsx --test src/lib/discovery-engine.test.ts src/lib/nasdaq-execution-policy.test.ts src/lib/nasdaq-run-policy.test.ts src/lib/portfolio-performance-engine.test.ts src/lib/portfolio-refresh-policy.test.ts src/lib/trading-access-policy.test.ts src/lib/trading-signature.test.ts src/lib/workspace.test.ts"
   },
   "dependencies": {
     "@neondatabase/serverless": "^1.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "eslint",
     "portfolio:refresh": "tsx scripts/refresh-portfolio-performance.ts",
-    "test:portfolio": "tsx --test src/lib/discovery-engine.test.ts src/lib/nasdaq-execution-policy.test.ts src/lib/nasdaq-run-policy.test.ts src/lib/portfolio-performance-engine.test.ts src/lib/portfolio-refresh-policy.test.ts src/lib/trading-access-policy.test.ts src/lib/trading-signature.test.ts src/lib/workspace.test.ts"
+    "test:portfolio": "tsx --test src/lib/discovery-engine.test.ts src/lib/nasdaq-execution-policy.test.ts src/lib/nasdaq-run-policy.test.ts src/lib/portfolio-performance-engine.test.ts src/lib/portfolio-refresh-policy.test.ts src/lib/trading-access-policy.test.ts src/lib/trading-db.test.ts src/lib/trading-signature.test.ts src/lib/workspace.test.ts"
   },
   "dependencies": {
     "@neondatabase/serverless": "^1.1.0",

--- a/frontend/scripts/refresh-portfolio-performance.ts
+++ b/frontend/scripts/refresh-portfolio-performance.ts
@@ -36,6 +36,12 @@ import {
   type PortfolioTrack,
 } from "../src/lib/portfolio-performance-engine";
 import { planPaperCutoffs } from "../src/lib/portfolio-refresh-policy";
+import {
+  enqueueArmedStrategiesForSnapshots,
+  finishPortfolioRefreshRun,
+  recordSnapshotTradeEligibility,
+  startPortfolioRefreshRun,
+} from "../src/lib/trading-db";
 import type { Workspace } from "../src/lib/workspace";
 
 type PriceBundle = {
@@ -273,7 +279,14 @@ async function main() {
     return;
   }
 
+  let refreshRunId: string | null = null;
   try {
+    refreshRunId = await startPortfolioRefreshRun({
+      workspace: args.workspace,
+      track: args.track,
+      methodologyVersion: PORTFOLIO_METHODOLOGY_VERSION,
+    });
+    const processedSnapshotIds: string[] = [];
     if (args.replaceBacktest) {
       await deletePortfolioTrack(args.workspace, "backtest", PORTFOLIO_METHODOLOGY_VERSION);
     }
@@ -307,6 +320,12 @@ async function main() {
     });
     if (args.workspace === "nasdaq100" && reports.length === 0) {
       console.log("[portfolio] Nasdaq 100 has no active release reports; no snapshots were created.");
+      await finishPortfolioRefreshRun({
+        runId: refreshRunId,
+        status: "partial",
+        warnings: [{ code: "no_active_release_reports" }],
+      });
+      refreshRunId = null;
       return;
     }
     const currencyByTicker = new Map<string, string>();
@@ -400,7 +419,7 @@ async function main() {
           priceBySymbol,
           currencyByTicker,
         });
-        await insertPortfolioSnapshot({
+        const storedSnapshot = await insertPortfolioSnapshot({
           workspace: args.workspace,
           track: args.track,
           lens,
@@ -413,6 +432,7 @@ async function main() {
           status: holdings.length ? "ready" : "no_positions",
           holdings,
         });
+        processedSnapshotIds.push(storedSnapshot.id);
         createdForCutoff += 1;
       }
       console.log(`[portfolio] ${args.track} cutoff ${cutoffDate}: ${createdForCutoff} snapshots (${visibleReports.length} reports).`);
@@ -439,7 +459,48 @@ async function main() {
     if (priceBundle.errors?.length) {
       console.warn(`[portfolio] provider warnings: ${JSON.stringify(priceBundle.errors)}`);
     }
+    const warningReasons = priceBundle.errors?.length ? ["provider_warnings"] : [];
+    const uniqueSnapshotIds = Array.from(new Set(processedSnapshotIds));
+    const snapshotsById = new Map(existing.map((snapshot) => [snapshot.id, snapshot]));
+    const tradeEligibleSnapshotIds: string[] = [];
+    for (const snapshotId of uniqueSnapshotIds) {
+      const snapshot = snapshotsById.get(snapshotId);
+      const reasons = [...warningReasons];
+      if (args.track !== "paper") reasons.push("backtest_not_tradeable");
+      if (args.workspace !== "nasdaq100") reasons.push("analysis_execution_not_released");
+      if (snapshot?.status !== "ready") reasons.push("empty_target_requires_confirmation");
+      const eligible = reasons.length === 0;
+      await recordSnapshotTradeEligibility({
+        snapshotIds: [snapshotId],
+        refreshRunId,
+        eligible,
+        reasons,
+        allowUpgrade: Boolean(args.paperCutoff),
+      });
+      if (eligible) tradeEligibleSnapshotIds.push(snapshotId);
+    }
+    const enqueued = await enqueueArmedStrategiesForSnapshots(tradeEligibleSnapshotIds);
+    await finishPortfolioRefreshRun({
+      runId: refreshRunId,
+      status: priceBundle.errors?.length ? "partial" : "completed",
+      warnings: priceBundle.errors || [],
+    });
+    refreshRunId = null;
+    if (enqueued) console.log(`[portfolio] enqueued ${enqueued} IBKR Paper rebalance plan(s).`);
     console.log(`[portfolio] refreshed ${args.workspace}/${args.track}: ${existing.length} snapshots, ${fetchedPoints.length} price rows.`);
+  } catch (error) {
+    if (refreshRunId) {
+      try {
+        await finishPortfolioRefreshRun({
+          runId: refreshRunId,
+          status: "failed",
+          error: error instanceof Error ? error.message : String(error),
+        });
+      } catch (finishError) {
+        console.error(`[portfolio] could not record failed refresh: ${String(finishError)}`);
+      }
+    }
+    throw error;
   } finally {
     await releasePortfolioRefreshLock(lockKey, owner);
   }

--- a/frontend/src/app/(app)/trading/page.tsx
+++ b/frontend/src/app/(app)/trading/page.tsx
@@ -1,0 +1,11 @@
+import { Suspense } from "react";
+
+import { TradingDashboard } from "@/components/trading-dashboard";
+
+export default function TradingPage() {
+  return (
+    <Suspense fallback={<div className="p-6 text-sm text-[color:var(--text-muted)]">Loading trading controls...</div>}>
+      <TradingDashboard />
+    </Suspense>
+  );
+}

--- a/frontend/src/app/api/portfolio-performance/route.ts
+++ b/frontend/src/app/api/portfolio-performance/route.ts
@@ -52,6 +52,15 @@ function summarizeLens(
   const sorted = rows.slice().sort((a, b) => a.date.localeCompare(b.date));
   const summary = summarizePortfolioPeriod(sorted, period, riskFreePoints);
   const latest = sorted[sorted.length - 1];
+  const tradeEligibilityReasons = track === "paper"
+    ? latest.tradeEligibilityReasons.slice()
+    : ["backtest_not_tradeable"];
+  if (track === "paper" && workspace === "analysis") {
+    tradeEligibilityReasons.push("analysis_execution_not_released");
+  }
+  if (track === "paper" && !latest.tradeEligible && !tradeEligibilityReasons.length) {
+    tradeEligibilityReasons.push("refresh_not_verified");
+  }
   return {
     lens_type: latest.lensType,
     lens_key: latest.lensType === "overall" ? null : latest.lensKey,
@@ -66,8 +75,8 @@ function summarizeLens(
     cutoff_at: latest.snapshotCutoffAt,
     execution_date: latest.snapshotExecutionDate,
     trade_eligibility: {
-      eligible: track === "paper" && latest.tradeEligible,
-      reasons: track === "paper" ? latest.tradeEligibilityReasons : ["backtest_not_tradeable"],
+      eligible: track === "paper" && workspace === "nasdaq100" && latest.tradeEligible,
+      reasons: Array.from(new Set(tradeEligibilityReasons)),
     },
     return_pct: summary.returnPct,
     benchmark_return_pct: summary.benchmarkReturnPct,

--- a/frontend/src/app/api/portfolio-performance/route.ts
+++ b/frontend/src/app/api/portfolio-performance/route.ts
@@ -15,6 +15,7 @@ import {
   type PortfolioTrack,
 } from "@/lib/portfolio-performance-engine";
 import { parseApiWorkspace, type Workspace } from "@/lib/workspace";
+import { tradingPortfolioKey } from "@/lib/trading-types";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -45,6 +46,8 @@ function summarizeLens(
   rows: StoredPortfolioNavPoint[],
   period: PortfolioPeriod,
   riskFreePoints: MarketPricePoint[],
+  workspace: Workspace,
+  track: PortfolioTrack,
 ) {
   const sorted = rows.slice().sort((a, b) => a.date.localeCompare(b.date));
   const summary = summarizePortfolioPeriod(sorted, period, riskFreePoints);
@@ -53,6 +56,19 @@ function summarizeLens(
     lens_type: latest.lensType,
     lens_key: latest.lensType === "overall" ? null : latest.lensKey,
     label: latest.lensType === "overall" ? "Overall" : latest.lensLabel,
+    portfolio_key: tradingPortfolioKey({
+      workspace,
+      lensType: latest.lensType,
+      lensKey: latest.lensKey,
+      methodologyVersion: latest.methodologyVersion,
+    }),
+    latest_snapshot_id: latest.snapshotId,
+    cutoff_at: latest.snapshotCutoffAt,
+    execution_date: latest.snapshotExecutionDate,
+    trade_eligibility: {
+      eligible: track === "paper" && latest.tradeEligible,
+      reasons: track === "paper" ? latest.tradeEligibilityReasons : ["backtest_not_tradeable"],
+    },
     return_pct: summary.returnPct,
     benchmark_return_pct: summary.benchmarkReturnPct,
     excess_return_pct: summary.excessReturnPct,
@@ -128,7 +144,7 @@ export async function GET(request: Request) {
     });
     const riskFreePoints = riskFreePrices.get(PORTFOLIO_RISK_FREE_SYMBOL) || [];
     const summaries = groupByLens(rows)
-      .map((group) => summarizeLens(group, period, riskFreePoints))
+      .map((group) => summarizeLens(group, period, riskFreePoints, workspace, track))
       .sort((a, b) => {
         if (a.lens_type === "overall") return -1;
         if (b.lens_type === "overall") return 1;

--- a/frontend/src/app/api/trading/control/route.ts
+++ b/frontend/src/app/api/trading/control/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+
+import { pauseTradingStrategy, resumeTradingStrategy } from "@/lib/trading-db";
+import {
+  requireTradingMutationEnabled,
+  requireTradingUser,
+  TradingDisabledError,
+  TradingUnauthorizedError,
+} from "@/lib/trading-security";
+
+export const runtime = "nodejs";
+
+export async function POST(request: Request) {
+  try {
+    requireTradingMutationEnabled();
+    const user = await requireTradingUser();
+    const body = await request.json() as Record<string, unknown>;
+    const action = String(body.action || "");
+    if (!new Set(["pause", "resume", "kill_switch"]).has(action)) {
+      return NextResponse.json({ error: "Invalid control action." }, { status: 400 });
+    }
+    const connectionId = String(body.connection_id || "");
+    if (action === "resume") {
+      await resumeTradingStrategy({ userId: user.userId, connectionId });
+    } else {
+      await pauseTradingStrategy({
+        userId: user.userId,
+        connectionId,
+        cancelOpenOrders: action === "kill_switch",
+      });
+    }
+    return NextResponse.json({ ok: true, action });
+  } catch (error) {
+    if (error instanceof TradingUnauthorizedError) return NextResponse.json({ error: error.message }, { status: 401 });
+    if (error instanceof TradingDisabledError) return NextResponse.json({ error: error.message }, { status: 503 });
+    const message = error instanceof Error ? error.message : "Could not apply the control action.";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/frontend/src/app/api/trading/executor/events/route.ts
+++ b/frontend/src/app/api/trading/executor/events/route.ts
@@ -4,7 +4,6 @@ import { sendTradingTelegramAlert } from "@/lib/trading-alerts";
 import {
   insertTradingFill,
   recordTradingEvent,
-  replaceTradingStrategyPositions,
   updateRebalanceStatus,
   upsertTradingInstrument,
   upsertTradingOrder,
@@ -23,6 +22,7 @@ const ORDER_STATUSES = new Set([
   "planned", "what_if", "submitted", "partially_filled", "filled",
   "cancel_pending", "cancelled", "rejected", "error",
 ]);
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function finite(value: unknown): number | null {
   const parsed = Number(value);
@@ -38,10 +38,13 @@ export async function POST(request: Request) {
     let responsePayload: Record<string, unknown> = {};
     if (action === "plan_status") {
       const status = String(body.status || "") as RebalanceStatus;
-      if (!PLAN_STATUSES.has(status)) return NextResponse.json({ error: "Invalid plan status." }, { status: 400 });
+      const planId = String(body.plan_id || "");
+      if (!PLAN_STATUSES.has(status) || !UUID_RE.test(planId)) {
+        return NextResponse.json({ error: "Invalid plan status." }, { status: 400 });
+      }
       accepted = await updateRebalanceStatus({
         connectionId,
-        planId: String(body.plan_id || ""),
+        planId,
         status,
         error: String(body.error || "").slice(0, 2_000),
         preflight: (body.preflight || {}) as Record<string, unknown>,
@@ -66,12 +69,13 @@ export async function POST(request: Request) {
       const quantity = finite(body.requested_quantity);
       const clientOrderKey = String(body.client_order_key || "");
       const symbol = String(body.symbol || "");
+      const planId = String(body.plan_id || "");
       if ((side !== "BUY" && side !== "SELL") || !ORDER_STATUSES.has(status) || !quantity || quantity <= 0
-        || !clientOrderKey || clientOrderKey.length > 300 || !symbol || symbol.length > 30) {
+        || !clientOrderKey || clientOrderKey.length > 300 || !symbol || symbol.length > 30 || !UUID_RE.test(planId)) {
         return NextResponse.json({ error: "Invalid order event." }, { status: 400 });
       }
       const orderId = await upsertTradingOrder({
-        connectionId, planId: String(body.plan_id || ""), clientOrderKey,
+        connectionId, planId, clientOrderKey,
         symbol, conid: finite(body.conid), side,
         requestedQuantity: quantity, limitPrice: finite(body.limit_price), ibOrderId: finite(body.ib_order_id),
         ibPermId: finite(body.ib_perm_id), status, filledQuantity: finite(body.filled_quantity) || 0,
@@ -87,12 +91,15 @@ export async function POST(request: Request) {
       const price = finite(body.price);
       const execId = String(body.exec_id || "");
       const symbol = String(body.symbol || "");
+      const orderId = body.order_id ? String(body.order_id) : "";
+      const clientOrderKey = String(body.client_order_key || "");
       if ((side !== "BUY" && side !== "SELL") || !quantity || quantity <= 0 || !price || price <= 0
-        || !execId || execId.length > 300 || !symbol || symbol.length > 30) {
+        || !execId || execId.length > 300 || !symbol || symbol.length > 30
+        || (orderId ? !UUID_RE.test(orderId) : !clientOrderKey || clientOrderKey.length > 300)) {
         return NextResponse.json({ error: "Invalid fill event." }, { status: 400 });
       }
       accepted = await insertTradingFill({
-        connectionId, orderId: body.order_id ? String(body.order_id) : null,
+        connectionId, orderId: orderId || null, clientOrderKey: clientOrderKey || null,
         execId, symbol, side,
         quantity, price, commission: finite(body.commission) || 0,
         commissionCurrency: String(body.commission_currency || "USD"),
@@ -100,18 +107,9 @@ export async function POST(request: Request) {
         rawExecution: (body.raw_execution || {}) as Record<string, unknown>,
       });
     } else if (action === "positions") {
-      const positions = Array.isArray(body.positions) ? body.positions : [];
-      accepted = await replaceTradingStrategyPositions({
-        connectionId,
-        strategyLinkId: String(body.strategy_link_id || ""),
-        positions: positions.map((value) => {
-          const row = (value || {}) as Record<string, unknown>;
-          return {
-            symbol: String(row.symbol || ""), conid: finite(row.conid), quantity: finite(row.quantity) ?? -1,
-            averageCostUsd: finite(row.average_cost_usd),
-          };
-        }),
-      });
+      return NextResponse.json({
+        error: "Broker positions cannot mutate strategy ownership; ownership is derived from system fills.",
+      }, { status: 400 });
     } else if (action === "event") {
       const severity = String(body.severity || "info") as "info" | "warning" | "critical";
       if (!new Set(["info", "warning", "critical"]).has(severity)) {
@@ -120,11 +118,12 @@ export async function POST(request: Request) {
       const eventId = String(body.event_id || "");
       const message = String(body.message || "").slice(0, 2_000);
       if (!eventId || eventId.length > 300) return NextResponse.json({ error: "Invalid event id." }, { status: 400 });
-      accepted = await recordTradingEvent({
+      const inserted = await recordTradingEvent({
         connectionId, eventId, eventType: String(body.event_type || "executor"), severity, message,
         payload: (body.payload || {}) as Record<string, unknown>,
       });
-      if (accepted && severity !== "info") {
+      accepted = true;
+      if (inserted && severity !== "info") {
         await sendTradingTelegramAlert({ connectionId, eventId, severity, message });
       }
     } else {

--- a/frontend/src/app/api/trading/executor/events/route.ts
+++ b/frontend/src/app/api/trading/executor/events/route.ts
@@ -1,0 +1,140 @@
+import { NextResponse } from "next/server";
+
+import { sendTradingTelegramAlert } from "@/lib/trading-alerts";
+import {
+  insertTradingFill,
+  recordTradingEvent,
+  replaceTradingStrategyPositions,
+  updateRebalanceStatus,
+  upsertTradingInstrument,
+  upsertTradingOrder,
+} from "@/lib/trading-db";
+import { authenticateExecutorRequest, ExecutorAuthenticationError } from "@/lib/trading-executor-auth";
+import { requireTradingMutationEnabled, TradingDisabledError } from "@/lib/trading-security";
+import type { RebalanceStatus } from "@/lib/trading-types";
+
+export const runtime = "nodejs";
+
+const PLAN_STATUSES = new Set<RebalanceStatus>([
+  "queued", "preflight", "awaiting_market", "selling", "buying", "completed",
+  "partial", "blocked", "cancel_requested", "cancelled",
+]);
+const ORDER_STATUSES = new Set([
+  "planned", "what_if", "submitted", "partially_filled", "filled",
+  "cancel_pending", "cancelled", "rejected", "error",
+]);
+
+function finite(value: unknown): number | null {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export async function POST(request: Request) {
+  try {
+    requireTradingMutationEnabled();
+    const { connectionId, body } = await authenticateExecutorRequest<Record<string, unknown>>(request);
+    const action = String(body.action || "");
+    let accepted = false;
+    let responsePayload: Record<string, unknown> = {};
+    if (action === "plan_status") {
+      const status = String(body.status || "") as RebalanceStatus;
+      if (!PLAN_STATUSES.has(status)) return NextResponse.json({ error: "Invalid plan status." }, { status: 400 });
+      accepted = await updateRebalanceStatus({
+        connectionId,
+        planId: String(body.plan_id || ""),
+        status,
+        error: String(body.error || "").slice(0, 2_000),
+        preflight: (body.preflight || {}) as Record<string, unknown>,
+      });
+    } else if (action === "instrument") {
+      const conid = finite(body.conid);
+      const symbol = String(body.symbol || "");
+      if (!conid || !symbol || symbol.length > 30) return NextResponse.json({ error: "Invalid instrument." }, { status: 400 });
+      await upsertTradingInstrument({
+        symbol, conid,
+        secType: String(body.sec_type || "STK"), exchange: String(body.exchange || "SMART"),
+        primaryExchange: String(body.primary_exchange || ""), currency: String(body.currency || "USD"),
+        minTick: finite(body.min_tick), minSize: finite(body.min_size), sizeIncrement: finite(body.size_increment),
+        supportsFractional: body.supports_fractional === true,
+        liquidHours: String(body.liquid_hours || ""), timeZone: String(body.time_zone || ""),
+        approved: body.approved === true,
+      });
+      accepted = true;
+    } else if (action === "order") {
+      const side = String(body.side || "");
+      const status = String(body.status || "");
+      const quantity = finite(body.requested_quantity);
+      const clientOrderKey = String(body.client_order_key || "");
+      const symbol = String(body.symbol || "");
+      if ((side !== "BUY" && side !== "SELL") || !ORDER_STATUSES.has(status) || !quantity || quantity <= 0
+        || !clientOrderKey || clientOrderKey.length > 300 || !symbol || symbol.length > 30) {
+        return NextResponse.json({ error: "Invalid order event." }, { status: 400 });
+      }
+      const orderId = await upsertTradingOrder({
+        connectionId, planId: String(body.plan_id || ""), clientOrderKey,
+        symbol, conid: finite(body.conid), side,
+        requestedQuantity: quantity, limitPrice: finite(body.limit_price), ibOrderId: finite(body.ib_order_id),
+        ibPermId: finite(body.ib_perm_id), status, filledQuantity: finite(body.filled_quantity) || 0,
+        averageFillPrice: finite(body.average_fill_price), commission: finite(body.commission) || 0,
+        commissionCurrency: String(body.commission_currency || "USD"),
+        rawStatus: (body.raw_status || {}) as Record<string, unknown>,
+      });
+      accepted = Boolean(orderId);
+      responsePayload = { order_id: orderId };
+    } else if (action === "fill") {
+      const side = String(body.side || "");
+      const quantity = finite(body.quantity);
+      const price = finite(body.price);
+      const execId = String(body.exec_id || "");
+      const symbol = String(body.symbol || "");
+      if ((side !== "BUY" && side !== "SELL") || !quantity || quantity <= 0 || !price || price <= 0
+        || !execId || execId.length > 300 || !symbol || symbol.length > 30) {
+        return NextResponse.json({ error: "Invalid fill event." }, { status: 400 });
+      }
+      accepted = await insertTradingFill({
+        connectionId, orderId: body.order_id ? String(body.order_id) : null,
+        execId, symbol, side,
+        quantity, price, commission: finite(body.commission) || 0,
+        commissionCurrency: String(body.commission_currency || "USD"),
+        executedAt: String(body.executed_at || new Date().toISOString()),
+        rawExecution: (body.raw_execution || {}) as Record<string, unknown>,
+      });
+    } else if (action === "positions") {
+      const positions = Array.isArray(body.positions) ? body.positions : [];
+      accepted = await replaceTradingStrategyPositions({
+        connectionId,
+        strategyLinkId: String(body.strategy_link_id || ""),
+        positions: positions.map((value) => {
+          const row = (value || {}) as Record<string, unknown>;
+          return {
+            symbol: String(row.symbol || ""), conid: finite(row.conid), quantity: finite(row.quantity) ?? -1,
+            averageCostUsd: finite(row.average_cost_usd),
+          };
+        }),
+      });
+    } else if (action === "event") {
+      const severity = String(body.severity || "info") as "info" | "warning" | "critical";
+      if (!new Set(["info", "warning", "critical"]).has(severity)) {
+        return NextResponse.json({ error: "Invalid event severity." }, { status: 400 });
+      }
+      const eventId = String(body.event_id || "");
+      const message = String(body.message || "").slice(0, 2_000);
+      if (!eventId || eventId.length > 300) return NextResponse.json({ error: "Invalid event id." }, { status: 400 });
+      accepted = await recordTradingEvent({
+        connectionId, eventId, eventType: String(body.event_type || "executor"), severity, message,
+        payload: (body.payload || {}) as Record<string, unknown>,
+      });
+      if (accepted && severity !== "info") {
+        await sendTradingTelegramAlert({ connectionId, eventId, severity, message });
+      }
+    } else {
+      return NextResponse.json({ error: "Unknown executor event action." }, { status: 400 });
+    }
+    return NextResponse.json({ accepted, ...responsePayload });
+  } catch (error) {
+    if (error instanceof ExecutorAuthenticationError) return NextResponse.json({ error: error.message }, { status: 401 });
+    if (error instanceof TradingDisabledError) return NextResponse.json({ error: error.message }, { status: 503 });
+    console.error("[trading] executor event failed", error);
+    return NextResponse.json({ error: "Executor event failed." }, { status: 500 });
+  }
+}

--- a/frontend/src/app/api/trading/executor/events/route.ts
+++ b/frontend/src/app/api/trading/executor/events/route.ts
@@ -16,7 +16,7 @@ import type { RebalanceStatus } from "@/lib/trading-types";
 export const runtime = "nodejs";
 
 const PLAN_STATUSES = new Set<RebalanceStatus>([
-  "queued", "preflight", "awaiting_market", "selling", "buying", "completed",
+  "queued", "preflight", "awaiting_market", "awaiting_settlement", "selling", "buying", "completed",
   "partial", "blocked", "cancel_requested", "cancelled",
 ]);
 const ORDER_STATUSES = new Set([

--- a/frontend/src/app/api/trading/executor/pair/route.ts
+++ b/frontend/src/app/api/trading/executor/pair/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+
+import { consumeTradingPairing } from "@/lib/trading-db";
+import {
+  accountFingerprint,
+  generateDeviceSecret,
+  maskAccountId,
+  normalizePairingCode,
+  requireTradingMutationEnabled,
+  sha256,
+  TradingDisabledError,
+} from "@/lib/trading-security";
+
+export const runtime = "nodejs";
+
+export async function POST(request: Request) {
+  try {
+    requireTradingMutationEnabled();
+    const body = await request.json() as Record<string, unknown>;
+    const code = normalizePairingCode(String(body.code || ""));
+    const mode = String(body.mode || "paper");
+    const accountId = String(body.account_id || "").trim().toUpperCase();
+    const executorVersion = String(body.executor_version || "unknown").trim().slice(0, 100);
+    if (code.length !== 8 || mode !== "paper" || !accountId || accountId.length > 50) {
+      return NextResponse.json({ error: "Invalid Paper pairing request." }, { status: 400 });
+    }
+    const deviceSecret = generateDeviceSecret();
+    const connectionId = await consumeTradingPairing({
+      codeHash: sha256(code),
+      deviceSecretHash: sha256(deviceSecret),
+      accountFingerprint: accountFingerprint(accountId),
+      accountMasked: maskAccountId(accountId),
+      mode: "paper",
+      executorVersion,
+    });
+    if (!connectionId) return NextResponse.json({ error: "Pairing code is invalid or expired." }, { status: 401 });
+    return NextResponse.json({
+      connection_id: connectionId,
+      device_secret: deviceSecret,
+      mode: "paper",
+      account_masked: maskAccountId(accountId),
+    });
+  } catch (error) {
+    if (error instanceof TradingDisabledError) return NextResponse.json({ error: error.message }, { status: 503 });
+    console.error("[trading] executor pairing failed", error);
+    return NextResponse.json({ error: "Executor pairing failed." }, { status: 500 });
+  }
+}

--- a/frontend/src/app/api/trading/executor/sync/route.ts
+++ b/frontend/src/app/api/trading/executor/sync/route.ts
@@ -1,7 +1,12 @@
 import { NextResponse } from "next/server";
 
 import { sendTradingTelegramAlert } from "@/lib/trading-alerts";
-import { loadExecutorCommands, recordTradingEvent, updateTradingHeartbeat } from "@/lib/trading-db";
+import {
+  loadExecutorCancellationIds,
+  loadExecutorCommands,
+  recordTradingEvent,
+  updateTradingHeartbeat,
+} from "@/lib/trading-db";
 import { authenticateExecutorRequest, ExecutorAuthenticationError } from "@/lib/trading-executor-auth";
 import {
   accountFingerprint,
@@ -21,27 +26,40 @@ type SyncBody = {
   gateway_authenticated?: boolean;
   account_type?: string;
   error?: string;
+  executor_instance_id?: string;
+  lease_only?: boolean;
 };
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 export async function POST(request: Request) {
   try {
     requireTradingMutationEnabled();
     const authenticated = await authenticateExecutorRequest<SyncBody>(request);
     const body = authenticated.body;
+    const executorInstanceId = String(body.executor_instance_id || "");
+    if (!UUID_RE.test(executorInstanceId)) {
+      return NextResponse.json({ error: "A stable executor instance id is required." }, { status: 400 });
+    }
     const suppliedFingerprint = accountFingerprint(String(body.account_id || ""));
     if (body.mode !== authenticated.mode
       || !constantTimeTextEqual(suppliedFingerprint, authenticated.accountFingerprint)) {
       return NextResponse.json({ error: "Executor account or mode does not match the paired connection." }, { status: 409 });
     }
-    await updateTradingHeartbeat({
+    const leaseAcquired = await updateTradingHeartbeat({
       connectionId: authenticated.connectionId,
+      executorInstanceId,
       gatewayConnected: body.gateway_connected === true,
       gatewayAuthenticated: body.gateway_authenticated === true,
       executorVersion: String(body.executor_version || "unknown").slice(0, 100),
       accountType: String(body.account_type || "UNKNOWN").slice(0, 100),
       error: String(body.error || "").slice(0, 2_000),
+      leaseOnly: body.lease_only === true,
     });
-    if (!body.gateway_connected || !body.gateway_authenticated) {
+    if (!leaseAcquired) {
+      return NextResponse.json({ error: "Another executor instance owns the active lease." }, { status: 409 });
+    }
+    if (body.lease_only !== true && (!body.gateway_connected || !body.gateway_authenticated)) {
       const message = String(body.error || "IB Gateway is disconnected or unauthenticated.").slice(0, 2_000);
       const eventId = `gateway-disconnected:${new Date().toISOString().slice(0, 10)}:${sha256(message).slice(0, 12)}`;
       const inserted = await recordTradingEvent({
@@ -60,10 +78,18 @@ export async function POST(request: Request) {
         });
       }
     }
-    const commands = body.gateway_connected && body.gateway_authenticated
-      ? await loadExecutorCommands(authenticated.connectionId)
+    const commands = body.lease_only !== true && body.gateway_connected && body.gateway_authenticated
+      ? await loadExecutorCommands(authenticated.connectionId, executorInstanceId)
       : [];
-    return NextResponse.json({ server_time: new Date().toISOString(), commands });
+    const cancelRequestedPlanIds = await loadExecutorCancellationIds(
+      authenticated.connectionId,
+      executorInstanceId,
+    );
+    return NextResponse.json({
+      server_time: new Date().toISOString(),
+      commands,
+      cancel_requested_plan_ids: cancelRequestedPlanIds,
+    });
   } catch (error) {
     if (error instanceof ExecutorAuthenticationError) return NextResponse.json({ error: error.message }, { status: 401 });
     if (error instanceof TradingDisabledError) return NextResponse.json({ error: error.message }, { status: 503 });

--- a/frontend/src/app/api/trading/executor/sync/route.ts
+++ b/frontend/src/app/api/trading/executor/sync/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+
+import { sendTradingTelegramAlert } from "@/lib/trading-alerts";
+import { loadExecutorCommands, recordTradingEvent, updateTradingHeartbeat } from "@/lib/trading-db";
+import { authenticateExecutorRequest, ExecutorAuthenticationError } from "@/lib/trading-executor-auth";
+import {
+  accountFingerprint,
+  constantTimeTextEqual,
+  requireTradingMutationEnabled,
+  TradingDisabledError,
+  sha256,
+} from "@/lib/trading-security";
+
+export const runtime = "nodejs";
+
+type SyncBody = {
+  account_id?: string;
+  mode?: string;
+  executor_version?: string;
+  gateway_connected?: boolean;
+  gateway_authenticated?: boolean;
+  error?: string;
+};
+
+export async function POST(request: Request) {
+  try {
+    requireTradingMutationEnabled();
+    const authenticated = await authenticateExecutorRequest<SyncBody>(request);
+    const body = authenticated.body;
+    const suppliedFingerprint = accountFingerprint(String(body.account_id || ""));
+    if (body.mode !== authenticated.mode
+      || !constantTimeTextEqual(suppliedFingerprint, authenticated.accountFingerprint)) {
+      return NextResponse.json({ error: "Executor account or mode does not match the paired connection." }, { status: 409 });
+    }
+    await updateTradingHeartbeat({
+      connectionId: authenticated.connectionId,
+      gatewayConnected: body.gateway_connected === true,
+      gatewayAuthenticated: body.gateway_authenticated === true,
+      executorVersion: String(body.executor_version || "unknown").slice(0, 100),
+      error: String(body.error || "").slice(0, 2_000),
+    });
+    if (!body.gateway_connected || !body.gateway_authenticated) {
+      const message = String(body.error || "IB Gateway is disconnected or unauthenticated.").slice(0, 2_000);
+      const eventId = `gateway-disconnected:${new Date().toISOString().slice(0, 10)}:${sha256(message).slice(0, 12)}`;
+      const inserted = await recordTradingEvent({
+        connectionId: authenticated.connectionId,
+        eventId,
+        eventType: "gateway_disconnected",
+        severity: "critical",
+        message,
+      });
+      if (inserted) {
+        await sendTradingTelegramAlert({
+          connectionId: authenticated.connectionId,
+          eventId,
+          severity: "critical",
+          message,
+        });
+      }
+    }
+    const commands = body.gateway_connected && body.gateway_authenticated
+      ? await loadExecutorCommands(authenticated.connectionId)
+      : [];
+    return NextResponse.json({ server_time: new Date().toISOString(), commands });
+  } catch (error) {
+    if (error instanceof ExecutorAuthenticationError) return NextResponse.json({ error: error.message }, { status: 401 });
+    if (error instanceof TradingDisabledError) return NextResponse.json({ error: error.message }, { status: 503 });
+    console.error("[trading] executor sync failed", error);
+    return NextResponse.json({ error: "Executor sync failed." }, { status: 500 });
+  }
+}

--- a/frontend/src/app/api/trading/executor/sync/route.ts
+++ b/frontend/src/app/api/trading/executor/sync/route.ts
@@ -19,6 +19,7 @@ type SyncBody = {
   executor_version?: string;
   gateway_connected?: boolean;
   gateway_authenticated?: boolean;
+  account_type?: string;
   error?: string;
 };
 
@@ -37,6 +38,7 @@ export async function POST(request: Request) {
       gatewayConnected: body.gateway_connected === true,
       gatewayAuthenticated: body.gateway_authenticated === true,
       executorVersion: String(body.executor_version || "unknown").slice(0, 100),
+      accountType: String(body.account_type || "UNKNOWN").slice(0, 100),
       error: String(body.error || "").slice(0, 2_000),
     });
     if (!body.gateway_connected || !body.gateway_authenticated) {

--- a/frontend/src/app/api/trading/monitor/route.ts
+++ b/frontend/src/app/api/trading/monitor/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+
+import { sendTradingTelegramAlert } from "@/lib/trading-alerts";
+import { listPendingTradingAlerts, listStaleTradingConnections, recordTradingEvent } from "@/lib/trading-db";
+import {
+  constantTimeTextEqual,
+  requireTradingMutationEnabled,
+  TradingDisabledError,
+} from "@/lib/trading-security";
+
+export const runtime = "nodejs";
+
+export async function POST(request: Request) {
+  try {
+    requireTradingMutationEnabled();
+    const expected = String(process.env.TRADING_MONITOR_TOKEN || "").trim();
+    const authorization = request.headers.get("authorization") || "";
+    const supplied = authorization.startsWith("Bearer ") ? authorization.slice(7).trim() : "";
+    if (!expected || !constantTimeTextEqual(supplied, expected)) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const stale = await listStaleTradingConnections(10);
+    const bucket = Math.floor(Date.now() / (10 * 60 * 1000));
+    let alerted = 0;
+    for (const connection of stale) {
+      const eventId = `heartbeat-stale:${bucket}`;
+      const message = `${connection.mode.toUpperCase()} ${connection.accountMasked || "account"}: executor heartbeat is stale.`;
+      const inserted = await recordTradingEvent({
+        connectionId: connection.id,
+        eventId,
+        eventType: "heartbeat_stale",
+        severity: "critical",
+        message,
+        payload: { last_heartbeat_at: connection.lastHeartbeatAt },
+      });
+      if (inserted) {
+        await sendTradingTelegramAlert({ connectionId: connection.id, eventId, severity: "critical", message });
+        alerted += 1;
+      }
+    }
+    const pending = await listPendingTradingAlerts();
+    let retried = 0;
+    for (const alert of pending) {
+      if (await sendTradingTelegramAlert(alert)) retried += 1;
+    }
+    return NextResponse.json({ checked: stale.length, alerted, pending: pending.length, delivered: retried });
+  } catch (error) {
+    if (error instanceof TradingDisabledError) return NextResponse.json({ error: error.message }, { status: 503 });
+    console.error("[trading] monitor failed", error);
+    return NextResponse.json({ error: "Trading monitor failed." }, { status: 500 });
+  }
+}

--- a/frontend/src/app/api/trading/pairing/route.ts
+++ b/frontend/src/app/api/trading/pairing/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+
+import { createTradingPairing } from "@/lib/trading-db";
+import {
+  generatePairingCode,
+  normalizePairingCode,
+  requireTradingMutationEnabled,
+  requireTradingUser,
+  sha256,
+  TradingDisabledError,
+  TradingUnauthorizedError,
+} from "@/lib/trading-security";
+
+export const runtime = "nodejs";
+
+export async function POST(request: Request) {
+  try {
+    requireTradingMutationEnabled();
+    const user = await requireTradingUser();
+    const body = await request.json().catch(() => ({})) as Record<string, unknown>;
+    const requestedConnectionId = String(body.connection_id || "").trim();
+    const code = generatePairingCode();
+    const expiresAt = new Date(Date.now() + 10 * 60 * 1000).toISOString();
+    const connectionId = await createTradingPairing({
+      userId: user.userId,
+      mode: "paper",
+      codeHash: sha256(normalizePairingCode(code)),
+      expiresAt,
+      connectionId: requestedConnectionId || undefined,
+    });
+    return NextResponse.json({ connection_id: connectionId, code, mode: "paper", expires_at: expiresAt });
+  } catch (error) {
+    if (error instanceof TradingUnauthorizedError) return NextResponse.json({ error: error.message }, { status: 401 });
+    if (error instanceof TradingDisabledError) return NextResponse.json({ error: error.message }, { status: 503 });
+    console.error("[trading] pairing failed", error);
+    return NextResponse.json({ error: "Could not create the pairing code." }, { status: 500 });
+  }
+}

--- a/frontend/src/app/api/trading/route.ts
+++ b/frontend/src/app/api/trading/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+
+import { listTradingPortfolios, loadTradingDashboard } from "@/lib/trading-db";
+import {
+  isLiveTradingEnabled,
+  isTradingControlEnabled,
+  requireTradingUser,
+  TradingUnauthorizedError,
+} from "@/lib/trading-security";
+import type { TradingDashboardPayload } from "@/lib/trading-types";
+import { parseApiWorkspace } from "@/lib/workspace";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function isPreview(): boolean {
+  return ["1", "true", "yes", "on"].includes(String(process.env.AUTH_BYPASS_PREVIEW || "").toLowerCase());
+}
+
+export async function GET(request: Request) {
+  const workspace = parseApiWorkspace(new URL(request.url).searchParams.get("workspace"));
+  if (!workspace) return NextResponse.json({ error: "Invalid workspace." }, { status: 400 });
+  try {
+    if (isPreview()) {
+      const payload: TradingDashboardPayload = {
+        enabled: false,
+        live_enabled: false,
+        workspace,
+        connections: [],
+        strategy: null,
+        portfolios: await listTradingPortfolios(workspace),
+        plans: [],
+        events: [],
+        positions: [],
+        orders: [],
+        fills: [],
+      };
+      return NextResponse.json(payload);
+    }
+    const user = await requireTradingUser();
+    return NextResponse.json(await loadTradingDashboard({
+      userId: user.userId,
+      workspace,
+      enabled: isTradingControlEnabled(),
+      liveEnabled: isLiveTradingEnabled(),
+    }));
+  } catch (error) {
+    if (error instanceof TradingUnauthorizedError) {
+      return NextResponse.json({ error: error.message }, { status: 401 });
+    }
+    console.error("[trading] dashboard failed", error);
+    return NextResponse.json({ error: "Trading dashboard is temporarily unavailable." }, { status: 503 });
+  }
+}

--- a/frontend/src/app/api/trading/strategy/route.ts
+++ b/frontend/src/app/api/trading/strategy/route.ts
@@ -1,0 +1,99 @@
+import { NextResponse } from "next/server";
+
+import { sendTradingTelegramAlert } from "@/lib/trading-alerts";
+import {
+  configureTradingStrategy,
+  consumeTradingStrategyPreview,
+  createTradingStrategyPreview,
+  recordTradingEvent,
+} from "@/lib/trading-db";
+import {
+  requireTradingMutationEnabled,
+  requireTradingUser,
+  TradingDisabledError,
+  TradingUnauthorizedError,
+} from "@/lib/trading-security";
+import type { TradingLensType } from "@/lib/trading-types";
+import { isWorkspace } from "@/lib/workspace";
+
+export const runtime = "nodejs";
+
+const UUID_RE = /^[0-9a-f-]{36}$/i;
+const LENSES = new Set<TradingLensType>(["overall", "model", "valuator"]);
+
+export async function POST(request: Request) {
+  try {
+    requireTradingMutationEnabled();
+    const user = await requireTradingUser();
+    const body = await request.json() as Record<string, unknown>;
+    const previewId = String(body.preview_id || "");
+    if (previewId) {
+      if (!UUID_RE.test(previewId)) return NextResponse.json({ error: "Invalid preview." }, { status: 400 });
+      const preview = await consumeTradingStrategyPreview({ userId: user.userId, previewId });
+      if (!preview) return NextResponse.json({ error: "Preview is invalid, expired, or already confirmed." }, { status: 409 });
+      const result = await configureTradingStrategy({
+        userId: user.userId,
+        connectionId: preview.connectionId,
+        workspace: preview.workspace,
+        lensType: preview.lensType,
+        lensKey: preview.lensKey,
+        methodologyVersion: preview.methodologyVersion,
+        budgetUsd: preview.budgetUsd,
+        arm: preview.arm,
+        expectedSnapshotId: preview.snapshotId,
+      });
+      if (result.status === "armed") {
+        const eventId = `paper-activated:${preview.snapshotId}`;
+        const message = `IBKR Paper automation armed for ${preview.workspace}/${preview.lensType}:${preview.lensKey} with a $${preview.budgetUsd.toFixed(2)} budget.`;
+        const inserted = await recordTradingEvent({
+          connectionId: preview.connectionId,
+          eventId,
+          eventType: "paper_activated",
+          severity: "warning",
+          message,
+          payload: { snapshot_id: preview.snapshotId, budget_usd: preview.budgetUsd },
+        });
+        if (inserted) {
+          await sendTradingTelegramAlert({
+            connectionId: preview.connectionId,
+            eventId,
+            severity: "warning",
+            message,
+          });
+        }
+      }
+      return NextResponse.json(result);
+    }
+    const connectionId = String(body.connection_id || "");
+    const workspace = String(body.workspace || "");
+    const lensType = String(body.lens_type || "") as TradingLensType;
+    const lensKey = lensType === "overall" ? "overall" : String(body.lens_key || "").trim();
+    const methodologyVersion = String(body.methodology_version || "").trim();
+    const budgetUsd = Number(body.budget_usd);
+    if (!UUID_RE.test(connectionId) || !isWorkspace(workspace) || !LENSES.has(lensType)
+      || !lensKey || !methodologyVersion || !Number.isFinite(budgetUsd) || budgetUsd < 100) {
+      return NextResponse.json({ error: "Invalid strategy configuration." }, { status: 400 });
+    }
+    const result = await createTradingStrategyPreview({
+      userId: user.userId,
+      connectionId,
+      workspace,
+      lensType,
+      lensKey,
+      methodologyVersion,
+      budgetUsd: Math.round(budgetUsd * 100) / 100,
+      arm: body.arm === true,
+    });
+    return NextResponse.json({
+      preview_id: result.previewId,
+      expires_at: result.expiresAt,
+      preview: result.preview,
+      confirmation_required: true,
+    });
+  } catch (error) {
+    if (error instanceof TradingUnauthorizedError) return NextResponse.json({ error: error.message }, { status: 401 });
+    if (error instanceof TradingDisabledError) return NextResponse.json({ error: error.message }, { status: 503 });
+    const message = error instanceof Error ? error.message : "Could not configure the strategy.";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/frontend/src/components/portfolio-returns-section.tsx
+++ b/frontend/src/components/portfolio-returns-section.tsx
@@ -27,6 +27,11 @@ type PortfolioReturnRow = {
   period_start: string | null;
   period_end: string | null;
   status: PortfolioStatus;
+  portfolio_key: string;
+  latest_snapshot_id: string;
+  cutoff_at: string | null;
+  execution_date: string | null;
+  trade_eligibility: { eligible: boolean; reasons: string[] };
 };
 
 type PortfolioPerformancePayload = {
@@ -121,16 +126,19 @@ function ReturnsTable({
   rows,
   benchmarkName,
   minimumObservations,
+  track,
 }: {
   title: string;
   rows: PortfolioReturnRow[];
   benchmarkName: string;
   minimumObservations: number;
+  track: PortfolioTrack;
 }) {
   const { href } = useWorkspace();
   const rowHref = (row: PortfolioReturnRow): string => row.lens_type === "overall"
     ? href("/discovery?lens_type=overall")
     : href(`/discovery?lens_type=${row.lens_type}&lens_key=${encodeURIComponent(row.lens_key || row.label)}`);
+  const tradingHref = (row: PortfolioReturnRow): string => href(`/trading?portfolio=${encodeURIComponent(row.portfolio_key)}`);
   const sortedRows = sortRowsByReturn(rows);
   return (
     <section className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
@@ -146,6 +154,11 @@ function ReturnsTable({
                     {row.label}
                   </Link>
                   <p className="mt-1 text-xs text-[color:var(--text-muted)]">{statusLabel(row) || `${row.holdings_count} latest holdings`}</p>
+                  {track === "paper" ? (
+                    <Link href={tradingHref(row)} className="mt-2 inline-flex rounded-md border border-[color:var(--accent)] px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.12em] text-[color:var(--accent)] hover:bg-[color:var(--surface-elevated)]">
+                      Connect
+                    </Link>
+                  ) : null}
                 </div>
                 <div className="text-right">
                   <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-[color:var(--text-muted)]">Excess return</p>
@@ -205,6 +218,11 @@ function ReturnsTable({
                       {statusLabel(row) || `${row.holdings_count} holdings · since ${formatDate(row.period_start)}`}
                     </p>
                     {riskNotice ? <p className="mt-0.5 max-w-56 text-[11px] leading-snug text-[color:var(--warning)]">{riskNotice}</p> : null}
+                    {track === "paper" ? (
+                      <Link href={tradingHref(row)} className="mt-1.5 inline-flex rounded-md border border-[color:var(--accent)] px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.12em] text-[color:var(--accent)] hover:bg-[color:var(--surface)]">
+                        Connect
+                      </Link>
+                    ) : null}
                   </td>
                   <td className={`border-l border-[color:var(--border-subtle)] px-3 py-2 text-right font-semibold tabular-nums ${returnTone(row.return_pct)}`}>{formatPercent(row.return_pct)}</td>
                   <td className="px-3 py-2 text-right tabular-nums text-[color:var(--text-primary)]">{formatPercent(row.portfolio_volatility_pct)}</td>
@@ -296,8 +314,8 @@ export function PortfolioReturnsSection() {
         </div>
       ) : (
         <div className="mt-4 grid items-start gap-4 xl:grid-cols-2">
-          <ReturnsTable title="Models" rows={data.by_model} benchmarkName={benchmarkName} minimumObservations={minimumRiskObservations} />
-          <ReturnsTable title="Valuators" rows={data.by_valuator} benchmarkName={benchmarkName} minimumObservations={minimumRiskObservations} />
+          <ReturnsTable title="Models" rows={data.by_model} benchmarkName={benchmarkName} minimumObservations={minimumRiskObservations} track={track} />
+          <ReturnsTable title="Valuators" rows={data.by_valuator} benchmarkName={benchmarkName} minimumObservations={minimumRiskObservations} track={track} />
         </div>
       )}
 

--- a/frontend/src/components/shell/sidebar.tsx
+++ b/frontend/src/components/shell/sidebar.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import {
   Activity,
+  CandlestickChart,
   ChevronLeft,
   ChevronRight,
   Compass,
@@ -13,7 +14,6 @@ import {
   Target,
   Plus,
   Play,
-  Landmark,
 } from "lucide-react";
 import type { ComponentType } from "react";
 
@@ -38,7 +38,7 @@ const GLOBAL_NAV: NavItem[] = [
   { path: "/screeners", label: "Screeners", icon: ScanSearch },
   { path: "/discovery", label: "Discovery", icon: Compass },
   { path: "/hit-rate", label: "Track Record", icon: Target },
-  { path: "/trading", label: "Trading", icon: Landmark },
+  { path: "/trading", label: "Trading", icon: CandlestickChart },
 ];
 
 type SidebarProps = {

--- a/frontend/src/components/shell/sidebar.tsx
+++ b/frontend/src/components/shell/sidebar.tsx
@@ -13,6 +13,7 @@ import {
   Target,
   Plus,
   Play,
+  Landmark,
 } from "lucide-react";
 import type { ComponentType } from "react";
 
@@ -37,6 +38,7 @@ const GLOBAL_NAV: NavItem[] = [
   { path: "/screeners", label: "Screeners", icon: ScanSearch },
   { path: "/discovery", label: "Discovery", icon: Compass },
   { path: "/hit-rate", label: "Track Record", icon: Target },
+  { path: "/trading", label: "Trading", icon: Landmark },
 ];
 
 type SidebarProps = {

--- a/frontend/src/components/shell/sidebar.tsx
+++ b/frontend/src/components/shell/sidebar.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import {
   Activity,
-  CandlestickChart,
+  BriefcaseBusiness,
   ChevronLeft,
   ChevronRight,
   Compass,
@@ -38,7 +38,7 @@ const GLOBAL_NAV: NavItem[] = [
   { path: "/screeners", label: "Screeners", icon: ScanSearch },
   { path: "/discovery", label: "Discovery", icon: Compass },
   { path: "/hit-rate", label: "Track Record", icon: Target },
-  { path: "/trading", label: "Trading", icon: CandlestickChart },
+  { path: "/trading", label: "Trading", icon: BriefcaseBusiness },
 ];
 
 type SidebarProps = {

--- a/frontend/src/components/trading-dashboard.tsx
+++ b/frontend/src/components/trading-dashboard.tsx
@@ -252,6 +252,7 @@ export function TradingDashboard() {
             <dl className="mt-3 grid grid-cols-2 gap-2 text-xs">
               <div><dt className="text-[color:var(--text-muted)]">Status</dt><dd className={`mt-1 font-semibold ${statusTone(selectedConnection.status)}`}>{selectedConnection.status}</dd></div>
               <div><dt className="text-[color:var(--text-muted)]">Gateway</dt><dd className={`mt-1 font-semibold ${selectedConnection.gateway_authenticated ? "text-[color:var(--success)]" : "text-[color:var(--warning)]"}`}>{selectedConnection.gateway_authenticated ? "Authenticated" : "Offline"}</dd></div>
+              <div><dt className="text-[color:var(--text-muted)]">IBKR account structure</dt><dd className="mt-1 font-semibold text-[color:var(--text-primary)]">{selectedConnection.account_type}</dd></div>
               <div className="col-span-2"><dt className="text-[color:var(--text-muted)]">Last heartbeat</dt><dd className="mt-1 text-[color:var(--text-primary)]">{displayDate(selectedConnection.last_heartbeat_at)}</dd></div>
             </dl>
           ) : null}
@@ -270,14 +271,14 @@ export function TradingDashboard() {
         </Card>
 
         <Card title="2. Portfolio and budget">
-          <label className="text-xs font-medium text-[color:var(--text-secondary)]" htmlFor="trading-portfolio">Paper Top 20 portfolio</label>
+          <label className="text-xs font-medium text-[color:var(--text-secondary)]" htmlFor="trading-portfolio">Paper portfolio</label>
           <select id="trading-portfolio" value={portfolioKey} onChange={(event) => { setPortfolioKey(event.target.value); setPreview(null); }} className="mt-1 w-full rounded-lg border border-[color:var(--border-strong)] bg-[color:var(--surface)] px-3 py-2 text-sm text-[color:var(--text-primary)]">
             <option value="">Select portfolio</option>
             {(data?.portfolios || []).map((portfolio) => <option key={portfolio.portfolio_key} value={portfolio.portfolio_key}>{portfolio.label} · {portfolio.holdings_count} holdings</option>)}
           </select>
           <label className="mt-3 block text-xs font-medium text-[color:var(--text-secondary)]" htmlFor="trading-budget">Fixed USD budget</label>
           <input id="trading-budget" type="number" min="100" step="100" value={budget} onChange={(event) => { setBudget(event.target.value); setPreview(null); }} className="mt-1 w-full rounded-lg border border-[color:var(--border-strong)] bg-[color:var(--surface)] px-3 py-2 text-sm text-[color:var(--text-primary)]" />
-          <p className="mt-2 text-xs text-[color:var(--text-muted)]">Up to 98% invested; 2% remains for fees and price movement. No margin borrowing.</p>
+          <p className="mt-2 text-xs text-[color:var(--text-muted)]">Up to 98% invested; 2% remains for fees and price movement. The executor requires full N/N target coverage and never borrows on margin or counts unsettled sale proceeds.</p>
           {selectedPortfolio ? (
             <dl className="mt-3 grid grid-cols-2 gap-2 text-xs">
               <div><dt className="text-[color:var(--text-muted)]">Snapshot</dt><dd className="mt-1 font-mono text-[color:var(--text-primary)]">{selectedPortfolio.latest_snapshot_id.slice(0, 8)}</dd></div>
@@ -322,7 +323,7 @@ export function TradingDashboard() {
           {!strategyPortfolio ? <p className="text-sm text-[color:var(--text-muted)]">No portfolio is armed yet.</p> : null}
         </Card>
         <Card title="Rebalance plans">
-          <div className="space-y-2">{(data?.plans || []).map((plan) => <div key={plan.id} className="flex items-start justify-between gap-3 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-3 text-sm"><div><p className="font-mono text-xs">{plan.snapshot_id.slice(0, 8)}</p><p className="mt-1 text-xs text-[color:var(--text-muted)]">{plan.target_holdings.length} targets · {displayDate(plan.created_at)}</p>{plan.error ? <p className="mt-1 text-xs text-[color:var(--danger)]">{plan.error}</p> : null}</div><span className={`font-semibold ${statusTone(plan.status)}`}>{plan.status}</span></div>)}{!data?.plans.length ? <p className="text-sm text-[color:var(--text-muted)]">No rebalance plans yet.</p> : null}</div>
+          <div className="space-y-2">{(data?.plans || []).map((plan) => <div key={plan.id} className="flex items-start justify-between gap-3 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-3 text-sm"><div><p className="font-mono text-xs">{plan.snapshot_id.slice(0, 8)}</p><p className="mt-1 text-xs text-[color:var(--text-muted)]">{plan.target_holdings.length} targets · coverage {String(plan.preflight.target_coverage || `pending/${plan.target_holdings.length}`)} · {displayDate(plan.created_at)}</p>{plan.preflight.minimum_budget_usd ? <p className="mt-1 text-xs text-[color:var(--text-muted)]">Estimated minimum full-coverage budget: ${String(plan.preflight.minimum_budget_usd)}</p> : null}{plan.error ? <p className="mt-1 text-xs text-[color:var(--danger)]">{plan.error}</p> : null}</div><span className={`font-semibold ${statusTone(plan.status)}`}>{plan.status}</span></div>)}{!data?.plans.length ? <p className="text-sm text-[color:var(--text-muted)]">No rebalance plans yet.</p> : null}</div>
         </Card>
         <Card title="Orders">
           <div className="space-y-2">{(data?.orders || []).map((order) => <div key={order.id} className="grid grid-cols-[auto_1fr_auto] gap-3 border-b border-[color:var(--border-subtle)] pb-2 text-sm"><span className={order.side === "BUY" ? "text-[color:var(--success)]" : "text-[color:var(--warning)]"}>{order.side}</span><span>{order.symbol} · {order.filled_quantity}/{order.requested_quantity}</span><span className={statusTone(order.status)}>{order.status}</span></div>)}{!data?.orders.length ? <p className="text-sm text-[color:var(--text-muted)]">No system orders yet.</p> : null}</div>

--- a/frontend/src/components/trading-dashboard.tsx
+++ b/frontend/src/components/trading-dashboard.tsx
@@ -1,0 +1,336 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+
+import { useWorkspace } from "@/components/shell/workspace-context";
+import type { TradingDashboardPayload } from "@/lib/trading-types";
+
+type PairingResult = {
+  connection_id: string;
+  code: string;
+  expires_at: string;
+};
+
+type StrategyPreview = {
+  preview_id: string;
+  expires_at: string;
+  preview: {
+    current: { portfolio_key: string; budget_usd: number } | null;
+    target: {
+      portfolio_key: string;
+      label: string;
+      snapshot_id: string;
+      cutoff_at: string;
+      execution_date: string;
+      budget_usd: number;
+      investable_budget_usd: number;
+      holdings_count: number;
+      eligible: boolean;
+      eligibility_reasons: string[];
+    };
+    estimated_changes: { additions: string[]; removals: string[] };
+    safeguards: string[];
+  };
+};
+
+function displayDate(value: string | null | undefined): string {
+  if (!value) return "Not available";
+  return new Intl.DateTimeFormat("en-GB", { dateStyle: "medium", timeStyle: value.includes("T") ? "short" : undefined }).format(new Date(value));
+}
+
+function nextMonthlyCutoff(value: string | null | undefined): string {
+  if (!value) return "After the next monthly refresh";
+  const date = new Date(value);
+  const next = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + 2, 0));
+  return displayDate(next.toISOString().slice(0, 10));
+}
+
+function statusTone(status: string): string {
+  if (["ready", "armed", "completed", "filled"].includes(status)) return "text-[color:var(--success)]";
+  if (["error", "blocked", "rejected", "partial"].includes(status)) return "text-[color:var(--danger)]";
+  if (["paused", "disconnected", "awaiting_pairing"].includes(status)) return "text-[color:var(--warning)]";
+  return "text-[color:var(--text-secondary)]";
+}
+
+function Card({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
+      <h2 className="text-sm font-semibold uppercase tracking-[0.14em] text-[color:var(--text-secondary)]">{title}</h2>
+      <div className="mt-3">{children}</div>
+    </section>
+  );
+}
+
+export function TradingDashboard() {
+  const { workspace, api } = useWorkspace();
+  const searchParams = useSearchParams();
+  const requestedPortfolio = searchParams.get("portfolio") || "";
+  const [data, setData] = useState<TradingDashboardPayload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const [notice, setNotice] = useState("");
+  const [pairing, setPairing] = useState<PairingResult | null>(null);
+  const [preview, setPreview] = useState<StrategyPreview | null>(null);
+  const [connectionId, setConnectionId] = useState("");
+  const [portfolioKey, setPortfolioKey] = useState(requestedPortfolio);
+  const [budget, setBudget] = useState("1000");
+
+  const load = useCallback(async () => {
+    await Promise.resolve();
+    setLoading(true);
+    setError("");
+    try {
+      const response = await fetch(api("/api/trading"), { cache: "no-store" });
+      const payload = await response.json() as TradingDashboardPayload & { error?: string };
+      if (!response.ok) throw new Error(payload.error || "Could not load trading controls.");
+      setData(payload);
+      const paired = payload.connections.find((connection) => connection.status !== "awaiting_pairing");
+      setConnectionId((current) => current || paired?.id || "");
+      if (payload.strategy) {
+        setBudget(String(payload.strategy.budget_usd));
+        const linked = payload.portfolios.find((portfolio) => (
+          portfolio.lens_type === payload.strategy?.lens_type
+          && portfolio.lens_key === payload.strategy?.lens_key
+          && portfolio.methodology_version === payload.strategy?.methodology_version
+        ));
+        setPortfolioKey((current) => current || linked?.portfolio_key || "");
+      } else {
+        setPortfolioKey((current) => current || requestedPortfolio || payload.portfolios[0]?.portfolio_key || "");
+      }
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : "Could not load trading controls.");
+    } finally {
+      setLoading(false);
+    }
+  }, [api, requestedPortfolio]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => { void load(); }, 0);
+    return () => window.clearTimeout(timer);
+  }, [load, workspace]);
+
+  const selectedPortfolio = useMemo(
+    () => data?.portfolios.find((portfolio) => portfolio.portfolio_key === portfolioKey) || null,
+    [data?.portfolios, portfolioKey],
+  );
+  const selectedConnection = data?.connections.find((connection) => connection.id === connectionId) || null;
+  const strategyPortfolio = data?.strategy
+    ? data.portfolios.find((portfolio) => (
+      portfolio.lens_type === data.strategy?.lens_type
+      && portfolio.lens_key === data.strategy?.lens_key
+      && portfolio.methodology_version === data.strategy?.methodology_version
+    )) || null
+    : null;
+  const actualBySymbol = new Map((data?.positions || []).map((position) => [position.symbol, position]));
+
+  async function createPairing() {
+    if (selectedConnection && !window.confirm("Rotate this connection's device secret? The current executor will stop authenticating immediately.")) return;
+    setBusy(true); setError(""); setNotice("");
+    try {
+      const response = await fetch("/api/trading/pairing", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ connection_id: selectedConnection?.id || null }),
+      });
+      const payload = await response.json() as PairingResult & { error?: string };
+      if (!response.ok) throw new Error(payload.error || "Could not create pairing code.");
+      setPairing(payload);
+      setConnectionId(payload.connection_id);
+      setNotice("Pairing code created. Enter it once on the Windows executor VM.");
+      await load();
+    } catch (actionError) {
+      setError(actionError instanceof Error ? actionError.message : "Pairing failed.");
+    } finally { setBusy(false); }
+  }
+
+  async function requestPreview() {
+    if (!selectedPortfolio || !connectionId) return;
+    setBusy(true); setError(""); setNotice("");
+    try {
+      const response = await fetch("/api/trading/strategy", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          connection_id: connectionId,
+          workspace,
+          lens_type: selectedPortfolio.lens_type,
+          lens_key: selectedPortfolio.lens_key,
+          methodology_version: selectedPortfolio.methodology_version,
+          budget_usd: Number(budget),
+          arm: true,
+        }),
+      });
+      const payload = await response.json() as StrategyPreview & { error?: string };
+      if (!response.ok) throw new Error(payload.error || "Could not prepare strategy preview.");
+      setPreview(payload);
+    } catch (actionError) {
+      setError(actionError instanceof Error ? actionError.message : "Preview failed.");
+    } finally { setBusy(false); }
+  }
+
+  async function confirmPreview() {
+    if (!preview) return;
+    setBusy(true); setError("");
+    try {
+      const response = await fetch("/api/trading/strategy", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ preview_id: preview.preview_id }),
+      });
+      const payload = await response.json() as { reason?: string; error?: string };
+      if (!response.ok) throw new Error(payload.error || "Could not confirm strategy.");
+      setPreview(null);
+      setNotice(payload.reason || "Paper strategy updated.");
+      await load();
+    } catch (actionError) {
+      setError(actionError instanceof Error ? actionError.message : "Confirmation failed.");
+    } finally { setBusy(false); }
+  }
+
+  async function control(action: "pause" | "resume" | "kill_switch") {
+    if (!selectedConnection) return;
+    if (action === "kill_switch" && !window.confirm("Cancel all open system orders and pause trading? Existing holdings will not be sold.")) return;
+    setBusy(true); setError("");
+    try {
+      const response = await fetch("/api/trading/control", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ connection_id: selectedConnection.id, action }),
+      });
+      const payload = await response.json() as { error?: string };
+      if (!response.ok) throw new Error(payload.error || "Control action failed.");
+      setNotice(action === "kill_switch" ? "Kill switch requested. Holdings were left intact." : `Trading ${action} requested.`);
+      await load();
+    } catch (actionError) {
+      setError(actionError instanceof Error ? actionError.message : "Control action failed.");
+    } finally { setBusy(false); }
+  }
+
+  if (loading && !data) {
+    return <div className="mx-auto w-full max-w-[1500px] p-6 text-sm text-[color:var(--text-muted)]">Loading trading controls...</div>;
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-[1500px] space-y-4 px-4 py-6 text-[color:var(--text-primary)] sm:px-8">
+      <header className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-overlay)] p-5">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--accent)]">IBKR automation</p>
+        <div className="mt-1 flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h1 className="font-display text-2xl">Trading</h1>
+            <p className="mt-1 max-w-3xl text-sm leading-relaxed text-[color:var(--text-muted)]">
+              Connect one frozen Portfolio Returns strategy to an IBKR Paper account. Research returns remain separate from real fills, fees, and execution lag.
+            </p>
+          </div>
+          <span className="rounded-full border border-[color:var(--warning)] px-3 py-1 text-xs font-semibold text-[color:var(--warning)]">
+            Paper only · Live locked
+          </span>
+        </div>
+        {!data?.enabled ? (
+          <p className="mt-4 rounded-lg border border-[color:var(--warning)] bg-[color:var(--surface)] p-3 text-sm text-[color:var(--warning)]">
+            Trading mutations are disabled in this environment. Preview builds expose the UI and portfolio data only.
+          </p>
+        ) : null}
+        {workspace === "analysis" ? (
+          <p className="mt-3 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-3 text-sm text-[color:var(--text-muted)]">
+            Analysis portfolios are visible for planning but execution is disabled until contract, market-hours, and explicit FX mapping are complete. Nasdaq 100 is the first executable universe.
+          </p>
+        ) : null}
+        {error ? <p className="mt-3 text-sm text-[color:var(--danger)]">{error}</p> : null}
+        {notice ? <p className="mt-3 text-sm text-[color:var(--success)]">{notice}</p> : null}
+      </header>
+
+      <div className="grid gap-4 xl:grid-cols-3">
+        <Card title="1. Paper connection">
+          {data?.connections.length ? (
+            <select value={connectionId} onChange={(event) => setConnectionId(event.target.value)} className="w-full rounded-lg border border-[color:var(--border-strong)] bg-[color:var(--surface)] px-3 py-2 text-sm text-[color:var(--text-primary)]">
+              {data.connections.map((connection) => <option key={connection.id} value={connection.id}>{connection.account_masked || "Awaiting VM"} · {connection.mode}</option>)}
+            </select>
+          ) : <p className="text-sm text-[color:var(--text-muted)]">No IBKR executor is paired.</p>}
+          {selectedConnection ? (
+            <dl className="mt-3 grid grid-cols-2 gap-2 text-xs">
+              <div><dt className="text-[color:var(--text-muted)]">Status</dt><dd className={`mt-1 font-semibold ${statusTone(selectedConnection.status)}`}>{selectedConnection.status}</dd></div>
+              <div><dt className="text-[color:var(--text-muted)]">Gateway</dt><dd className={`mt-1 font-semibold ${selectedConnection.gateway_authenticated ? "text-[color:var(--success)]" : "text-[color:var(--warning)]"}`}>{selectedConnection.gateway_authenticated ? "Authenticated" : "Offline"}</dd></div>
+              <div className="col-span-2"><dt className="text-[color:var(--text-muted)]">Last heartbeat</dt><dd className="mt-1 text-[color:var(--text-primary)]">{displayDate(selectedConnection.last_heartbeat_at)}</dd></div>
+            </dl>
+          ) : null}
+          <button type="button" onClick={createPairing} disabled={busy || !data?.enabled} className="mt-4 rounded-lg border border-[color:var(--accent)] px-3 py-2 text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--accent)] disabled:cursor-not-allowed disabled:text-[color:var(--text-disabled)]">
+            {selectedConnection ? "Rotate executor pairing" : "Create Paper pairing code"}
+          </button>
+          <button type="button" onClick={() => { void load(); }} disabled={busy || loading} className="ml-2 mt-4 rounded-lg border border-[color:var(--border-strong)] px-3 py-2 text-xs font-semibold text-[color:var(--text-secondary)] disabled:cursor-not-allowed disabled:text-[color:var(--text-disabled)]">
+            Refresh status
+          </button>
+          {pairing ? (
+            <div className="mt-3 rounded-lg border border-[color:var(--accent)] bg-[color:var(--surface)] p-3">
+              <p className="font-mono text-xl font-bold tracking-[0.18em] text-[color:var(--accent)]">{pairing.code}</p>
+              <p className="mt-1 text-xs text-[color:var(--text-muted)]">Expires {displayDate(pairing.expires_at)}. It is shown only in this session.</p>
+            </div>
+          ) : null}
+        </Card>
+
+        <Card title="2. Portfolio and budget">
+          <label className="text-xs font-medium text-[color:var(--text-secondary)]" htmlFor="trading-portfolio">Paper Top 20 portfolio</label>
+          <select id="trading-portfolio" value={portfolioKey} onChange={(event) => { setPortfolioKey(event.target.value); setPreview(null); }} className="mt-1 w-full rounded-lg border border-[color:var(--border-strong)] bg-[color:var(--surface)] px-3 py-2 text-sm text-[color:var(--text-primary)]">
+            <option value="">Select portfolio</option>
+            {(data?.portfolios || []).map((portfolio) => <option key={portfolio.portfolio_key} value={portfolio.portfolio_key}>{portfolio.label} · {portfolio.holdings_count} holdings</option>)}
+          </select>
+          <label className="mt-3 block text-xs font-medium text-[color:var(--text-secondary)]" htmlFor="trading-budget">Fixed USD budget</label>
+          <input id="trading-budget" type="number" min="100" step="100" value={budget} onChange={(event) => { setBudget(event.target.value); setPreview(null); }} className="mt-1 w-full rounded-lg border border-[color:var(--border-strong)] bg-[color:var(--surface)] px-3 py-2 text-sm text-[color:var(--text-primary)]" />
+          <p className="mt-2 text-xs text-[color:var(--text-muted)]">Up to 98% invested; 2% remains for fees and price movement. No margin borrowing.</p>
+          {selectedPortfolio ? (
+            <dl className="mt-3 grid grid-cols-2 gap-2 text-xs">
+              <div><dt className="text-[color:var(--text-muted)]">Snapshot</dt><dd className="mt-1 font-mono text-[color:var(--text-primary)]">{selectedPortfolio.latest_snapshot_id.slice(0, 8)}</dd></div>
+              <div><dt className="text-[color:var(--text-muted)]">Execution session</dt><dd className="mt-1 text-[color:var(--text-primary)]">{selectedPortfolio.execution_date}</dd></div>
+              <div><dt className="text-[color:var(--text-muted)]">Next cutoff</dt><dd className="mt-1 text-[color:var(--text-primary)]">{nextMonthlyCutoff(selectedPortfolio.cutoff_at)}</dd></div>
+              <div><dt className="text-[color:var(--text-muted)]">Order window</dt><dd className="mt-1 text-[color:var(--text-primary)]">10:00 New York</dd></div>
+            </dl>
+          ) : null}
+          <button type="button" onClick={requestPreview} disabled={busy || !data?.enabled || workspace !== "nasdaq100" || !selectedPortfolio || !connectionId || Number(budget) < 100} className="mt-4 rounded-lg bg-[color:var(--accent)] px-3 py-2 text-xs font-semibold uppercase tracking-[0.12em] text-[color:var(--text-on-accent)] disabled:cursor-not-allowed disabled:bg-[color:var(--surface)] disabled:text-[color:var(--text-disabled)]">
+            Review and arm Paper
+          </button>
+        </Card>
+
+        <Card title="3. Safety controls">
+          <p className="text-sm text-[color:var(--text-muted)]">Pause leaves holdings and orders untouched. Kill switch pauses and asks the executor to cancel system-owned open orders; it never liquidates automatically.</p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {selectedConnection?.status === "paused" ? (
+              <button type="button" onClick={() => control("resume")} disabled={busy || !data?.enabled} className="rounded-lg border border-[color:var(--success)] px-3 py-2 text-xs font-semibold text-[color:var(--success)] disabled:text-[color:var(--text-disabled)]">Resume</button>
+            ) : (
+              <button type="button" onClick={() => control("pause")} disabled={busy || !data?.enabled || !selectedConnection} className="rounded-lg border border-[color:var(--warning)] px-3 py-2 text-xs font-semibold text-[color:var(--warning)] disabled:text-[color:var(--text-disabled)]">Pause</button>
+            )}
+            <button type="button" onClick={() => control("kill_switch")} disabled={busy || !data?.enabled || !selectedConnection} className="rounded-lg border border-[color:var(--danger)] px-3 py-2 text-xs font-semibold text-[color:var(--danger)] disabled:text-[color:var(--text-disabled)]">Kill switch</button>
+          </div>
+          <p className="mt-4 text-xs leading-relaxed text-[color:var(--text-muted)]">An empty target is blocked and requires a separate future liquidation flow. This screen does not expose liquidation.</p>
+        </Card>
+      </div>
+
+      {preview ? (
+        <Card title="Confirmation preview">
+          <div className="grid gap-4 lg:grid-cols-3">
+            <dl className="space-y-2 text-sm"><div><dt className="text-[color:var(--text-muted)]">Target</dt><dd className="font-semibold">{preview.preview.target.label}</dd></div><div><dt className="text-[color:var(--text-muted)]">Budget / investable</dt><dd>${preview.preview.target.budget_usd.toLocaleString()} / ${preview.preview.target.investable_budget_usd.toLocaleString()}</dd></div><div><dt className="text-[color:var(--text-muted)]">Eligibility</dt><dd className={preview.preview.target.eligible ? "text-[color:var(--success)]" : "text-[color:var(--danger)]"}>{preview.preview.target.eligible ? "Eligible" : preview.preview.target.eligibility_reasons.join(", ")}</dd></div></dl>
+            <div className="text-sm"><p className="text-[color:var(--text-muted)]">Estimated symbol changes</p><p className="mt-2 text-[color:var(--success)]">Add: {preview.preview.estimated_changes.additions.join(", ") || "None"}</p><p className="mt-1 text-[color:var(--danger)]">Remove: {preview.preview.estimated_changes.removals.join(", ") || "None"}</p></div>
+            <ul className="space-y-1 text-xs text-[color:var(--text-muted)]">{preview.preview.safeguards.map((item) => <li key={item}>· {item}</li>)}</ul>
+          </div>
+          <div className="mt-4 flex gap-2"><button type="button" onClick={confirmPreview} disabled={busy || !preview.preview.target.eligible} className="rounded-lg bg-[color:var(--accent)] px-3 py-2 text-xs font-semibold text-[color:var(--text-on-accent)] disabled:bg-[color:var(--surface)] disabled:text-[color:var(--text-disabled)]">Confirm Paper automation</button><button type="button" onClick={() => setPreview(null)} className="rounded-lg border border-[color:var(--border-strong)] px-3 py-2 text-xs text-[color:var(--text-secondary)]">Cancel</button></div>
+        </Card>
+      ) : null}
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <Card title="Target versus strategy-owned positions">
+          <div className="overflow-x-auto"><table className="w-full min-w-[540px] text-sm"><thead className="text-left text-xs text-[color:var(--text-muted)]"><tr><th className="pb-2">Symbol</th><th className="pb-2 text-right">Target weight</th><th className="pb-2 text-right">Owned quantity</th><th className="pb-2 text-right">Average cost</th></tr></thead><tbody>{(strategyPortfolio?.holdings || []).map((holding) => { const actual = actualBySymbol.get(holding.ticker); return <tr key={holding.ticker} className="border-t border-[color:var(--border-subtle)]"><td className="py-2 font-semibold">{holding.ticker}</td><td className="py-2 text-right">{(holding.weight * 100).toFixed(2)}%</td><td className="py-2 text-right">{actual?.quantity ?? "—"}</td><td className="py-2 text-right">{actual?.average_cost_usd == null ? "—" : `$${actual.average_cost_usd.toFixed(2)}`}</td></tr>; })}</tbody></table></div>
+          {!strategyPortfolio ? <p className="text-sm text-[color:var(--text-muted)]">No portfolio is armed yet.</p> : null}
+        </Card>
+        <Card title="Rebalance plans">
+          <div className="space-y-2">{(data?.plans || []).map((plan) => <div key={plan.id} className="flex items-start justify-between gap-3 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-3 text-sm"><div><p className="font-mono text-xs">{plan.snapshot_id.slice(0, 8)}</p><p className="mt-1 text-xs text-[color:var(--text-muted)]">{plan.target_holdings.length} targets · {displayDate(plan.created_at)}</p>{plan.error ? <p className="mt-1 text-xs text-[color:var(--danger)]">{plan.error}</p> : null}</div><span className={`font-semibold ${statusTone(plan.status)}`}>{plan.status}</span></div>)}{!data?.plans.length ? <p className="text-sm text-[color:var(--text-muted)]">No rebalance plans yet.</p> : null}</div>
+        </Card>
+        <Card title="Orders">
+          <div className="space-y-2">{(data?.orders || []).map((order) => <div key={order.id} className="grid grid-cols-[auto_1fr_auto] gap-3 border-b border-[color:var(--border-subtle)] pb-2 text-sm"><span className={order.side === "BUY" ? "text-[color:var(--success)]" : "text-[color:var(--warning)]"}>{order.side}</span><span>{order.symbol} · {order.filled_quantity}/{order.requested_quantity}</span><span className={statusTone(order.status)}>{order.status}</span></div>)}{!data?.orders.length ? <p className="text-sm text-[color:var(--text-muted)]">No system orders yet.</p> : null}</div>
+        </Card>
+        <Card title="Fills, fees, and alerts">
+          <div className="space-y-2">{(data?.fills || []).slice(0, 8).map((fill) => <p key={fill.exec_id} className="text-sm"><span className="font-semibold">{fill.side} {fill.symbol}</span> · {fill.quantity} @ ${fill.price.toFixed(2)} · fee {fill.commission.toFixed(2)} {fill.commission_currency}</p>)}{(data?.events || []).slice(0, 8).map((event) => <p key={`${event.created_at}:${event.event_type}`} className={`border-t border-[color:var(--border-subtle)] pt-2 text-xs ${statusTone(event.severity === "critical" ? "error" : event.severity)}`}>{event.event_type}: {event.message}</p>)}{!data?.fills.length && !data?.events.length ? <p className="text-sm text-[color:var(--text-muted)]">No fills or alerts yet.</p> : null}</div>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/trading-dashboard.tsx
+++ b/frontend/src/components/trading-dashboard.tsx
@@ -279,6 +279,7 @@ export function TradingDashboard() {
           <label className="mt-3 block text-xs font-medium text-[color:var(--text-secondary)]" htmlFor="trading-budget">Fixed USD budget</label>
           <input id="trading-budget" type="number" min="100" step="100" value={budget} onChange={(event) => { setBudget(event.target.value); setPreview(null); }} className="mt-1 w-full rounded-lg border border-[color:var(--border-strong)] bg-[color:var(--surface)] px-3 py-2 text-sm text-[color:var(--text-primary)]" />
           <p className="mt-2 text-xs text-[color:var(--text-muted)]">Up to 98% invested; 2% remains for fees and price movement. The executor requires full N/N target coverage and never borrows on margin or counts unsettled sale proceeds.</p>
+          {data?.strategy ? <p className="mt-2 text-xs text-[color:var(--text-muted)]">Strategy-owned cash ledger: <span className="font-semibold text-[color:var(--text-primary)]">${data.strategy.cash_balance_usd.toLocaleString(undefined, { maximumFractionDigits: 2 })}</span>. Other account cash is excluded from sizing.</p> : null}
           {selectedPortfolio ? (
             <dl className="mt-3 grid grid-cols-2 gap-2 text-xs">
               <div><dt className="text-[color:var(--text-muted)]">Snapshot</dt><dd className="mt-1 font-mono text-[color:var(--text-primary)]">{selectedPortfolio.latest_snapshot_id.slice(0, 8)}</dd></div>

--- a/frontend/src/lib/portfolio-db.ts
+++ b/frontend/src/lib/portfolio-db.ts
@@ -27,6 +27,10 @@ export type StoredPortfolioNavPoint = PortfolioNavPoint & {
   lensKey: string;
   lensLabel: string;
   methodologyVersion: string;
+  snapshotCutoffAt: string | null;
+  snapshotExecutionDate: string | null;
+  tradeEligible: boolean;
+  tradeEligibilityReasons: string[];
 };
 
 type SnapshotRow = {
@@ -393,12 +397,17 @@ export async function loadPortfolioNav(
            n.methodology_version,
            n.nav_date::text AS nav_date,
            n.snapshot_id::text AS snapshot_id,
+           s.cutoff_at::text AS snapshot_cutoff_at,
+           s.execution_date::text AS snapshot_execution_date,
+           COALESCE(e.eligible, false) AS trade_eligible,
+           COALESCE(e.reasons, '[]'::jsonb) AS trade_eligibility_reasons,
            n.nav::float8 AS nav,
            n.benchmark_nav::float8 AS benchmark_nav,
            n.holdings_count,
            n.status
       FROM portfolio_nav_daily n
       LEFT JOIN portfolio_snapshots s ON s.id = n.snapshot_id
+      LEFT JOIN portfolio_snapshot_trade_eligibility e ON e.snapshot_id = n.snapshot_id
      WHERE n.track = ${track}
        AND n.workspace = ${workspace}
        AND n.methodology_version = ${methodologyVersion}
@@ -410,6 +419,10 @@ export async function loadPortfolioNav(
     methodology_version: string;
     nav_date: string;
     snapshot_id: string;
+    snapshot_cutoff_at: string | null;
+    snapshot_execution_date: string | null;
+    trade_eligible: boolean;
+    trade_eligibility_reasons: unknown;
     nav: number;
     benchmark_nav: number;
     holdings_count: number;
@@ -420,6 +433,12 @@ export async function loadPortfolioNav(
     lensKey: row.lens_key,
     lensLabel: row.lens_label,
     methodologyVersion: row.methodology_version,
+    snapshotCutoffAt: row.snapshot_cutoff_at ? new Date(row.snapshot_cutoff_at).toISOString() : null,
+    snapshotExecutionDate: row.snapshot_execution_date,
+    tradeEligible: Boolean(row.trade_eligible),
+    tradeEligibilityReasons: Array.isArray(row.trade_eligibility_reasons)
+      ? row.trade_eligibility_reasons.map((value) => String(value))
+      : [],
     date: row.nav_date,
     snapshotId: row.snapshot_id,
     nav: Number(row.nav),

--- a/frontend/src/lib/trading-access-policy.test.ts
+++ b/frontend/src/lib/trading-access-policy.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { tradingMutationsEnabled, tradingSessionIsEligible } from "./trading-access-policy";
+
+test("preview environments cannot enable trading mutations", () => {
+  assert.equal(tradingMutationsEnabled({ controlFlag: "1", previewFlag: "1" }), false);
+  assert.equal(tradingMutationsEnabled({ controlFlag: "1", previewFlag: "0" }), true);
+  assert.equal(tradingMutationsEnabled({ controlFlag: "0", previewFlag: "0" }), false);
+});
+
+test("trading controls require a durable Google user and reject guests", () => {
+  const googleUser = {
+    id: "123e4567-e89b-42d3-a456-426614174000",
+    email: "owner@example.com",
+    isGuest: false,
+    authProvider: "google",
+  };
+  assert.equal(tradingSessionIsEligible(googleUser), true);
+  assert.equal(tradingSessionIsEligible({ ...googleUser, isGuest: true }), false);
+  assert.equal(tradingSessionIsEligible({ ...googleUser, authProvider: "guest" }), false);
+  assert.equal(tradingSessionIsEligible({ ...googleUser, id: "browser-local-id" }), false);
+});

--- a/frontend/src/lib/trading-access-policy.ts
+++ b/frontend/src/lib/trading-access-policy.ts
@@ -1,0 +1,24 @@
+export const TRADING_USER_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function flagEnabled(raw: string | undefined): boolean {
+  return ["1", "true", "yes", "on"].includes(String(raw || "").trim().toLowerCase());
+}
+
+export function tradingMutationsEnabled(args: { controlFlag: string | undefined; previewFlag: string | undefined }): boolean {
+  return flagEnabled(args.controlFlag) && !flagEnabled(args.previewFlag);
+}
+
+export function tradingSessionIsEligible(user: {
+  id?: string | null;
+  email?: string | null;
+  isGuest?: boolean | null;
+  authProvider?: string | null;
+} | null | undefined): boolean {
+  return Boolean(
+    user
+    && TRADING_USER_ID_RE.test(String(user.id || "").trim())
+    && String(user.email || "").trim()
+    && !user.isGuest
+    && user.authProvider === "google",
+  );
+}

--- a/frontend/src/lib/trading-alerts.ts
+++ b/frontend/src/lib/trading-alerts.ts
@@ -1,0 +1,34 @@
+import "server-only";
+
+import { markTradingEventTelegramSent } from "@/lib/trading-db";
+
+export async function sendTradingTelegramAlert(args: {
+  connectionId: string;
+  eventId: string;
+  severity: "warning" | "critical";
+  message: string;
+}): Promise<boolean> {
+  const token = String(process.env.TRADING_TELEGRAM_BOT_TOKEN || "").trim();
+  const chatId = String(process.env.TRADING_TELEGRAM_CHAT_ID || "").trim();
+  if (!token || !chatId) return false;
+  const prefix = args.severity === "critical" ? "TRADING CRITICAL" : "TRADING WARNING";
+  try {
+    const response = await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        chat_id: chatId,
+        text: `${prefix}\n${args.message}`,
+        disable_web_page_preview: true,
+      }),
+      cache: "no-store",
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!response.ok) return false;
+    await markTradingEventTelegramSent(args.connectionId, args.eventId);
+    return true;
+  } catch (error) {
+    console.warn("[trading] Telegram alert delivery failed", error);
+    return false;
+  }
+}

--- a/frontend/src/lib/trading-db.test.ts
+++ b/frontend/src/lib/trading-db.test.ts
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { tradingExecutionIdentity } from "./trading-db";
+
+test("IBKR execution corrections share a family and advance the revision", () => {
+  assert.deepEqual(tradingExecutionIdentity("0001.01"), { familyId: "0001", revision: 1 });
+  assert.deepEqual(tradingExecutionIdentity("0001.02"), { familyId: "0001", revision: 2 });
+});
+
+test("execution ids without a correction suffix remain independent", () => {
+  assert.deepEqual(tradingExecutionIdentity("paper-fill-a"), { familyId: "paper-fill-a", revision: 0 });
+});

--- a/frontend/src/lib/trading-db.ts
+++ b/frontend/src/lib/trading-db.ts
@@ -1,0 +1,1343 @@
+import { getSql } from "@/lib/db";
+import {
+  PORTFOLIO_METHODOLOGY_VERSION,
+  type PortfolioTrack,
+} from "@/lib/portfolio-performance-engine";
+import {
+  TRADING_RESERVE_FRACTION,
+  tradingPortfolioKey,
+  type BrokerMode,
+  type RebalanceStatus,
+  type TradingConnectionView,
+  type TradingDashboardPayload,
+  type TradingEventView,
+  type TradingHolding,
+  type TradingFillView,
+  type TradingLensType,
+  type TradingOrderView,
+  type TradingPlanView,
+  type TradingPortfolioOption,
+  type TradingPositionView,
+  type TradingStrategyView,
+} from "@/lib/trading-types";
+import type { Workspace } from "@/lib/workspace";
+
+function requireSql() {
+  const sql = getSql();
+  if (!sql) throw new Error("DATABASE_URL is required for trading controls.");
+  return sql;
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.map((item) => String(item)) : [];
+}
+
+function asHoldings(value: unknown): TradingHolding[] {
+  if (!Array.isArray(value)) return [];
+  return value.map((item) => {
+    const row = (item || {}) as Record<string, unknown>;
+    return {
+      rank: Number(row.rank),
+      ticker: String(row.ticker || "").toUpperCase(),
+      score: Number(row.score),
+      weight: Number(row.weight),
+      currency: String(row.currency || "USD").toUpperCase(),
+    };
+  }).filter((item) => item.ticker && Number.isFinite(item.rank));
+}
+
+export async function createTradingPairing(args: {
+  userId: string;
+  mode: BrokerMode;
+  codeHash: string;
+  expiresAt: string;
+  connectionId?: string;
+}): Promise<string> {
+  const sql = requireSql();
+  const connectionRows = args.connectionId
+    ? (await sql`
+        UPDATE trading_connections
+           SET device_secret_hash = NULL,
+               status = 'awaiting_pairing',
+               gateway_connected = false,
+               gateway_authenticated = false,
+               last_error = '',
+               updated_at = now()
+         WHERE id = ${args.connectionId}::uuid
+           AND user_id = ${args.userId}::uuid
+           AND mode = ${args.mode}
+           AND status <> 'revoked'
+        RETURNING id::text AS id;
+      `) as Array<{ id: string }>
+    : (await sql`
+        INSERT INTO trading_connections (user_id, mode)
+        VALUES (${args.userId}::uuid, ${args.mode})
+        RETURNING id::text AS id;
+      `) as Array<{ id: string }>;
+  const connectionId = connectionRows[0]?.id;
+  if (!connectionId) throw new Error("Could not create trading connection.");
+  await sql`
+    UPDATE trading_pairing_codes
+       SET consumed_at = now()
+     WHERE connection_id = ${connectionId}::uuid AND consumed_at IS NULL;
+  `;
+  await sql`
+    INSERT INTO trading_pairing_codes (connection_id, code_hash, expires_at)
+    VALUES (${connectionId}::uuid, ${args.codeHash}, ${args.expiresAt}::timestamptz);
+  `;
+  await appendTradingAudit({
+    userId: args.userId,
+    connectionId,
+    actorType: "user",
+    action: args.connectionId ? "device_token_rotation_requested" : "pairing_code_created",
+    payload: { mode: args.mode, expires_at: args.expiresAt },
+  });
+  return connectionId;
+}
+
+export async function consumeTradingPairing(args: {
+  codeHash: string;
+  deviceSecretHash: string;
+  accountFingerprint: string;
+  accountMasked: string;
+  mode: BrokerMode;
+  executorVersion: string;
+}): Promise<string | null> {
+  const sql = requireSql();
+  const rows = (await sql`
+    UPDATE trading_pairing_codes p
+       SET consumed_at = now()
+      FROM trading_connections c
+     WHERE p.connection_id = c.id
+       AND p.code_hash = ${args.codeHash}
+       AND p.consumed_at IS NULL
+       AND p.expires_at > now()
+       AND c.mode = ${args.mode}
+       AND c.status = 'awaiting_pairing'
+    RETURNING p.connection_id::text AS connection_id;
+  `) as Array<{ connection_id: string }>;
+  const connectionId = rows[0]?.connection_id || null;
+  if (!connectionId) return null;
+  await sql`
+    UPDATE trading_connections
+       SET account_fingerprint = ${args.accountFingerprint},
+           account_masked = ${args.accountMasked},
+           device_secret_hash = ${args.deviceSecretHash},
+           executor_version = ${args.executorVersion},
+           status = 'disconnected',
+           paired_at = now(),
+           updated_at = now()
+     WHERE id = ${connectionId}::uuid;
+  `;
+  await appendTradingAudit({
+    connectionId,
+    actorType: "executor",
+    action: "executor_paired",
+    payload: { mode: args.mode, account_masked: args.accountMasked, executor_version: args.executorVersion },
+  });
+  return connectionId;
+}
+
+export async function loadExecutorCredential(connectionId: string): Promise<{
+  deviceSecretHash: string;
+  status: string;
+  mode: BrokerMode;
+  accountFingerprint: string;
+} | null> {
+  const sql = requireSql();
+  const rows = (await sql`
+    SELECT device_secret_hash, status, mode, account_fingerprint
+      FROM trading_connections
+     WHERE id = ${connectionId}::uuid
+       AND status <> 'revoked'
+     LIMIT 1;
+  `) as Array<{
+    device_secret_hash: string | null;
+    status: string;
+    mode: BrokerMode;
+    account_fingerprint: string | null;
+  }>;
+  const row = rows[0];
+  if (!row?.device_secret_hash) return null;
+  return {
+    deviceSecretHash: row.device_secret_hash,
+    status: row.status,
+    mode: row.mode,
+    accountFingerprint: String(row.account_fingerprint || ""),
+  };
+}
+
+export async function registerExecutorNonce(connectionId: string, nonce: string): Promise<boolean> {
+  const sql = requireSql();
+  await sql`DELETE FROM trading_request_nonces WHERE seen_at < now() - interval '1 day';`;
+  const rows = (await sql`
+    INSERT INTO trading_request_nonces (connection_id, nonce)
+    VALUES (${connectionId}::uuid, ${nonce})
+    ON CONFLICT DO NOTHING
+    RETURNING nonce;
+  `) as Array<{ nonce: string }>;
+  return rows.length === 1;
+}
+
+export async function updateTradingHeartbeat(args: {
+  connectionId: string;
+  gatewayConnected: boolean;
+  gatewayAuthenticated: boolean;
+  executorVersion: string;
+  error?: string;
+}): Promise<void> {
+  const sql = requireSql();
+  const status = args.gatewayConnected && args.gatewayAuthenticated ? "ready" : args.error ? "error" : "disconnected";
+  await sql`
+    UPDATE trading_connections
+       SET gateway_connected = ${args.gatewayConnected},
+           gateway_authenticated = ${args.gatewayAuthenticated},
+           executor_version = ${args.executorVersion},
+           status = CASE WHEN status = 'paused' THEN 'paused' ELSE ${status} END,
+           last_heartbeat_at = now(),
+           last_error = ${args.error || ""},
+           updated_at = now()
+     WHERE id = ${args.connectionId}::uuid
+       AND status <> 'revoked';
+  `;
+}
+
+export async function listTradingPortfolios(workspace: Workspace): Promise<TradingPortfolioOption[]> {
+  const sql = requireSql();
+  const rows = (await sql`
+    WITH latest AS (
+      SELECT DISTINCT ON (s.lens_type, s.lens_key, s.methodology_version)
+             s.id,
+             s.workspace,
+             s.lens_type,
+             s.lens_key,
+             s.lens_label,
+             s.methodology_version,
+             s.cutoff_at,
+             s.execution_date,
+             s.status,
+             s.selected_count,
+             COALESCE(e.eligible, false) AS eligible,
+             COALESCE(e.reasons, '["refresh_not_verified"]'::jsonb) AS eligibility_reasons
+        FROM portfolio_snapshots s
+        LEFT JOIN portfolio_snapshot_trade_eligibility e ON e.snapshot_id = s.id
+       WHERE s.workspace = ${workspace}
+         AND s.track = 'paper'
+         AND s.methodology_version = ${PORTFOLIO_METHODOLOGY_VERSION}
+         AND s.status IN ('ready', 'no_positions')
+       ORDER BY s.lens_type, s.lens_key, s.methodology_version, s.cutoff_at DESC
+    )
+    SELECT l.id::text AS id,
+           l.workspace,
+           l.lens_type,
+           l.lens_key,
+           l.lens_label,
+           l.methodology_version,
+           l.cutoff_at::text AS cutoff_at,
+           l.execution_date::text AS execution_date,
+           l.status,
+           l.selected_count,
+           l.eligible,
+           l.eligibility_reasons,
+           COALESCE(
+             jsonb_agg(
+               jsonb_build_object(
+                 'rank', h.rank,
+                 'ticker', h.ticker,
+                 'score', h.score,
+                 'weight', h.weight,
+                 'currency', h.currency
+               ) ORDER BY h.rank
+             ) FILTER (WHERE h.snapshot_id IS NOT NULL),
+             '[]'::jsonb
+           ) AS holdings
+      FROM latest l
+      LEFT JOIN portfolio_holdings h ON h.snapshot_id = l.id
+     GROUP BY l.id, l.workspace, l.lens_type, l.lens_key, l.lens_label,
+              l.methodology_version, l.cutoff_at, l.execution_date, l.status,
+              l.selected_count, l.eligible, l.eligibility_reasons
+     ORDER BY CASE WHEN l.lens_type = 'overall' THEN 0 WHEN l.lens_type = 'model' THEN 1 ELSE 2 END,
+              l.lens_label;
+  `) as Array<Record<string, unknown>>;
+  return rows.map((row) => {
+    const lensType = row.lens_type as TradingLensType;
+    const lensKey = String(row.lens_key || (lensType === "overall" ? "overall" : ""));
+    const reasons = asStringArray(row.eligibility_reasons);
+    const status = row.status as "ready" | "no_positions";
+    if (workspace !== "nasdaq100") reasons.push("analysis_live_execution_not_released");
+    if (status === "no_positions") reasons.push("empty_target_requires_confirmation");
+    const uniqueReasons = Array.from(new Set(reasons));
+    const eligible = Boolean(row.eligible) && workspace === "nasdaq100" && status === "ready";
+    return {
+      portfolio_key: tradingPortfolioKey({
+        workspace,
+        lensType,
+        lensKey,
+        methodologyVersion: String(row.methodology_version),
+      }),
+      workspace,
+      lens_type: lensType,
+      lens_key: lensKey,
+      label: lensType === "overall" ? "Overall" : String(row.lens_label || lensKey),
+      methodology_version: String(row.methodology_version),
+      latest_snapshot_id: String(row.id),
+      cutoff_at: new Date(String(row.cutoff_at)).toISOString(),
+      execution_date: String(row.execution_date),
+      status,
+      holdings_count: Number(row.selected_count),
+      eligible,
+      eligibility_reasons: uniqueReasons,
+      holdings: asHoldings(row.holdings),
+    };
+  });
+}
+
+export async function loadTradingDashboard(args: {
+  userId: string;
+  workspace: Workspace;
+  enabled: boolean;
+  liveEnabled: boolean;
+}): Promise<TradingDashboardPayload> {
+  const sql = requireSql();
+  const [connectionRows, strategyRows, planRows, eventRows, positionRows, orderRows, fillRows, portfolios] = await Promise.all([
+    sql`
+      SELECT id::text AS id, mode, account_masked, status, gateway_connected,
+             gateway_authenticated, executor_version,
+             last_heartbeat_at::text AS last_heartbeat_at, last_error,
+             paired_at::text AS paired_at
+        FROM trading_connections
+       WHERE user_id = ${args.userId}::uuid AND status <> 'revoked'
+       ORDER BY created_at DESC;
+    `,
+    sql`
+      SELECT l.id::text AS id, l.connection_id::text AS connection_id, l.workspace,
+             l.lens_type, l.lens_key, l.methodology_version,
+             l.budget_usd::float8 AS budget_usd,
+             l.reserve_fraction::float8 AS reserve_fraction,
+             l.status, l.latest_snapshot_id::text AS latest_snapshot_id,
+             l.last_error, l.armed_at::text AS armed_at
+        FROM trading_strategy_links l
+        JOIN trading_connections c ON c.id = l.connection_id
+       WHERE c.user_id = ${args.userId}::uuid AND l.status <> 'revoked'
+       ORDER BY l.updated_at DESC
+       LIMIT 1;
+    `,
+    sql`
+      SELECT p.id::text AS id, p.strategy_link_id::text AS strategy_link_id,
+             p.snapshot_id::text AS snapshot_id, p.status, p.target_holdings,
+             p.not_before::text AS not_before, p.error,
+             p.created_at::text AS created_at, p.updated_at::text AS updated_at
+        FROM trading_rebalance_plans p
+        JOIN trading_strategy_links l ON l.id = p.strategy_link_id
+        JOIN trading_connections c ON c.id = l.connection_id
+       WHERE c.user_id = ${args.userId}::uuid
+       ORDER BY p.created_at DESC
+       LIMIT 20;
+    `,
+    sql`
+      SELECT e.event_type, e.severity, e.message, e.created_at::text AS created_at
+        FROM trading_events e
+        JOIN trading_connections c ON c.id = e.connection_id
+       WHERE c.user_id = ${args.userId}::uuid
+       ORDER BY e.created_at DESC
+       LIMIT 20;
+    `,
+    sql`
+      SELECT p.symbol, p.conid, p.quantity::float8 AS quantity,
+             p.average_cost_usd::float8 AS average_cost_usd
+        FROM trading_strategy_positions p
+        JOIN trading_strategy_links l ON l.id = p.strategy_link_id
+        JOIN trading_connections c ON c.id = l.connection_id
+       WHERE c.user_id = ${args.userId}::uuid
+       ORDER BY p.symbol;
+    `,
+    sql`
+      SELECT o.id::text AS id, o.rebalance_plan_id::text AS plan_id, o.symbol, o.side,
+             o.requested_quantity::float8 AS requested_quantity,
+             o.filled_quantity::float8 AS filled_quantity,
+             o.limit_price::float8 AS limit_price,
+             o.average_fill_price::float8 AS average_fill_price,
+             o.commission::float8 AS commission, o.commission_currency, o.status,
+             o.updated_at::text AS updated_at
+        FROM trading_orders o
+        JOIN trading_rebalance_plans p ON p.id = o.rebalance_plan_id
+        JOIN trading_strategy_links l ON l.id = p.strategy_link_id
+        JOIN trading_connections c ON c.id = l.connection_id
+       WHERE c.user_id = ${args.userId}::uuid
+       ORDER BY o.updated_at DESC
+       LIMIT 50;
+    `,
+    sql`
+      SELECT f.exec_id, f.symbol, f.side, f.quantity::float8 AS quantity,
+             f.price::float8 AS price, f.commission::float8 AS commission,
+             f.commission_currency, f.executed_at::text AS executed_at
+        FROM trading_fills f
+        JOIN trading_connections c ON c.id = f.connection_id
+       WHERE c.user_id = ${args.userId}::uuid
+       ORDER BY f.executed_at DESC
+       LIMIT 50;
+    `,
+    listTradingPortfolios(args.workspace),
+  ]);
+
+  const connections = (connectionRows as Array<Record<string, unknown>>).map((row): TradingConnectionView => ({
+    id: String(row.id),
+    mode: row.mode as BrokerMode,
+    account_masked: String(row.account_masked || ""),
+    status: row.status as TradingConnectionView["status"],
+    gateway_connected: Boolean(row.gateway_connected),
+    gateway_authenticated: Boolean(row.gateway_authenticated),
+    executor_version: String(row.executor_version || ""),
+    last_heartbeat_at: row.last_heartbeat_at ? new Date(String(row.last_heartbeat_at)).toISOString() : null,
+    last_error: String(row.last_error || ""),
+    paired_at: row.paired_at ? new Date(String(row.paired_at)).toISOString() : null,
+  }));
+  const strategyRow = (strategyRows as Array<Record<string, unknown>>)[0];
+  const strategy: TradingStrategyView | null = strategyRow ? {
+    id: String(strategyRow.id),
+    connection_id: String(strategyRow.connection_id),
+    workspace: strategyRow.workspace as Workspace,
+    lens_type: strategyRow.lens_type as TradingLensType,
+    lens_key: String(strategyRow.lens_key),
+    methodology_version: String(strategyRow.methodology_version),
+    budget_usd: Number(strategyRow.budget_usd),
+    reserve_fraction: Number(strategyRow.reserve_fraction),
+    status: strategyRow.status as TradingStrategyView["status"],
+    latest_snapshot_id: strategyRow.latest_snapshot_id ? String(strategyRow.latest_snapshot_id) : null,
+    last_error: String(strategyRow.last_error || ""),
+    armed_at: strategyRow.armed_at ? new Date(String(strategyRow.armed_at)).toISOString() : null,
+  } : null;
+  const plans = (planRows as Array<Record<string, unknown>>).map((row): TradingPlanView => ({
+    id: String(row.id),
+    strategy_link_id: String(row.strategy_link_id),
+    snapshot_id: String(row.snapshot_id),
+    status: row.status as RebalanceStatus,
+    target_holdings: asHoldings(row.target_holdings),
+    not_before: row.not_before ? new Date(String(row.not_before)).toISOString() : null,
+    error: String(row.error || ""),
+    created_at: new Date(String(row.created_at)).toISOString(),
+    updated_at: new Date(String(row.updated_at)).toISOString(),
+  }));
+  const events = (eventRows as Array<Record<string, unknown>>).map((row): TradingEventView => ({
+    event_type: String(row.event_type),
+    severity: row.severity as TradingEventView["severity"],
+    message: String(row.message || ""),
+    created_at: new Date(String(row.created_at)).toISOString(),
+  }));
+  const positions = (positionRows as Array<Record<string, unknown>>).map((row): TradingPositionView => ({
+    symbol: String(row.symbol),
+    conid: row.conid == null ? null : Number(row.conid),
+    quantity: Number(row.quantity),
+    average_cost_usd: row.average_cost_usd == null ? null : Number(row.average_cost_usd),
+  }));
+  const orders = (orderRows as Array<Record<string, unknown>>).map((row): TradingOrderView => ({
+    id: String(row.id),
+    plan_id: String(row.plan_id),
+    symbol: String(row.symbol),
+    side: row.side as "BUY" | "SELL",
+    requested_quantity: Number(row.requested_quantity),
+    filled_quantity: Number(row.filled_quantity),
+    limit_price: row.limit_price == null ? null : Number(row.limit_price),
+    average_fill_price: row.average_fill_price == null ? null : Number(row.average_fill_price),
+    commission: Number(row.commission),
+    commission_currency: String(row.commission_currency),
+    status: String(row.status),
+    updated_at: new Date(String(row.updated_at)).toISOString(),
+  }));
+  const fills = (fillRows as Array<Record<string, unknown>>).map((row): TradingFillView => ({
+    exec_id: String(row.exec_id),
+    symbol: String(row.symbol),
+    side: row.side as "BUY" | "SELL",
+    quantity: Number(row.quantity),
+    price: Number(row.price),
+    commission: Number(row.commission),
+    commission_currency: String(row.commission_currency),
+    executed_at: new Date(String(row.executed_at)).toISOString(),
+  }));
+  return {
+    enabled: args.enabled,
+    live_enabled: args.liveEnabled,
+    workspace: args.workspace,
+    connections,
+    strategy,
+    portfolios,
+    plans,
+    events,
+    positions,
+    orders,
+    fills,
+  };
+}
+
+export async function configureTradingStrategy(args: {
+  userId: string;
+  connectionId: string;
+  workspace: Workspace;
+  lensType: TradingLensType;
+  lensKey: string;
+  methodologyVersion: string;
+  budgetUsd: number;
+  arm: boolean;
+  expectedSnapshotId?: string;
+}): Promise<{ linkId: string; status: TradingStrategyView["status"]; reason: string }> {
+  const sql = requireSql();
+  const connectionRows = (await sql`
+    SELECT id::text AS id, mode, status
+      FROM trading_connections
+     WHERE id = ${args.connectionId}::uuid
+       AND user_id = ${args.userId}::uuid
+       AND status NOT IN ('awaiting_pairing', 'revoked')
+     LIMIT 1;
+  `) as Array<{ id: string; mode: BrokerMode; status: string }>;
+  const connection = connectionRows[0];
+  if (!connection) throw new Error("A paired connection owned by this user is required.");
+  if (connection.mode === "live") throw new Error("Live strategy activation is locked until the Paper gate is complete.");
+
+  const portfolios = await listTradingPortfolios(args.workspace);
+  const selected = portfolios.find((portfolio) => (
+    portfolio.lens_type === args.lensType
+    && portfolio.lens_key === args.lensKey
+    && portfolio.methodology_version === args.methodologyVersion
+  ));
+  if (!selected) throw new Error("The selected Paper portfolio is not available.");
+  if (args.expectedSnapshotId && selected.latest_snapshot_id !== args.expectedSnapshotId) {
+    throw new Error("The portfolio snapshot changed after preview. Review the new snapshot before confirming.");
+  }
+
+  let status: TradingStrategyView["status"] = "draft";
+  let reason = "Saved as a draft.";
+  if (args.arm) {
+    if (!selected.eligible) {
+      status = "blocked";
+      reason = selected.eligibility_reasons.join(", ") || "Snapshot is not trade-eligible.";
+    } else {
+      status = "armed";
+      reason = "Paper strategy armed.";
+    }
+  }
+  const rows = (await sql`
+    INSERT INTO trading_strategy_links (
+      connection_id, workspace, lens_type, lens_key, methodology_version,
+      budget_usd, status, latest_snapshot_id, last_error, armed_at
+    ) VALUES (
+      ${args.connectionId}::uuid, ${args.workspace}, ${args.lensType}, ${args.lensKey},
+      ${args.methodologyVersion}, ${args.budgetUsd}, ${status}, ${selected.latest_snapshot_id}::uuid,
+      ${status === "blocked" ? reason : ""},
+      CASE WHEN ${status} = 'armed' THEN now() ELSE NULL END
+    )
+    ON CONFLICT (connection_id) DO UPDATE SET
+      workspace = EXCLUDED.workspace,
+      lens_type = EXCLUDED.lens_type,
+      lens_key = EXCLUDED.lens_key,
+      methodology_version = EXCLUDED.methodology_version,
+      budget_usd = EXCLUDED.budget_usd,
+      status = EXCLUDED.status,
+      latest_snapshot_id = EXCLUDED.latest_snapshot_id,
+      last_error = EXCLUDED.last_error,
+      armed_at = EXCLUDED.armed_at,
+      updated_at = now()
+    RETURNING id::text AS id;
+  `) as Array<{ id: string }>;
+  const linkId = rows[0].id;
+  await sql`
+    UPDATE trading_rebalance_plans
+       SET status = 'cancel_requested', updated_at = now()
+     WHERE strategy_link_id = ${linkId}::uuid
+       AND snapshot_id <> ${selected.latest_snapshot_id}::uuid
+       AND status IN ('queued', 'preflight', 'awaiting_market', 'partial');
+  `;
+  if (status === "armed") {
+    await insertRebalancePlan({
+      linkId,
+      snapshotId: selected.latest_snapshot_id,
+      holdings: selected.holdings,
+      retryBlocked: true,
+    });
+  }
+  await appendTradingAudit({
+    userId: args.userId,
+    connectionId: args.connectionId,
+    actorType: "user",
+    action: args.arm ? "strategy_arm_requested" : "strategy_draft_saved",
+    payload: {
+      workspace: args.workspace,
+      lens_type: args.lensType,
+      lens_key: args.lensKey,
+      methodology_version: args.methodologyVersion,
+      budget_usd: args.budgetUsd,
+      resolved_status: status,
+      reason,
+    },
+  });
+  return { linkId, status, reason };
+}
+
+export async function createTradingStrategyPreview(args: {
+  userId: string;
+  connectionId: string;
+  workspace: Workspace;
+  lensType: TradingLensType;
+  lensKey: string;
+  methodologyVersion: string;
+  budgetUsd: number;
+  arm: boolean;
+}): Promise<{ previewId: string; expiresAt: string; preview: Record<string, unknown> }> {
+  const sql = requireSql();
+  const connections = (await sql`
+    SELECT id::text AS id, mode
+      FROM trading_connections
+     WHERE id = ${args.connectionId}::uuid
+       AND user_id = ${args.userId}::uuid
+       AND status NOT IN ('awaiting_pairing', 'revoked')
+     LIMIT 1;
+  `) as Array<{ id: string; mode: BrokerMode }>;
+  if (!connections.length) throw new Error("A paired connection owned by this user is required.");
+  if (connections[0].mode !== "paper") throw new Error("Live strategy activation is locked.");
+  const portfolios = await listTradingPortfolios(args.workspace);
+  const selected = portfolios.find((portfolio) => (
+    portfolio.lens_type === args.lensType
+    && portfolio.lens_key === args.lensKey
+    && portfolio.methodology_version === args.methodologyVersion
+  ));
+  if (!selected) throw new Error("The selected Paper portfolio is not available.");
+  const currentRows = (await sql`
+    SELECT l.workspace, l.lens_type, l.lens_key, l.methodology_version,
+           l.budget_usd::float8 AS budget_usd,
+           COALESCE(jsonb_agg(p.symbol ORDER BY p.symbol) FILTER (WHERE p.symbol IS NOT NULL), '[]'::jsonb) AS symbols
+      FROM trading_strategy_links l
+      LEFT JOIN trading_strategy_positions p ON p.strategy_link_id = l.id AND p.quantity > 0
+     WHERE l.connection_id = ${args.connectionId}::uuid
+     GROUP BY l.id;
+  `) as Array<Record<string, unknown>>;
+  const current = currentRows[0] || null;
+  const currentSymbols = new Set(asStringArray(current?.symbols));
+  const targetSymbols = new Set(selected.holdings.map((holding) => holding.ticker));
+  const preview = {
+    current: current ? {
+      portfolio_key: tradingPortfolioKey({
+        workspace: current.workspace as Workspace,
+        lensType: current.lens_type as TradingLensType,
+        lensKey: String(current.lens_key),
+        methodologyVersion: String(current.methodology_version),
+      }),
+      budget_usd: Number(current.budget_usd),
+    } : null,
+    target: {
+      portfolio_key: selected.portfolio_key,
+      label: selected.label,
+      snapshot_id: selected.latest_snapshot_id,
+      cutoff_at: selected.cutoff_at,
+      execution_date: selected.execution_date,
+      budget_usd: args.budgetUsd,
+      investable_budget_usd: Math.round(args.budgetUsd * (1 - TRADING_RESERVE_FRACTION) * 100) / 100,
+      holdings_count: selected.holdings_count,
+      eligible: selected.eligible,
+      eligibility_reasons: selected.eligibility_reasons,
+    },
+    estimated_changes: {
+      additions: Array.from(targetSymbols).filter((symbol) => !currentSymbols.has(symbol)).sort(),
+      removals: Array.from(currentSymbols).filter((symbol) => !targetSymbols.has(symbol)).sort(),
+    },
+    safeguards: [
+      "Paper account only",
+      "2% cash reserve",
+      "Sells complete before buys",
+      "No manual-position liquidation",
+      "No empty-target liquidation",
+    ],
+  };
+  const expiresAt = new Date(Date.now() + 10 * 60 * 1000).toISOString();
+  const rows = (await sql`
+    INSERT INTO trading_strategy_previews (
+      user_id, connection_id, workspace, lens_type, lens_key, methodology_version,
+      budget_usd, arm, snapshot_id, preview_payload, expires_at
+    ) VALUES (
+      ${args.userId}::uuid, ${args.connectionId}::uuid, ${args.workspace}, ${args.lensType},
+      ${args.lensKey}, ${args.methodologyVersion}, ${args.budgetUsd}, ${args.arm},
+      ${selected.latest_snapshot_id}::uuid, ${JSON.stringify(preview)}::jsonb, ${expiresAt}::timestamptz
+    )
+    RETURNING id::text AS id;
+  `) as Array<{ id: string }>;
+  await appendTradingAudit({
+    userId: args.userId,
+    connectionId: args.connectionId,
+    actorType: "user",
+    action: "strategy_preview_created",
+    payload: { preview_id: rows[0].id, target: preview.target },
+  });
+  return { previewId: rows[0].id, expiresAt, preview };
+}
+
+export async function consumeTradingStrategyPreview(args: {
+  userId: string;
+  previewId: string;
+}): Promise<{
+  connectionId: string;
+  workspace: Workspace;
+  lensType: TradingLensType;
+  lensKey: string;
+  methodologyVersion: string;
+  budgetUsd: number;
+  arm: boolean;
+  snapshotId: string;
+} | null> {
+  const sql = requireSql();
+  const rows = (await sql`
+    UPDATE trading_strategy_previews
+       SET consumed_at = now()
+     WHERE id = ${args.previewId}::uuid
+       AND user_id = ${args.userId}::uuid
+       AND consumed_at IS NULL
+       AND expires_at > now()
+    RETURNING connection_id::text AS connection_id, workspace, lens_type, lens_key,
+              methodology_version, budget_usd::float8 AS budget_usd, arm,
+              snapshot_id::text AS snapshot_id;
+  `) as Array<Record<string, unknown>>;
+  const row = rows[0];
+  if (!row) return null;
+  return {
+    connectionId: String(row.connection_id),
+    workspace: row.workspace as Workspace,
+    lensType: row.lens_type as TradingLensType,
+    lensKey: String(row.lens_key),
+    methodologyVersion: String(row.methodology_version),
+    budgetUsd: Number(row.budget_usd),
+    arm: Boolean(row.arm),
+    snapshotId: String(row.snapshot_id),
+  };
+}
+
+async function insertRebalancePlan(args: {
+  linkId: string;
+  snapshotId: string;
+  holdings: TradingHolding[];
+  retryBlocked?: boolean;
+}): Promise<void> {
+  const sql = requireSql();
+  await sql`
+    INSERT INTO trading_rebalance_plans (strategy_link_id, snapshot_id, target_holdings, not_before)
+    VALUES (
+      ${args.linkId}::uuid,
+      ${args.snapshotId}::uuid,
+      ${JSON.stringify(args.holdings)}::jsonb,
+      ((timezone('America/New_York', now())::date + 1) + time '10:00') AT TIME ZONE 'America/New_York'
+    )
+    ON CONFLICT (strategy_link_id, snapshot_id) DO UPDATE SET
+      status = 'queued',
+      target_holdings = EXCLUDED.target_holdings,
+      preflight = '{}'::jsonb,
+      command_revision = trading_rebalance_plans.command_revision + 1,
+      not_before = EXCLUDED.not_before,
+      claimed_at = NULL,
+      completed_at = NULL,
+      error = '',
+      updated_at = now()
+    WHERE ${args.retryBlocked === true}
+      AND trading_rebalance_plans.status = 'blocked';
+  `;
+}
+
+export async function pauseTradingStrategy(args: {
+  userId: string;
+  connectionId: string;
+  cancelOpenOrders: boolean;
+}): Promise<void> {
+  const sql = requireSql();
+  const rows = (await sql`
+    UPDATE trading_connections
+       SET status = 'paused', updated_at = now()
+     WHERE id = ${args.connectionId}::uuid
+       AND user_id = ${args.userId}::uuid
+       AND status <> 'revoked'
+    RETURNING id::text AS id;
+  `) as Array<{ id: string }>;
+  if (!rows.length) throw new Error("Trading connection was not found.");
+  await sql`
+    UPDATE trading_strategy_links
+       SET status = 'paused', updated_at = now()
+     WHERE connection_id = ${args.connectionId}::uuid AND status <> 'revoked';
+  `;
+  if (args.cancelOpenOrders) {
+    await sql`
+      UPDATE trading_rebalance_plans p
+         SET status = 'cancel_requested', updated_at = now()
+        FROM trading_strategy_links l
+       WHERE p.strategy_link_id = l.id
+         AND l.connection_id = ${args.connectionId}::uuid
+         AND p.status IN ('queued', 'preflight', 'awaiting_market', 'selling', 'buying', 'partial');
+    `;
+  }
+  await appendTradingAudit({
+    userId: args.userId,
+    connectionId: args.connectionId,
+    actorType: "user",
+    action: args.cancelOpenOrders ? "kill_switch" : "strategy_paused",
+    payload: { cancel_open_orders: args.cancelOpenOrders },
+  });
+}
+
+export async function resumeTradingStrategy(args: {
+  userId: string;
+  connectionId: string;
+}): Promise<void> {
+  const sql = requireSql();
+  const rows = (await sql`
+    UPDATE trading_connections
+       SET status = CASE WHEN gateway_connected AND gateway_authenticated THEN 'ready' ELSE 'disconnected' END,
+           updated_at = now()
+     WHERE id = ${args.connectionId}::uuid
+       AND user_id = ${args.userId}::uuid
+       AND status = 'paused'
+    RETURNING id::text AS id;
+  `) as Array<{ id: string }>;
+  if (!rows.length) throw new Error("Paused trading connection was not found.");
+  await sql`
+    UPDATE trading_strategy_links l
+       SET status = CASE
+             WHEN EXISTS (
+               SELECT 1 FROM portfolio_snapshot_trade_eligibility e
+                WHERE e.snapshot_id = l.latest_snapshot_id AND e.eligible
+             ) THEN 'armed'
+             ELSE 'blocked'
+           END,
+           last_error = CASE
+             WHEN EXISTS (
+               SELECT 1 FROM portfolio_snapshot_trade_eligibility e
+                WHERE e.snapshot_id = l.latest_snapshot_id AND e.eligible
+             ) THEN ''
+             ELSE 'Latest snapshot is not trade-eligible.'
+           END,
+           updated_at = now()
+     WHERE l.connection_id = ${args.connectionId}::uuid AND l.status = 'paused';
+  `;
+  await appendTradingAudit({
+    userId: args.userId,
+    connectionId: args.connectionId,
+    actorType: "user",
+    action: "strategy_resumed",
+  });
+}
+
+export async function startPortfolioRefreshRun(args: {
+  workspace: Workspace;
+  track: PortfolioTrack;
+  methodologyVersion: string;
+}): Promise<string> {
+  const sql = requireSql();
+  const rows = (await sql`
+    INSERT INTO portfolio_refresh_runs (workspace, track, methodology_version)
+    VALUES (${args.workspace}, ${args.track}, ${args.methodologyVersion})
+    RETURNING id::text AS id;
+  `) as Array<{ id: string }>;
+  return rows[0].id;
+}
+
+export async function finishPortfolioRefreshRun(args: {
+  runId: string;
+  status: "completed" | "partial" | "failed";
+  warnings?: unknown[];
+  error?: string;
+}): Promise<void> {
+  const sql = requireSql();
+  await sql`
+    UPDATE portfolio_refresh_runs
+       SET status = ${args.status},
+           provider_warnings = ${JSON.stringify(args.warnings || [])}::jsonb,
+           error = ${args.error || ""},
+           finished_at = now()
+     WHERE id = ${args.runId}::uuid;
+  `;
+}
+
+export async function recordSnapshotTradeEligibility(args: {
+  snapshotIds: string[];
+  refreshRunId: string;
+  eligible: boolean;
+  reasons: string[];
+  allowUpgrade?: boolean;
+}): Promise<void> {
+  if (!args.snapshotIds.length) return;
+  const sql = requireSql();
+  for (const snapshotId of args.snapshotIds) {
+    await sql`
+      INSERT INTO portfolio_snapshot_trade_eligibility (
+        snapshot_id, refresh_run_id, eligible, reasons, checked_at
+      ) VALUES (
+        ${snapshotId}::uuid, ${args.refreshRunId}::uuid, ${args.eligible},
+        ${JSON.stringify(args.reasons)}::jsonb, now()
+      )
+      ON CONFLICT (snapshot_id) DO UPDATE SET
+        refresh_run_id = EXCLUDED.refresh_run_id,
+        eligible = EXCLUDED.eligible,
+        reasons = EXCLUDED.reasons,
+        checked_at = now()
+      WHERE ${args.allowUpgrade === true}
+        AND portfolio_snapshot_trade_eligibility.eligible = false
+        AND EXCLUDED.eligible = true;
+    `;
+  }
+}
+
+export async function enqueueArmedStrategiesForSnapshots(snapshotIds: string[]): Promise<number> {
+  if (!snapshotIds.length) return 0;
+  const sql = requireSql();
+  const rows = (await sql`
+    SELECT l.id::text AS link_id,
+           s.id::text AS snapshot_id,
+           COALESCE(
+             jsonb_agg(
+               jsonb_build_object(
+                 'rank', h.rank, 'ticker', h.ticker, 'score', h.score,
+                 'weight', h.weight, 'currency', h.currency
+               ) ORDER BY h.rank
+             ) FILTER (WHERE h.snapshot_id IS NOT NULL),
+             '[]'::jsonb
+           ) AS holdings
+      FROM trading_strategy_links l
+      JOIN portfolio_snapshots s
+        ON s.workspace = l.workspace
+       AND s.lens_type = l.lens_type
+       AND s.lens_key = l.lens_key
+       AND s.methodology_version = l.methodology_version
+      JOIN portfolio_snapshot_trade_eligibility e ON e.snapshot_id = s.id AND e.eligible
+      LEFT JOIN portfolio_holdings h ON h.snapshot_id = s.id
+     WHERE l.status = 'armed'
+       AND s.id = ANY(${snapshotIds}::uuid[])
+       AND s.track = 'paper'
+       AND s.status = 'ready'
+     GROUP BY l.id, s.id;
+  `) as Array<{ link_id: string; snapshot_id: string; holdings: unknown }>;
+  for (const row of rows) {
+    await insertRebalancePlan({
+      linkId: row.link_id,
+      snapshotId: row.snapshot_id,
+      holdings: asHoldings(row.holdings),
+      retryBlocked: false,
+    });
+    await sql`
+      UPDATE trading_strategy_links
+         SET latest_snapshot_id = ${row.snapshot_id}::uuid, updated_at = now()
+       WHERE id = ${row.link_id}::uuid;
+    `;
+  }
+  return rows.length;
+}
+
+export async function loadExecutorCommands(connectionId: string): Promise<Array<Record<string, unknown>>> {
+  const sql = requireSql();
+  const rows = (await sql`
+    SELECT p.id::text AS plan_id,
+           p.snapshot_id::text AS snapshot_id,
+           p.status,
+           p.command_revision,
+           p.target_holdings,
+           p.not_before::text AS not_before,
+           l.id::text AS strategy_link_id,
+           l.workspace,
+           l.lens_type,
+           l.lens_key,
+           l.budget_usd::float8 AS budget_usd,
+           l.reserve_fraction::float8 AS reserve_fraction,
+           c.mode,
+           c.account_masked,
+           COALESCE((
+             SELECT jsonb_agg(jsonb_build_object(
+               'client_order_key', o.client_order_key,
+               'symbol', o.symbol,
+               'side', o.side,
+               'status', o.status,
+               'requested_quantity', o.requested_quantity,
+               'filled_quantity', o.filled_quantity,
+               'ib_perm_id', o.ib_perm_id
+             ) ORDER BY o.created_at)
+               FROM trading_orders o
+              WHERE o.rebalance_plan_id = p.id
+           ), '[]'::jsonb) AS existing_orders,
+           COALESCE(
+             jsonb_agg(
+               jsonb_build_object(
+                 'symbol', pos.symbol,
+                 'conid', pos.conid,
+                 'quantity', pos.quantity,
+                 'average_cost_usd', pos.average_cost_usd
+               )
+             ) FILTER (WHERE pos.symbol IS NOT NULL),
+             '[]'::jsonb
+           ) AS owned_positions
+      FROM trading_rebalance_plans p
+      JOIN trading_strategy_links l ON l.id = p.strategy_link_id
+      JOIN trading_connections c ON c.id = l.connection_id
+      JOIN portfolio_snapshot_trade_eligibility e ON e.snapshot_id = p.snapshot_id
+      LEFT JOIN trading_strategy_positions pos ON pos.strategy_link_id = l.id
+     WHERE c.id = ${connectionId}::uuid
+       AND (
+         (c.status = 'ready' AND e.eligible AND p.status IN ('queued', 'preflight', 'awaiting_market', 'selling', 'buying', 'partial'))
+         OR p.status = 'cancel_requested'
+       )
+       AND (p.not_before IS NULL OR p.not_before <= now())
+     GROUP BY p.id, l.id, c.id
+     ORDER BY p.created_at
+     LIMIT 5;
+  `) as Array<Record<string, unknown>>;
+  const ids = rows.map((row) => String(row.plan_id));
+  if (ids.length) {
+    await sql`
+      UPDATE trading_rebalance_plans
+         SET claimed_at = COALESCE(claimed_at, now()), updated_at = now()
+       WHERE id = ANY(${ids}::uuid[]);
+    `;
+  }
+  return rows;
+}
+
+export async function updateRebalanceStatus(args: {
+  connectionId: string;
+  planId: string;
+  status: RebalanceStatus;
+  error?: string;
+  preflight?: Record<string, unknown>;
+}): Promise<boolean> {
+  const sql = requireSql();
+  const rows = (await sql`
+    UPDATE trading_rebalance_plans p
+       SET status = ${args.status},
+           command_revision = CASE
+             WHEN ${args.status} = 'partial' AND p.status <> 'partial' THEN command_revision + 1
+             ELSE command_revision
+           END,
+           not_before = CASE
+             WHEN ${args.status} = 'partial' AND p.status <> 'partial'
+               THEN ((timezone('America/New_York', now())::date + 1) + time '10:00') AT TIME ZONE 'America/New_York'
+             ELSE not_before
+           END,
+           error = ${args.error || ""},
+           preflight = ${JSON.stringify(args.preflight || {})}::jsonb,
+           completed_at = CASE WHEN ${args.status} IN ('completed', 'cancelled') THEN now() ELSE completed_at END,
+           updated_at = now()
+      FROM trading_strategy_links l
+     WHERE p.id = ${args.planId}::uuid
+       AND p.strategy_link_id = l.id
+       AND l.connection_id = ${args.connectionId}::uuid
+       AND (
+         p.status = ${args.status}
+         OR (p.status = 'queued' AND ${args.status} IN ('preflight', 'awaiting_market', 'blocked'))
+         OR (p.status = 'awaiting_market' AND ${args.status} IN ('preflight', 'blocked'))
+         OR (p.status = 'preflight' AND ${args.status} IN ('selling', 'buying', 'completed', 'partial', 'blocked'))
+         OR (p.status = 'selling' AND ${args.status} IN ('buying', 'completed', 'partial', 'blocked'))
+         OR (p.status = 'buying' AND ${args.status} IN ('completed', 'partial', 'blocked'))
+         OR (p.status = 'partial' AND ${args.status} IN ('preflight', 'selling', 'buying', 'completed', 'blocked'))
+         OR (p.status = 'cancel_requested' AND ${args.status} = 'cancelled')
+       )
+    RETURNING p.id::text AS id;
+  `) as Array<{ id: string }>;
+  const updated = rows.length === 1;
+  if (updated) {
+    await appendTradingAudit({
+      connectionId: args.connectionId,
+      actorType: "executor",
+      action: "rebalance_status_reported",
+      payload: { plan_id: args.planId, status: args.status, error: args.error || "" },
+    });
+  }
+  return updated;
+}
+
+export async function upsertTradingInstrument(args: {
+  symbol: string;
+  conid: number;
+  secType: string;
+  exchange: string;
+  primaryExchange: string;
+  currency: string;
+  minTick?: number | null;
+  minSize?: number | null;
+  sizeIncrement?: number | null;
+  supportsFractional: boolean;
+  liquidHours?: string;
+  timeZone?: string;
+  approved: boolean;
+}): Promise<void> {
+  const sql = requireSql();
+  await sql`
+    INSERT INTO trading_instruments (
+      symbol, conid, sec_type, exchange, primary_exchange, currency,
+      min_tick, min_size, size_increment, supports_fractional,
+      liquid_hours, time_zone, approved, approved_at
+    ) VALUES (
+      ${args.symbol.toUpperCase()}, ${args.conid}, ${args.secType}, ${args.exchange},
+      ${args.primaryExchange}, ${args.currency.toUpperCase()}, ${args.minTick ?? null},
+      ${args.minSize ?? null}, ${args.sizeIncrement ?? null}, ${args.supportsFractional},
+      ${args.liquidHours || ""}, ${args.timeZone || ""}, ${args.approved},
+      CASE WHEN ${args.approved} THEN now() ELSE NULL END
+    )
+    ON CONFLICT (symbol) DO UPDATE SET
+      conid = EXCLUDED.conid,
+      sec_type = EXCLUDED.sec_type,
+      exchange = EXCLUDED.exchange,
+      primary_exchange = EXCLUDED.primary_exchange,
+      currency = EXCLUDED.currency,
+      min_tick = EXCLUDED.min_tick,
+      min_size = EXCLUDED.min_size,
+      size_increment = EXCLUDED.size_increment,
+      supports_fractional = EXCLUDED.supports_fractional,
+      liquid_hours = EXCLUDED.liquid_hours,
+      time_zone = EXCLUDED.time_zone,
+      approved = EXCLUDED.approved,
+      approved_at = CASE WHEN EXCLUDED.approved THEN COALESCE(trading_instruments.approved_at, now()) ELSE NULL END,
+      updated_at = now();
+  `;
+}
+
+export async function upsertTradingOrder(args: {
+  connectionId: string;
+  planId: string;
+  clientOrderKey: string;
+  symbol: string;
+  conid?: number | null;
+  side: "BUY" | "SELL";
+  requestedQuantity: number;
+  limitPrice?: number | null;
+  ibOrderId?: number | null;
+  ibPermId?: number | null;
+  status: string;
+  filledQuantity?: number;
+  averageFillPrice?: number | null;
+  commission?: number;
+  commissionCurrency?: string;
+  rawStatus?: Record<string, unknown>;
+}): Promise<string | null> {
+  const sql = requireSql();
+  const rows = (await sql`
+    INSERT INTO trading_orders (
+      rebalance_plan_id, client_order_key, symbol, conid, side,
+      requested_quantity, limit_price, ib_order_id, ib_perm_id,
+      status, filled_quantity, average_fill_price, commission,
+      commission_currency, raw_status, submitted_at, completed_at
+    )
+    SELECT ${args.planId}::uuid, ${args.clientOrderKey}, ${args.symbol.toUpperCase()},
+           ${args.conid ?? null}, ${args.side}, ${args.requestedQuantity},
+           ${args.limitPrice ?? null}, ${args.ibOrderId ?? null}, ${args.ibPermId ?? null},
+           ${args.status}, ${args.filledQuantity || 0}, ${args.averageFillPrice ?? null},
+           ${args.commission || 0}, ${args.commissionCurrency || "USD"},
+           ${JSON.stringify(args.rawStatus || {})}::jsonb,
+           CASE WHEN ${args.status} IN ('submitted', 'partially_filled', 'filled') THEN now() ELSE NULL END,
+           CASE WHEN ${args.status} IN ('filled', 'cancelled', 'rejected', 'error') THEN now() ELSE NULL END
+      FROM trading_rebalance_plans p
+      JOIN trading_strategy_links l ON l.id = p.strategy_link_id
+     WHERE p.id = ${args.planId}::uuid AND l.connection_id = ${args.connectionId}::uuid
+    ON CONFLICT (client_order_key) DO UPDATE SET
+      conid = COALESCE(EXCLUDED.conid, trading_orders.conid),
+      limit_price = COALESCE(EXCLUDED.limit_price, trading_orders.limit_price),
+      ib_order_id = COALESCE(EXCLUDED.ib_order_id, trading_orders.ib_order_id),
+      ib_perm_id = COALESCE(EXCLUDED.ib_perm_id, trading_orders.ib_perm_id),
+      status = EXCLUDED.status,
+      filled_quantity = EXCLUDED.filled_quantity,
+      average_fill_price = COALESCE(EXCLUDED.average_fill_price, trading_orders.average_fill_price),
+      commission = EXCLUDED.commission,
+      commission_currency = EXCLUDED.commission_currency,
+      raw_status = EXCLUDED.raw_status,
+      updated_at = now(),
+      completed_at = CASE WHEN EXCLUDED.status IN ('filled', 'cancelled', 'rejected', 'error') THEN now() ELSE trading_orders.completed_at END
+    RETURNING id::text AS id;
+  `) as Array<{ id: string }>;
+  const orderId = rows[0]?.id || null;
+  if (orderId) {
+    await appendTradingAudit({
+      connectionId: args.connectionId,
+      actorType: "executor",
+      action: "order_reported",
+      payload: {
+        order_id: orderId,
+        plan_id: args.planId,
+        client_order_key: args.clientOrderKey,
+        symbol: args.symbol,
+        side: args.side,
+        status: args.status,
+      },
+    });
+  }
+  return orderId;
+}
+
+export async function insertTradingFill(args: {
+  connectionId: string;
+  orderId?: string | null;
+  execId: string;
+  symbol: string;
+  side: "BUY" | "SELL";
+  quantity: number;
+  price: number;
+  commission?: number;
+  commissionCurrency?: string;
+  executedAt: string;
+  rawExecution?: Record<string, unknown>;
+}): Promise<boolean> {
+  const sql = requireSql();
+  const rows = (await sql`
+    INSERT INTO trading_fills (
+      order_id, connection_id, exec_id, symbol, side, quantity, price,
+      commission, commission_currency, executed_at, raw_execution
+    ) VALUES (
+      ${args.orderId || null}::uuid, ${args.connectionId}::uuid, ${args.execId},
+      ${args.symbol.toUpperCase()}, ${args.side}, ${args.quantity}, ${args.price},
+      ${args.commission || 0}, ${args.commissionCurrency || "USD"},
+      ${args.executedAt}::timestamptz, ${JSON.stringify(args.rawExecution || {})}::jsonb
+    )
+    ON CONFLICT (exec_id) DO NOTHING
+    RETURNING id::text AS id;
+  `) as Array<{ id: string }>;
+  const inserted = rows.length === 1;
+  if (inserted) {
+    await appendTradingAudit({
+      connectionId: args.connectionId,
+      actorType: "executor",
+      action: "fill_reported",
+      payload: {
+        order_id: args.orderId || null,
+        exec_id: args.execId,
+        symbol: args.symbol,
+        side: args.side,
+        quantity: args.quantity,
+        price: args.price,
+      },
+    });
+  }
+  return inserted;
+}
+
+export async function replaceTradingStrategyPositions(args: {
+  connectionId: string;
+  strategyLinkId: string;
+  positions: Array<{
+    symbol: string;
+    conid?: number | null;
+    quantity: number;
+    averageCostUsd?: number | null;
+  }>;
+}): Promise<boolean> {
+  const sql = requireSql();
+  const ownedRows = (await sql`
+    SELECT l.id::text AS id
+      FROM trading_strategy_links l
+     WHERE l.id = ${args.strategyLinkId}::uuid
+       AND l.connection_id = ${args.connectionId}::uuid
+     LIMIT 1;
+  `) as Array<{ id: string }>;
+  if (!ownedRows.length) return false;
+  const positions = args.positions.filter((position) => (
+    position.symbol && Number.isFinite(position.quantity) && position.quantity >= 0
+  ));
+  await sql.transaction((tx) => [
+    tx`DELETE FROM trading_strategy_positions WHERE strategy_link_id = ${args.strategyLinkId}::uuid;`,
+    ...positions.map((position) => tx`
+      INSERT INTO trading_strategy_positions (
+        strategy_link_id, symbol, conid, quantity, average_cost_usd
+      ) VALUES (
+        ${args.strategyLinkId}::uuid, ${position.symbol.toUpperCase()},
+        ${position.conid ?? null}, ${position.quantity}, ${position.averageCostUsd ?? null}
+      );
+    `),
+  ]);
+  return true;
+}
+
+export async function recordTradingEvent(args: {
+  connectionId: string;
+  eventId: string;
+  eventType: string;
+  severity: "info" | "warning" | "critical";
+  message: string;
+  payload?: Record<string, unknown>;
+}): Promise<boolean> {
+  const sql = requireSql();
+  const rows = (await sql`
+    INSERT INTO trading_events (
+      connection_id, event_id, event_type, severity, message, payload
+    ) VALUES (
+      ${args.connectionId}::uuid, ${args.eventId}, ${args.eventType}, ${args.severity},
+      ${args.message}, ${JSON.stringify(args.payload || {})}::jsonb
+    )
+    ON CONFLICT (connection_id, event_id) DO NOTHING
+    RETURNING id::text AS id;
+  `) as Array<{ id: string }>;
+  return rows.length === 1;
+}
+
+export async function markTradingEventTelegramSent(connectionId: string, eventId: string): Promise<void> {
+  const sql = requireSql();
+  await sql`
+    UPDATE trading_events
+       SET telegram_sent_at = now()
+     WHERE connection_id = ${connectionId}::uuid AND event_id = ${eventId};
+  `;
+}
+
+export async function listStaleTradingConnections(staleMinutes = 10): Promise<Array<{
+  id: string;
+  accountMasked: string;
+  mode: BrokerMode;
+  lastHeartbeatAt: string | null;
+}>> {
+  const sql = requireSql();
+  const interval = `${Math.max(1, Math.min(1440, Math.floor(staleMinutes)))} minutes`;
+  const rows = (await sql`
+    SELECT id::text AS id, account_masked, mode, last_heartbeat_at::text AS last_heartbeat_at
+      FROM trading_connections
+     WHERE status NOT IN ('awaiting_pairing', 'paused', 'revoked')
+       AND (last_heartbeat_at IS NULL OR last_heartbeat_at < now() - ${interval}::interval);
+  `) as Array<{ id: string; account_masked: string; mode: BrokerMode; last_heartbeat_at: string | null }>;
+  return rows.map((row) => ({
+    id: row.id,
+    accountMasked: row.account_masked,
+    mode: row.mode,
+    lastHeartbeatAt: row.last_heartbeat_at,
+  }));
+}
+
+export async function listPendingTradingAlerts(limit = 50): Promise<Array<{
+  connectionId: string;
+  eventId: string;
+  severity: "warning" | "critical";
+  message: string;
+}>> {
+  const sql = requireSql();
+  const rows = (await sql`
+    SELECT connection_id::text AS connection_id, event_id, severity, message
+      FROM trading_events
+     WHERE severity IN ('warning', 'critical')
+       AND telegram_sent_at IS NULL
+     ORDER BY created_at
+     LIMIT ${Math.max(1, Math.min(200, Math.floor(limit)))};
+  `) as Array<{
+    connection_id: string;
+    event_id: string;
+    severity: "warning" | "critical";
+    message: string;
+  }>;
+  return rows.map((row) => ({
+    connectionId: row.connection_id,
+    eventId: row.event_id,
+    severity: row.severity,
+    message: row.message,
+  }));
+}
+
+export async function appendTradingAudit(args: {
+  userId?: string | null;
+  connectionId?: string | null;
+  actorType: "user" | "executor" | "monitor" | "system";
+  action: string;
+  payload?: Record<string, unknown>;
+}): Promise<void> {
+  const sql = requireSql();
+  await sql`
+    INSERT INTO trading_audit_log (user_id, connection_id, actor_type, action, payload)
+    VALUES (
+      ${args.userId || null}::uuid,
+      ${args.connectionId || null}::uuid,
+      ${args.actorType},
+      ${args.action},
+      ${JSON.stringify(args.payload || {})}::jsonb
+    );
+  `;
+}

--- a/frontend/src/lib/trading-db.ts
+++ b/frontend/src/lib/trading-db.ts
@@ -184,6 +184,7 @@ export async function updateTradingHeartbeat(args: {
   gatewayConnected: boolean;
   gatewayAuthenticated: boolean;
   executorVersion: string;
+  accountType?: string;
   error?: string;
 }): Promise<void> {
   const sql = requireSql();
@@ -193,6 +194,7 @@ export async function updateTradingHeartbeat(args: {
        SET gateway_connected = ${args.gatewayConnected},
            gateway_authenticated = ${args.gatewayAuthenticated},
            executor_version = ${args.executorVersion},
+           account_type = ${String(args.accountType || "UNKNOWN").slice(0, 100)},
            status = CASE WHEN status = 'paused' THEN 'paused' ELSE ${status} END,
            last_heartbeat_at = now(),
            last_error = ${args.error || ""},
@@ -302,7 +304,7 @@ export async function loadTradingDashboard(args: {
   const [connectionRows, strategyRows, planRows, eventRows, positionRows, orderRows, fillRows, portfolios] = await Promise.all([
     sql`
       SELECT id::text AS id, mode, account_masked, status, gateway_connected,
-             gateway_authenticated, executor_version,
+             gateway_authenticated, executor_version, account_type,
              last_heartbeat_at::text AS last_heartbeat_at, last_error,
              paired_at::text AS paired_at
         FROM trading_connections
@@ -324,7 +326,7 @@ export async function loadTradingDashboard(args: {
     `,
     sql`
       SELECT p.id::text AS id, p.strategy_link_id::text AS strategy_link_id,
-             p.snapshot_id::text AS snapshot_id, p.status, p.target_holdings,
+             p.snapshot_id::text AS snapshot_id, p.status, p.target_holdings, p.preflight,
              p.not_before::text AS not_before, p.error,
              p.created_at::text AS created_at, p.updated_at::text AS updated_at
         FROM trading_rebalance_plans p
@@ -387,6 +389,7 @@ export async function loadTradingDashboard(args: {
     status: row.status as TradingConnectionView["status"],
     gateway_connected: Boolean(row.gateway_connected),
     gateway_authenticated: Boolean(row.gateway_authenticated),
+    account_type: String(row.account_type || "UNKNOWN"),
     executor_version: String(row.executor_version || ""),
     last_heartbeat_at: row.last_heartbeat_at ? new Date(String(row.last_heartbeat_at)).toISOString() : null,
     last_error: String(row.last_error || ""),
@@ -413,6 +416,7 @@ export async function loadTradingDashboard(args: {
     snapshot_id: String(row.snapshot_id),
     status: row.status as RebalanceStatus,
     target_holdings: asHoldings(row.target_holdings),
+    preflight: (row.preflight || {}) as Record<string, unknown>,
     not_before: row.not_before ? new Date(String(row.not_before)).toISOString() : null,
     error: String(row.error || ""),
     created_at: new Date(String(row.created_at)).toISOString(),
@@ -544,7 +548,7 @@ export async function configureTradingStrategy(args: {
        SET status = 'cancel_requested', updated_at = now()
      WHERE strategy_link_id = ${linkId}::uuid
        AND snapshot_id <> ${selected.latest_snapshot_id}::uuid
-       AND status IN ('queued', 'preflight', 'awaiting_market', 'partial');
+       AND status IN ('queued', 'preflight', 'awaiting_market', 'awaiting_settlement', 'partial');
   `;
   if (status === "armed") {
     await insertRebalancePlan({
@@ -764,7 +768,7 @@ export async function pauseTradingStrategy(args: {
         FROM trading_strategy_links l
        WHERE p.strategy_link_id = l.id
          AND l.connection_id = ${args.connectionId}::uuid
-         AND p.status IN ('queued', 'preflight', 'awaiting_market', 'selling', 'buying', 'partial');
+         AND p.status IN ('queued', 'preflight', 'awaiting_market', 'awaiting_settlement', 'selling', 'buying', 'partial');
     `;
   }
   await appendTradingAudit({
@@ -971,7 +975,7 @@ export async function loadExecutorCommands(connectionId: string): Promise<Array<
       LEFT JOIN trading_strategy_positions pos ON pos.strategy_link_id = l.id
      WHERE c.id = ${connectionId}::uuid
        AND (
-         (c.status = 'ready' AND e.eligible AND p.status IN ('queued', 'preflight', 'awaiting_market', 'selling', 'buying', 'partial'))
+          (c.status = 'ready' AND e.eligible AND p.status IN ('queued', 'preflight', 'awaiting_market', 'awaiting_settlement', 'selling', 'buying', 'partial'))
          OR p.status = 'cancel_requested'
        )
        AND (p.not_before IS NULL OR p.not_before <= now())
@@ -1006,12 +1010,23 @@ export async function updateRebalanceStatus(args: {
              ELSE command_revision
            END,
            not_before = CASE
-             WHEN ${args.status} = 'partial' AND p.status <> 'partial'
-               THEN ((timezone('America/New_York', now())::date + 1) + time '10:00') AT TIME ZONE 'America/New_York'
+             WHEN ${args.status} IN ('partial', 'awaiting_settlement') AND p.status <> ${args.status}
+               THEN (
+                 timezone('America/New_York', now())::date
+                 + CASE extract(isodow FROM timezone('America/New_York', now()))::int
+                     WHEN 5 THEN 3
+                     WHEN 6 THEN 2
+                     ELSE 1
+                   END
+                 + time '10:00'
+               ) AT TIME ZONE 'America/New_York'
              ELSE not_before
            END,
            error = ${args.error || ""},
-           preflight = ${JSON.stringify(args.preflight || {})}::jsonb,
+           preflight = CASE
+             WHEN ${JSON.stringify(args.preflight || {})}::jsonb = '{}'::jsonb THEN p.preflight
+             ELSE ${JSON.stringify(args.preflight || {})}::jsonb
+           END,
            completed_at = CASE WHEN ${args.status} IN ('completed', 'cancelled') THEN now() ELSE completed_at END,
            updated_at = now()
       FROM trading_strategy_links l
@@ -1022,9 +1037,10 @@ export async function updateRebalanceStatus(args: {
          p.status = ${args.status}
          OR (p.status = 'queued' AND ${args.status} IN ('preflight', 'awaiting_market', 'blocked'))
          OR (p.status = 'awaiting_market' AND ${args.status} IN ('preflight', 'blocked'))
-         OR (p.status = 'preflight' AND ${args.status} IN ('selling', 'buying', 'completed', 'partial', 'blocked'))
-         OR (p.status = 'selling' AND ${args.status} IN ('buying', 'completed', 'partial', 'blocked'))
-         OR (p.status = 'buying' AND ${args.status} IN ('completed', 'partial', 'blocked'))
+         OR (p.status = 'awaiting_settlement' AND ${args.status} IN ('awaiting_settlement', 'preflight', 'buying', 'blocked'))
+         OR (p.status = 'preflight' AND ${args.status} IN ('awaiting_settlement', 'selling', 'buying', 'completed', 'partial', 'blocked'))
+         OR (p.status = 'selling' AND ${args.status} IN ('preflight', 'awaiting_settlement', 'buying', 'completed', 'partial', 'blocked'))
+         OR (p.status = 'buying' AND ${args.status} IN ('preflight', 'completed', 'partial', 'blocked'))
          OR (p.status = 'partial' AND ${args.status} IN ('preflight', 'selling', 'buying', 'completed', 'blocked'))
          OR (p.status = 'cancel_requested' AND ${args.status} = 'cancelled')
        )
@@ -1138,6 +1154,7 @@ export async function upsertTradingOrder(args: {
       raw_status = EXCLUDED.raw_status,
       updated_at = now(),
       completed_at = CASE WHEN EXCLUDED.status IN ('filled', 'cancelled', 'rejected', 'error') THEN now() ELSE trading_orders.completed_at END
+    WHERE trading_orders.rebalance_plan_id = EXCLUDED.rebalance_plan_id
     RETURNING id::text AS id;
   `) as Array<{ id: string }>;
   const orderId = rows[0]?.id || null;
@@ -1177,16 +1194,59 @@ export async function insertTradingFill(args: {
     INSERT INTO trading_fills (
       order_id, connection_id, exec_id, symbol, side, quantity, price,
       commission, commission_currency, executed_at, raw_execution
-    ) VALUES (
-      ${args.orderId || null}::uuid, ${args.connectionId}::uuid, ${args.execId},
-      ${args.symbol.toUpperCase()}, ${args.side}, ${args.quantity}, ${args.price},
-      ${args.commission || 0}, ${args.commissionCurrency || "USD"},
-      ${args.executedAt}::timestamptz, ${JSON.stringify(args.rawExecution || {})}::jsonb
     )
-    ON CONFLICT (exec_id) DO NOTHING
-    RETURNING id::text AS id;
-  `) as Array<{ id: string }>;
-  const inserted = rows.length === 1;
+    SELECT ${args.orderId || null}::uuid, ${args.connectionId}::uuid, ${args.execId},
+           ${args.symbol.toUpperCase()}, ${args.side}, ${args.quantity}, ${args.price},
+           ${args.commission || 0}, ${args.commissionCurrency || "USD"},
+           ${args.executedAt}::timestamptz, ${JSON.stringify(args.rawExecution || {})}::jsonb
+     WHERE ${args.orderId || null}::uuid IS NULL
+        OR EXISTS (
+          SELECT 1
+            FROM trading_orders owned_order
+            JOIN trading_rebalance_plans owned_plan ON owned_plan.id = owned_order.rebalance_plan_id
+            JOIN trading_strategy_links owned_link ON owned_link.id = owned_plan.strategy_link_id
+           WHERE owned_order.id = ${args.orderId || null}::uuid
+             AND owned_link.connection_id = ${args.connectionId}::uuid
+        )
+    ON CONFLICT (exec_id) DO UPDATE SET
+      order_id = COALESCE(EXCLUDED.order_id, trading_fills.order_id),
+      commission = EXCLUDED.commission,
+      commission_currency = EXCLUDED.commission_currency,
+      raw_execution = trading_fills.raw_execution || EXCLUDED.raw_execution,
+      updated_at = now()
+    WHERE trading_fills.connection_id = EXCLUDED.connection_id
+    RETURNING id::text AS id, (xmax = 0) AS inserted;
+  `) as Array<{ id: string; inserted: boolean }>;
+  const accepted = rows.length === 1;
+  const inserted = rows[0]?.inserted === true;
+  if (accepted && args.orderId) {
+    const linkRows = (await sql`
+      SELECT l.id::text AS id
+        FROM trading_orders o
+        JOIN trading_rebalance_plans p ON p.id = o.rebalance_plan_id
+        JOIN trading_strategy_links l ON l.id = p.strategy_link_id
+       WHERE o.id = ${args.orderId}::uuid
+         AND l.connection_id = ${args.connectionId}::uuid
+       LIMIT 1;
+    `) as Array<{ id: string }>;
+    const linkId = linkRows[0]?.id;
+    if (linkId) {
+      await sql.transaction((tx) => [
+        tx`DELETE FROM trading_strategy_positions WHERE strategy_link_id = ${linkId}::uuid;`,
+        tx`
+          INSERT INTO trading_strategy_positions (strategy_link_id, symbol, quantity)
+          SELECT ${linkId}::uuid, f.symbol,
+                 SUM(CASE WHEN f.side = 'BUY' THEN f.quantity ELSE -f.quantity END) AS quantity
+            FROM trading_fills f
+            JOIN trading_orders o ON o.id = f.order_id
+            JOIN trading_rebalance_plans p ON p.id = o.rebalance_plan_id
+           WHERE p.strategy_link_id = ${linkId}::uuid
+           GROUP BY f.symbol
+          HAVING SUM(CASE WHEN f.side = 'BUY' THEN f.quantity ELSE -f.quantity END) > 0;
+        `,
+      ]);
+    }
+  }
   if (inserted) {
     await appendTradingAudit({
       connectionId: args.connectionId,
@@ -1202,7 +1262,7 @@ export async function insertTradingFill(args: {
       },
     });
   }
-  return inserted;
+  return accepted;
 }
 
 export async function replaceTradingStrategyPositions(args: {

--- a/frontend/src/lib/trading-db.ts
+++ b/frontend/src/lib/trading-db.ts
@@ -46,6 +46,12 @@ function asHoldings(value: unknown): TradingHolding[] {
   }).filter((item) => item.ticker && Number.isFinite(item.rank));
 }
 
+export function tradingExecutionIdentity(execId: string): { familyId: string; revision: number } {
+  const match = execId.match(/^(.*)\.([0-9]+)$/);
+  if (!match) return { familyId: execId, revision: 0 };
+  return { familyId: match[1], revision: Number.parseInt(match[2], 10) };
+}
+
 export async function createTradingPairing(args: {
   userId: string;
   mode: BrokerMode;
@@ -61,6 +67,8 @@ export async function createTradingPairing(args: {
                status = 'awaiting_pairing',
                gateway_connected = false,
                gateway_authenticated = false,
+               executor_lease_owner = NULL,
+               executor_lease_expires_at = NULL,
                last_error = '',
                updated_at = now()
          WHERE id = ${args.connectionId}::uuid
@@ -125,6 +133,8 @@ export async function consumeTradingPairing(args: {
            device_secret_hash = ${args.deviceSecretHash},
            executor_version = ${args.executorVersion},
            status = 'disconnected',
+           executor_lease_owner = NULL,
+           executor_lease_expires_at = NULL,
            paired_at = now(),
            updated_at = now()
      WHERE id = ${connectionId}::uuid;
@@ -181,27 +191,42 @@ export async function registerExecutorNonce(connectionId: string, nonce: string)
 
 export async function updateTradingHeartbeat(args: {
   connectionId: string;
+  executorInstanceId: string;
   gatewayConnected: boolean;
   gatewayAuthenticated: boolean;
   executorVersion: string;
   accountType?: string;
   error?: string;
-}): Promise<void> {
+  leaseOnly?: boolean;
+}): Promise<boolean> {
   const sql = requireSql();
   const status = args.gatewayConnected && args.gatewayAuthenticated ? "ready" : args.error ? "error" : "disconnected";
-  await sql`
+  const rows = (await sql`
     UPDATE trading_connections
-       SET gateway_connected = ${args.gatewayConnected},
-           gateway_authenticated = ${args.gatewayAuthenticated},
+       SET gateway_connected = CASE WHEN ${args.leaseOnly === true} THEN gateway_connected ELSE ${args.gatewayConnected} END,
+           gateway_authenticated = CASE WHEN ${args.leaseOnly === true} THEN gateway_authenticated ELSE ${args.gatewayAuthenticated} END,
            executor_version = ${args.executorVersion},
-           account_type = ${String(args.accountType || "UNKNOWN").slice(0, 100)},
-           status = CASE WHEN status = 'paused' THEN 'paused' ELSE ${status} END,
+           account_type = CASE WHEN ${args.leaseOnly === true} THEN account_type ELSE ${String(args.accountType || "UNKNOWN").slice(0, 100)} END,
+           status = CASE
+             WHEN status = 'paused' OR ${args.leaseOnly === true} THEN status
+             ELSE ${status}
+           END,
            last_heartbeat_at = now(),
-           last_error = ${args.error || ""},
+           last_error = CASE WHEN ${args.leaseOnly === true} THEN last_error ELSE ${args.error || ""} END,
+           executor_lease_owner = ${args.executorInstanceId},
+           executor_lease_expires_at = now() + interval '6 hours',
            updated_at = now()
-     WHERE id = ${args.connectionId}::uuid
-       AND status <> 'revoked';
-  `;
+      WHERE id = ${args.connectionId}::uuid
+        AND status <> 'revoked'
+        AND (
+          executor_lease_owner IS NULL
+          OR executor_lease_owner = ${args.executorInstanceId}
+          OR executor_lease_expires_at IS NULL
+          OR executor_lease_expires_at <= now()
+        )
+    RETURNING id::text AS id;
+  `) as Array<{ id: string }>;
+  return rows.length === 1;
 }
 
 export async function listTradingPortfolios(workspace: Workspace): Promise<TradingPortfolioOption[]> {
@@ -315,6 +340,23 @@ export async function loadTradingDashboard(args: {
       SELECT l.id::text AS id, l.connection_id::text AS connection_id, l.workspace,
              l.lens_type, l.lens_key, l.methodology_version,
              l.budget_usd::float8 AS budget_usd,
+             (
+               l.cash_seed_usd + COALESCE((
+                 SELECT SUM(
+                   CASE WHEN effective.side = 'SELL' THEN effective.quantity * effective.price
+                        ELSE -(effective.quantity * effective.price) END
+                   - effective.commission
+                 )
+                   FROM (
+                     SELECT DISTINCT ON (f.connection_id, f.exec_family_id) f.*
+                       FROM trading_fills f
+                      ORDER BY f.connection_id, f.exec_family_id, f.exec_revision DESC, f.updated_at DESC
+                   ) effective
+                   JOIN trading_orders owned_order ON owned_order.id = effective.order_id
+                   JOIN trading_rebalance_plans owned_plan ON owned_plan.id = owned_order.rebalance_plan_id
+                  WHERE owned_plan.strategy_link_id = l.id
+               ), 0)
+             )::float8 AS cash_balance_usd,
              l.reserve_fraction::float8 AS reserve_fraction,
              l.status, l.latest_snapshot_id::text AS latest_snapshot_id,
              l.last_error, l.armed_at::text AS armed_at
@@ -370,10 +412,16 @@ export async function loadTradingDashboard(args: {
        LIMIT 50;
     `,
     sql`
-      SELECT f.exec_id, f.symbol, f.side, f.quantity::float8 AS quantity,
-             f.price::float8 AS price, f.commission::float8 AS commission,
-             f.commission_currency, f.executed_at::text AS executed_at
-        FROM trading_fills f
+      SELECT f.exec_id, f.exec_revision AS correction_revision, f.symbol, f.side,
+             f.quantity::float8 AS quantity, f.price::float8 AS price,
+             f.commission::float8 AS commission, f.commission_currency,
+             f.executed_at::text AS executed_at
+        FROM (
+          SELECT DISTINCT ON (source.connection_id, source.exec_family_id) source.*
+            FROM trading_fills source
+           ORDER BY source.connection_id, source.exec_family_id,
+                    source.exec_revision DESC, source.updated_at DESC
+        ) f
         JOIN trading_connections c ON c.id = f.connection_id
        WHERE c.user_id = ${args.userId}::uuid
        ORDER BY f.executed_at DESC
@@ -404,6 +452,7 @@ export async function loadTradingDashboard(args: {
     lens_key: String(strategyRow.lens_key),
     methodology_version: String(strategyRow.methodology_version),
     budget_usd: Number(strategyRow.budget_usd),
+    cash_balance_usd: Number(strategyRow.cash_balance_usd),
     reserve_fraction: Number(strategyRow.reserve_fraction),
     status: strategyRow.status as TradingStrategyView["status"],
     latest_snapshot_id: strategyRow.latest_snapshot_id ? String(strategyRow.latest_snapshot_id) : null,
@@ -450,6 +499,7 @@ export async function loadTradingDashboard(args: {
   }));
   const fills = (fillRows as Array<Record<string, unknown>>).map((row): TradingFillView => ({
     exec_id: String(row.exec_id),
+    correction_revision: Number(row.correction_revision || 0),
     symbol: String(row.symbol),
     side: row.side as "BUY" | "SELL",
     quantity: Number(row.quantity),
@@ -522,10 +572,10 @@ export async function configureTradingStrategy(args: {
   const rows = (await sql`
     INSERT INTO trading_strategy_links (
       connection_id, workspace, lens_type, lens_key, methodology_version,
-      budget_usd, status, latest_snapshot_id, last_error, armed_at
+      budget_usd, cash_seed_usd, status, latest_snapshot_id, last_error, armed_at
     ) VALUES (
       ${args.connectionId}::uuid, ${args.workspace}, ${args.lensType}, ${args.lensKey},
-      ${args.methodologyVersion}, ${args.budgetUsd}, ${status}, ${selected.latest_snapshot_id}::uuid,
+      ${args.methodologyVersion}, ${args.budgetUsd}, ${args.budgetUsd}, ${status}, ${selected.latest_snapshot_id}::uuid,
       ${status === "blocked" ? reason : ""},
       CASE WHEN ${status} = 'armed' THEN now() ELSE NULL END
     )
@@ -534,6 +584,8 @@ export async function configureTradingStrategy(args: {
       lens_type = EXCLUDED.lens_type,
       lens_key = EXCLUDED.lens_key,
       methodology_version = EXCLUDED.methodology_version,
+      cash_seed_usd = trading_strategy_links.cash_seed_usd
+        + (EXCLUDED.budget_usd - trading_strategy_links.budget_usd),
       budget_usd = EXCLUDED.budget_usd,
       status = EXCLUDED.status,
       latest_snapshot_id = EXCLUDED.latest_snapshot_id,
@@ -720,12 +772,16 @@ async function insertRebalancePlan(args: {
   const sql = requireSql();
   await sql`
     INSERT INTO trading_rebalance_plans (strategy_link_id, snapshot_id, target_holdings, not_before)
-    VALUES (
+    SELECT
       ${args.linkId}::uuid,
       ${args.snapshotId}::uuid,
       ${JSON.stringify(args.holdings)}::jsonb,
-      ((timezone('America/New_York', now())::date + 1) + time '10:00') AT TIME ZONE 'America/New_York'
-    )
+      GREATEST(
+        (s.execution_date + time '10:00') AT TIME ZONE 'America/New_York',
+        ((timezone('America/New_York', now())::date + 1) + time '10:00') AT TIME ZONE 'America/New_York'
+      )
+      FROM portfolio_snapshots s
+     WHERE s.id = ${args.snapshotId}::uuid
     ON CONFLICT (strategy_link_id, snapshot_id) DO UPDATE SET
       status = 'queued',
       target_holdings = EXCLUDED.target_holdings,
@@ -927,7 +983,10 @@ export async function enqueueArmedStrategiesForSnapshots(snapshotIds: string[]):
   return rows.length;
 }
 
-export async function loadExecutorCommands(connectionId: string): Promise<Array<Record<string, unknown>>> {
+export async function loadExecutorCommands(
+  connectionId: string,
+  executorInstanceId: string,
+): Promise<Array<Record<string, unknown>>> {
   const sql = requireSql();
   const rows = (await sql`
     SELECT p.id::text AS plan_id,
@@ -941,6 +1000,23 @@ export async function loadExecutorCommands(connectionId: string): Promise<Array<
            l.lens_type,
            l.lens_key,
            l.budget_usd::float8 AS budget_usd,
+           (
+              l.cash_seed_usd + COALESCE((
+                SELECT SUM(
+                  CASE WHEN effective.side = 'SELL' THEN effective.quantity * effective.price
+                       ELSE -(effective.quantity * effective.price) END
+                  - effective.commission
+                )
+                  FROM (
+                    SELECT DISTINCT ON (f.connection_id, f.exec_family_id) f.*
+                      FROM trading_fills f
+                     ORDER BY f.connection_id, f.exec_family_id, f.exec_revision DESC, f.updated_at DESC
+                  ) effective
+                  JOIN trading_orders owned_order ON owned_order.id = effective.order_id
+                  JOIN trading_rebalance_plans owned_plan ON owned_plan.id = owned_order.rebalance_plan_id
+                 WHERE owned_plan.strategy_link_id = l.id
+              ), 0)
+           )::float8 AS strategy_cash_usd,
            l.reserve_fraction::float8 AS reserve_fraction,
            c.mode,
            c.account_masked,
@@ -974,6 +1050,8 @@ export async function loadExecutorCommands(connectionId: string): Promise<Array<
       JOIN portfolio_snapshot_trade_eligibility e ON e.snapshot_id = p.snapshot_id
       LEFT JOIN trading_strategy_positions pos ON pos.strategy_link_id = l.id
      WHERE c.id = ${connectionId}::uuid
+        AND c.executor_lease_owner = ${executorInstanceId}
+        AND c.executor_lease_expires_at > now()
        AND (
           (c.status = 'ready' AND e.eligible AND p.status IN ('queued', 'preflight', 'awaiting_market', 'awaiting_settlement', 'selling', 'buying', 'partial'))
          OR p.status = 'cancel_requested'
@@ -994,6 +1072,24 @@ export async function loadExecutorCommands(connectionId: string): Promise<Array<
   return rows;
 }
 
+export async function loadExecutorCancellationIds(
+  connectionId: string,
+  executorInstanceId: string,
+): Promise<string[]> {
+  const sql = requireSql();
+  const rows = (await sql`
+    SELECT p.id::text AS id
+      FROM trading_rebalance_plans p
+      JOIN trading_strategy_links l ON l.id = p.strategy_link_id
+      JOIN trading_connections c ON c.id = l.connection_id
+     WHERE c.id = ${connectionId}::uuid
+       AND c.executor_lease_owner = ${executorInstanceId}
+       AND c.executor_lease_expires_at > now()
+       AND p.status = 'cancel_requested';
+  `) as Array<{ id: string }>;
+  return rows.map((row) => row.id);
+}
+
 export async function updateRebalanceStatus(args: {
   connectionId: string;
   planId: string;
@@ -1010,7 +1106,7 @@ export async function updateRebalanceStatus(args: {
              ELSE command_revision
            END,
            not_before = CASE
-             WHEN ${args.status} IN ('partial', 'awaiting_settlement') AND p.status <> ${args.status}
+             WHEN ${args.status} IN ('partial', 'awaiting_settlement', 'awaiting_market') AND p.status <> ${args.status}
                THEN (
                  timezone('America/New_York', now())::date
                  + CASE extract(isodow FROM timezone('America/New_York', now()))::int
@@ -1038,10 +1134,10 @@ export async function updateRebalanceStatus(args: {
          OR (p.status = 'queued' AND ${args.status} IN ('preflight', 'awaiting_market', 'blocked'))
          OR (p.status = 'awaiting_market' AND ${args.status} IN ('preflight', 'blocked'))
          OR (p.status = 'awaiting_settlement' AND ${args.status} IN ('awaiting_settlement', 'preflight', 'buying', 'blocked'))
-         OR (p.status = 'preflight' AND ${args.status} IN ('awaiting_settlement', 'selling', 'buying', 'completed', 'partial', 'blocked'))
-         OR (p.status = 'selling' AND ${args.status} IN ('preflight', 'awaiting_settlement', 'buying', 'completed', 'partial', 'blocked'))
-         OR (p.status = 'buying' AND ${args.status} IN ('preflight', 'completed', 'partial', 'blocked'))
-         OR (p.status = 'partial' AND ${args.status} IN ('preflight', 'selling', 'buying', 'completed', 'blocked'))
+         OR (p.status = 'preflight' AND ${args.status} IN ('awaiting_market', 'awaiting_settlement', 'selling', 'buying', 'completed', 'partial', 'blocked'))
+         OR (p.status = 'selling' AND ${args.status} IN ('preflight', 'awaiting_market', 'awaiting_settlement', 'buying', 'completed', 'partial', 'blocked'))
+         OR (p.status = 'buying' AND ${args.status} IN ('preflight', 'awaiting_market', 'completed', 'partial', 'blocked'))
+         OR (p.status = 'partial' AND ${args.status} IN ('awaiting_market', 'preflight', 'selling', 'buying', 'completed', 'blocked'))
          OR (p.status = 'cancel_requested' AND ${args.status} = 'cancelled')
        )
     RETURNING p.id::text AS id;
@@ -1179,6 +1275,7 @@ export async function upsertTradingOrder(args: {
 export async function insertTradingFill(args: {
   connectionId: string;
   orderId?: string | null;
+  clientOrderKey?: string | null;
   execId: string;
   symbol: string;
   side: "BUY" | "SELL";
@@ -1190,24 +1287,34 @@ export async function insertTradingFill(args: {
   rawExecution?: Record<string, unknown>;
 }): Promise<boolean> {
   const sql = requireSql();
+  const identity = tradingExecutionIdentity(args.execId);
   const rows = (await sql`
+    WITH resolved_order AS (
+      SELECT owned_order.id
+        FROM trading_orders owned_order
+        JOIN trading_rebalance_plans owned_plan ON owned_plan.id = owned_order.rebalance_plan_id
+        JOIN trading_strategy_links owned_link ON owned_link.id = owned_plan.strategy_link_id
+       WHERE owned_link.connection_id = ${args.connectionId}::uuid
+         AND (
+           (${args.orderId || null}::uuid IS NOT NULL AND owned_order.id = ${args.orderId || null}::uuid)
+           OR (
+             ${args.orderId || null}::uuid IS NULL
+             AND ${args.clientOrderKey || ""} <> ''
+             AND owned_order.client_order_key = ${args.clientOrderKey || ""}
+           )
+         )
+       LIMIT 1
+    )
     INSERT INTO trading_fills (
-      order_id, connection_id, exec_id, symbol, side, quantity, price,
+      order_id, connection_id, exec_id, exec_family_id, exec_revision, symbol, side, quantity, price,
       commission, commission_currency, executed_at, raw_execution
     )
-    SELECT ${args.orderId || null}::uuid, ${args.connectionId}::uuid, ${args.execId},
+    SELECT resolved_order.id,
+           ${args.connectionId}::uuid, ${args.execId}, ${identity.familyId}, ${identity.revision},
            ${args.symbol.toUpperCase()}, ${args.side}, ${args.quantity}, ${args.price},
            ${args.commission || 0}, ${args.commissionCurrency || "USD"},
            ${args.executedAt}::timestamptz, ${JSON.stringify(args.rawExecution || {})}::jsonb
-     WHERE ${args.orderId || null}::uuid IS NULL
-        OR EXISTS (
-          SELECT 1
-            FROM trading_orders owned_order
-            JOIN trading_rebalance_plans owned_plan ON owned_plan.id = owned_order.rebalance_plan_id
-            JOIN trading_strategy_links owned_link ON owned_link.id = owned_plan.strategy_link_id
-           WHERE owned_order.id = ${args.orderId || null}::uuid
-             AND owned_link.connection_id = ${args.connectionId}::uuid
-        )
+      FROM resolved_order
     ON CONFLICT (exec_id) DO UPDATE SET
       order_id = COALESCE(EXCLUDED.order_id, trading_fills.order_id),
       commission = EXCLUDED.commission,
@@ -1219,13 +1326,15 @@ export async function insertTradingFill(args: {
   `) as Array<{ id: string; inserted: boolean }>;
   const accepted = rows.length === 1;
   const inserted = rows[0]?.inserted === true;
-  if (accepted && args.orderId) {
+  if (accepted) {
     const linkRows = (await sql`
       SELECT l.id::text AS id
-        FROM trading_orders o
+        FROM trading_fills f
+        JOIN trading_orders o ON o.id = f.order_id
         JOIN trading_rebalance_plans p ON p.id = o.rebalance_plan_id
         JOIN trading_strategy_links l ON l.id = p.strategy_link_id
-       WHERE o.id = ${args.orderId}::uuid
+       WHERE f.connection_id = ${args.connectionId}::uuid
+         AND f.exec_id = ${args.execId}
          AND l.connection_id = ${args.connectionId}::uuid
        LIMIT 1;
     `) as Array<{ id: string }>;
@@ -1235,14 +1344,19 @@ export async function insertTradingFill(args: {
         tx`DELETE FROM trading_strategy_positions WHERE strategy_link_id = ${linkId}::uuid;`,
         tx`
           INSERT INTO trading_strategy_positions (strategy_link_id, symbol, quantity)
-          SELECT ${linkId}::uuid, f.symbol,
-                 SUM(CASE WHEN f.side = 'BUY' THEN f.quantity ELSE -f.quantity END) AS quantity
-            FROM trading_fills f
-            JOIN trading_orders o ON o.id = f.order_id
+          SELECT ${linkId}::uuid, effective.symbol,
+                 SUM(CASE WHEN effective.side = 'BUY' THEN effective.quantity ELSE -effective.quantity END) AS quantity
+            FROM (
+              SELECT DISTINCT ON (source.connection_id, source.exec_family_id) source.*
+                FROM trading_fills source
+               ORDER BY source.connection_id, source.exec_family_id,
+                        source.exec_revision DESC, source.updated_at DESC
+            ) effective
+            JOIN trading_orders o ON o.id = effective.order_id
             JOIN trading_rebalance_plans p ON p.id = o.rebalance_plan_id
            WHERE p.strategy_link_id = ${linkId}::uuid
-           GROUP BY f.symbol
-          HAVING SUM(CASE WHEN f.side = 'BUY' THEN f.quantity ELSE -f.quantity END) > 0;
+           GROUP BY effective.symbol
+          HAVING SUM(CASE WHEN effective.side = 'BUY' THEN effective.quantity ELSE -effective.quantity END) > 0;
         `,
       ]);
     }
@@ -1254,6 +1368,7 @@ export async function insertTradingFill(args: {
       action: "fill_reported",
       payload: {
         order_id: args.orderId || null,
+        client_order_key: args.clientOrderKey || null,
         exec_id: args.execId,
         symbol: args.symbol,
         side: args.side,
@@ -1263,42 +1378,6 @@ export async function insertTradingFill(args: {
     });
   }
   return accepted;
-}
-
-export async function replaceTradingStrategyPositions(args: {
-  connectionId: string;
-  strategyLinkId: string;
-  positions: Array<{
-    symbol: string;
-    conid?: number | null;
-    quantity: number;
-    averageCostUsd?: number | null;
-  }>;
-}): Promise<boolean> {
-  const sql = requireSql();
-  const ownedRows = (await sql`
-    SELECT l.id::text AS id
-      FROM trading_strategy_links l
-     WHERE l.id = ${args.strategyLinkId}::uuid
-       AND l.connection_id = ${args.connectionId}::uuid
-     LIMIT 1;
-  `) as Array<{ id: string }>;
-  if (!ownedRows.length) return false;
-  const positions = args.positions.filter((position) => (
-    position.symbol && Number.isFinite(position.quantity) && position.quantity >= 0
-  ));
-  await sql.transaction((tx) => [
-    tx`DELETE FROM trading_strategy_positions WHERE strategy_link_id = ${args.strategyLinkId}::uuid;`,
-    ...positions.map((position) => tx`
-      INSERT INTO trading_strategy_positions (
-        strategy_link_id, symbol, conid, quantity, average_cost_usd
-      ) VALUES (
-        ${args.strategyLinkId}::uuid, ${position.symbol.toUpperCase()},
-        ${position.conid ?? null}, ${position.quantity}, ${position.averageCostUsd ?? null}
-      );
-    `),
-  ]);
-  return true;
 }
 
 export async function recordTradingEvent(args: {

--- a/frontend/src/lib/trading-executor-auth.ts
+++ b/frontend/src/lib/trading-executor-auth.ts
@@ -1,0 +1,44 @@
+import "server-only";
+
+import { loadExecutorCredential, registerExecutorNonce } from "@/lib/trading-db";
+import {
+  matchesSha256,
+  readExecutorAuthHeaders,
+  verifyExecutorSignature,
+} from "@/lib/trading-security";
+
+export class ExecutorAuthenticationError extends Error {
+  constructor(message = "Executor authentication failed.") {
+    super(message);
+    this.name = "ExecutorAuthenticationError";
+  }
+}
+
+export async function authenticateExecutorRequest<T>(request: Request): Promise<{
+  connectionId: string;
+  body: T;
+  mode: "paper" | "live";
+  accountFingerprint: string;
+}> {
+  const rawBody = await request.text();
+  if (rawBody.length > 1_000_000) throw new ExecutorAuthenticationError("Executor request body is too large.");
+  const headers = readExecutorAuthHeaders(request);
+  if (!verifyExecutorSignature(headers, rawBody)) throw new ExecutorAuthenticationError();
+  const credential = await loadExecutorCredential(headers.connectionId);
+  if (!credential || !matchesSha256(headers.secret, credential.deviceSecretHash)) {
+    throw new ExecutorAuthenticationError();
+  }
+  if (!(await registerExecutorNonce(headers.connectionId, headers.nonce))) {
+    throw new ExecutorAuthenticationError("Executor request was already received.");
+  }
+  try {
+    return {
+      connectionId: headers.connectionId,
+      body: JSON.parse(rawBody || "{}") as T,
+      mode: credential.mode,
+      accountFingerprint: credential.accountFingerprint,
+    };
+  } catch {
+    throw new ExecutorAuthenticationError("Executor request body is not valid JSON.");
+  }
+}

--- a/frontend/src/lib/trading-security.ts
+++ b/frontend/src/lib/trading-security.ts
@@ -1,0 +1,143 @@
+import "server-only";
+
+import {
+  createHash,
+  createHmac,
+  randomBytes,
+  timingSafeEqual,
+} from "node:crypto";
+
+import { auth } from "@/auth";
+import {
+  flagEnabled,
+  TRADING_USER_ID_RE,
+  tradingMutationsEnabled,
+  tradingSessionIsEligible,
+} from "@/lib/trading-access-policy";
+import {
+  computeExecutorSignature,
+  constantTimeHexEqual,
+  executorTimestampIsFresh,
+} from "@/lib/trading-signature";
+
+export function isTradingControlEnabled(): boolean {
+  return tradingMutationsEnabled({
+    controlFlag: process.env.TRADING_CONTROL_ENABLED,
+    previewFlag: process.env.AUTH_BYPASS_PREVIEW,
+  });
+}
+
+export function isLiveTradingEnabled(): boolean {
+  return isTradingControlEnabled() && flagEnabled(process.env.IBKR_LIVE_TRADING_ENABLED);
+}
+
+export async function requireTradingUser(): Promise<{ userId: string; email: string }> {
+  const session = await auth();
+  const userId = String(session?.user?.id || "").trim();
+  const email = String(session?.user?.email || "").trim().toLowerCase();
+  if (!tradingSessionIsEligible(session?.user)) {
+    throw new TradingUnauthorizedError();
+  }
+  return { userId, email };
+}
+
+export class TradingUnauthorizedError extends Error {
+  constructor() {
+    super("Google sign-in is required for trading controls.");
+    this.name = "TradingUnauthorizedError";
+  }
+}
+
+export class TradingDisabledError extends Error {
+  constructor(message = "Trading mutations are disabled in this environment.") {
+    super(message);
+    this.name = "TradingDisabledError";
+  }
+}
+
+export function requireTradingMutationEnabled(): void {
+  if (!isTradingControlEnabled()) throw new TradingDisabledError();
+}
+
+export function sha256(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+export function matchesSha256(value: string, expectedHex: string): boolean {
+  const actual = Buffer.from(sha256(value), "hex");
+  const expected = Buffer.from(expectedHex, "hex");
+  return actual.length === expected.length && timingSafeEqual(actual, expected);
+}
+
+export function constantTimeTextEqual(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left, "utf8");
+  const rightBuffer = Buffer.from(right, "utf8");
+  return leftBuffer.length === rightBuffer.length && timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+export function generatePairingCode(): string {
+  let raw = "";
+  while (raw.length < 8) {
+    raw += randomBytes(6).toString("base64url").toUpperCase().replace(/[^A-Z0-9]/g, "");
+  }
+  raw = raw.slice(0, 8);
+  return `${raw.slice(0, 4)}-${raw.slice(4)}`;
+}
+
+export function normalizePairingCode(value: string): string {
+  return value.toUpperCase().replace(/[^A-Z0-9]/g, "");
+}
+
+export function generateDeviceSecret(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+export function accountFingerprint(accountId: string): string {
+  const pepper = String(process.env.TRADING_ACCOUNT_FINGERPRINT_KEY || process.env.AUTH_SECRET || "").trim();
+  if (!pepper) throw new TradingDisabledError("TRADING_ACCOUNT_FINGERPRINT_KEY or AUTH_SECRET is required.");
+  return createHmac("sha256", pepper).update(accountId.trim().toUpperCase(), "utf8").digest("hex");
+}
+
+export function maskAccountId(accountId: string): string {
+  const clean = accountId.trim().toUpperCase();
+  if (clean.length <= 4) return `***${clean}`;
+  return `${clean.slice(0, 1)}***${clean.slice(-4)}`;
+}
+
+export type ExecutorAuthHeaders = {
+  connectionId: string;
+  secret: string;
+  timestamp: string;
+  nonce: string;
+  signature: string;
+};
+
+export function readExecutorAuthHeaders(request: Request): ExecutorAuthHeaders {
+  const authorization = request.headers.get("authorization") || "";
+  const secret = authorization.startsWith("Bearer ") ? authorization.slice(7).trim() : "";
+  return {
+    connectionId: String(request.headers.get("x-trading-connection") || "").trim(),
+    secret,
+    timestamp: String(request.headers.get("x-trading-timestamp") || "").trim(),
+    nonce: String(request.headers.get("x-trading-nonce") || "").trim(),
+    signature: String(request.headers.get("x-trading-signature") || "").trim().toLowerCase(),
+  };
+}
+
+export function verifyExecutorSignature(headers: ExecutorAuthHeaders, rawBody: string): boolean {
+  if (
+    !TRADING_USER_ID_RE.test(headers.connectionId)
+    || !headers.secret || headers.secret.length > 128
+    || !headers.nonce || headers.nonce.length > 200
+    || !/^[0-9a-f]{64}$/.test(headers.signature)
+    || headers.timestamp.length > 20
+  ) return false;
+  if (!executorTimestampIsFresh(headers.timestamp)) return false;
+  const expected = computeExecutorSignature({
+    secret: headers.secret,
+    timestamp: headers.timestamp,
+    nonce: headers.nonce,
+    rawBody,
+  });
+  return constantTimeHexEqual(expected, headers.signature);
+}

--- a/frontend/src/lib/trading-signature.test.ts
+++ b/frontend/src/lib/trading-signature.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  computeExecutorSignature,
+  constantTimeHexEqual,
+  executorTimestampIsFresh,
+} from "./trading-signature";
+import { tradingPortfolioKey } from "./trading-types";
+
+test("executor signatures bind timestamp nonce and exact request body", () => {
+  const base = { secret: "device-secret", timestamp: "1800000000", nonce: "unique-nonce", rawBody: "{\"ok\":true}" };
+  const signature = computeExecutorSignature(base);
+  assert.equal(constantTimeHexEqual(signature, computeExecutorSignature(base)), true);
+  assert.notEqual(signature, computeExecutorSignature({ ...base, nonce: "different" }));
+  assert.notEqual(signature, computeExecutorSignature({ ...base, rawBody: "{\"ok\":false}" }));
+});
+
+test("executor timestamps reject requests outside the five minute window", () => {
+  assert.equal(executorTimestampIsFresh("1000", 1300), true);
+  assert.equal(executorTimestampIsFresh("999", 1300), false);
+  assert.equal(executorTimestampIsFresh("invalid", 1300), false);
+});
+
+test("portfolio identity is stable and workspace-isolated", () => {
+  const analysis = tradingPortfolioKey({ workspace: "analysis", lensType: "model", lensKey: "Analyst", methodologyVersion: "v1" });
+  const nasdaq = tradingPortfolioKey({ workspace: "nasdaq100", lensType: "model", lensKey: "Analyst", methodologyVersion: "v1" });
+  assert.equal(analysis, "analysis:model:Analyst:v1");
+  assert.notEqual(analysis, nasdaq);
+});

--- a/frontend/src/lib/trading-signature.ts
+++ b/frontend/src/lib/trading-signature.ts
@@ -1,0 +1,28 @@
+import { createHash, createHmac, timingSafeEqual } from "node:crypto";
+
+export const EXECUTOR_CLOCK_SKEW_SECONDS = 300;
+
+export function sha256Text(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+export function computeExecutorSignature(args: {
+  secret: string;
+  timestamp: string;
+  nonce: string;
+  rawBody: string;
+}): string {
+  const payload = `${args.timestamp}\n${args.nonce}\n${sha256Text(args.rawBody)}`;
+  return createHmac("sha256", args.secret).update(payload, "utf8").digest("hex");
+}
+
+export function executorTimestampIsFresh(timestamp: string, nowSeconds = Math.floor(Date.now() / 1000)): boolean {
+  const parsed = Number(timestamp);
+  return Number.isFinite(parsed) && Math.abs(nowSeconds - parsed) <= EXECUTOR_CLOCK_SKEW_SECONDS;
+}
+
+export function constantTimeHexEqual(leftHex: string, rightHex: string): boolean {
+  const left = Buffer.from(leftHex, "hex");
+  const right = Buffer.from(rightHex, "hex");
+  return left.length > 0 && left.length === right.length && timingSafeEqual(left, right);
+}

--- a/frontend/src/lib/trading-types.ts
+++ b/frontend/src/lib/trading-types.ts
@@ -16,6 +16,7 @@ export type RebalanceStatus =
   | "queued"
   | "preflight"
   | "awaiting_market"
+  | "awaiting_settlement"
   | "selling"
   | "buying"
   | "completed"
@@ -58,6 +59,7 @@ export type TradingConnectionView = {
   status: TradingConnectionStatus;
   gateway_connected: boolean;
   gateway_authenticated: boolean;
+  account_type: string;
   executor_version: string;
   last_heartbeat_at: string | null;
   last_error: string;
@@ -85,6 +87,7 @@ export type TradingPlanView = {
   snapshot_id: string;
   status: RebalanceStatus;
   target_holdings: TradingHolding[];
+  preflight: Record<string, unknown>;
   not_before: string | null;
   error: string;
   created_at: string;

--- a/frontend/src/lib/trading-types.ts
+++ b/frontend/src/lib/trading-types.ts
@@ -74,6 +74,7 @@ export type TradingStrategyView = {
   lens_key: string;
   methodology_version: string;
   budget_usd: number;
+  cash_balance_usd: number;
   reserve_fraction: number;
   status: TradingLinkStatus;
   latest_snapshot_id: string | null;
@@ -125,6 +126,7 @@ export type TradingOrderView = {
 
 export type TradingFillView = {
   exec_id: string;
+  correction_revision: number;
   symbol: string;
   side: "BUY" | "SELL";
   quantity: number;

--- a/frontend/src/lib/trading-types.ts
+++ b/frontend/src/lib/trading-types.ts
@@ -1,0 +1,160 @@
+import type { Workspace } from "@/lib/workspace";
+
+export const TRADING_PROVIDER = "ibkr" as const;
+export const TRADING_RESERVE_FRACTION = 0.02;
+
+export type BrokerMode = "paper" | "live";
+export type TradingConnectionStatus =
+  | "awaiting_pairing"
+  | "disconnected"
+  | "ready"
+  | "paused"
+  | "error"
+  | "revoked";
+export type TradingLinkStatus = "draft" | "armed" | "paused" | "blocked" | "revoked";
+export type RebalanceStatus =
+  | "queued"
+  | "preflight"
+  | "awaiting_market"
+  | "selling"
+  | "buying"
+  | "completed"
+  | "partial"
+  | "blocked"
+  | "cancel_requested"
+  | "cancelled";
+
+export type TradingLensType = "overall" | "model" | "valuator";
+
+export type TradingHolding = {
+  rank: number;
+  ticker: string;
+  score: number;
+  weight: number;
+  currency: string;
+};
+
+export type TradingPortfolioOption = {
+  portfolio_key: string;
+  workspace: Workspace;
+  lens_type: TradingLensType;
+  lens_key: string;
+  label: string;
+  methodology_version: string;
+  latest_snapshot_id: string;
+  cutoff_at: string;
+  execution_date: string;
+  status: "ready" | "no_positions";
+  holdings_count: number;
+  eligible: boolean;
+  eligibility_reasons: string[];
+  holdings: TradingHolding[];
+};
+
+export type TradingConnectionView = {
+  id: string;
+  mode: BrokerMode;
+  account_masked: string;
+  status: TradingConnectionStatus;
+  gateway_connected: boolean;
+  gateway_authenticated: boolean;
+  executor_version: string;
+  last_heartbeat_at: string | null;
+  last_error: string;
+  paired_at: string | null;
+};
+
+export type TradingStrategyView = {
+  id: string;
+  connection_id: string;
+  workspace: Workspace;
+  lens_type: TradingLensType;
+  lens_key: string;
+  methodology_version: string;
+  budget_usd: number;
+  reserve_fraction: number;
+  status: TradingLinkStatus;
+  latest_snapshot_id: string | null;
+  last_error: string;
+  armed_at: string | null;
+};
+
+export type TradingPlanView = {
+  id: string;
+  strategy_link_id: string;
+  snapshot_id: string;
+  status: RebalanceStatus;
+  target_holdings: TradingHolding[];
+  not_before: string | null;
+  error: string;
+  created_at: string;
+  updated_at: string;
+};
+
+export type TradingEventView = {
+  event_type: string;
+  severity: "info" | "warning" | "critical";
+  message: string;
+  created_at: string;
+};
+
+export type TradingPositionView = {
+  symbol: string;
+  conid: number | null;
+  quantity: number;
+  average_cost_usd: number | null;
+};
+
+export type TradingOrderView = {
+  id: string;
+  plan_id: string;
+  symbol: string;
+  side: "BUY" | "SELL";
+  requested_quantity: number;
+  filled_quantity: number;
+  limit_price: number | null;
+  average_fill_price: number | null;
+  commission: number;
+  commission_currency: string;
+  status: string;
+  updated_at: string;
+};
+
+export type TradingFillView = {
+  exec_id: string;
+  symbol: string;
+  side: "BUY" | "SELL";
+  quantity: number;
+  price: number;
+  commission: number;
+  commission_currency: string;
+  executed_at: string;
+};
+
+export type TradingDashboardPayload = {
+  enabled: boolean;
+  live_enabled: boolean;
+  workspace: Workspace;
+  connections: TradingConnectionView[];
+  strategy: TradingStrategyView | null;
+  portfolios: TradingPortfolioOption[];
+  plans: TradingPlanView[];
+  events: TradingEventView[];
+  positions: TradingPositionView[];
+  orders: TradingOrderView[];
+  fills: TradingFillView[];
+};
+
+export function tradingPortfolioKey(args: {
+  workspace: Workspace;
+  lensType: TradingLensType;
+  lensKey: string | null;
+  methodologyVersion: string;
+}): string {
+  return [
+    args.workspace,
+    args.lensType,
+    args.lensType === "overall" ? "overall" : String(args.lensKey || "").trim(),
+    args.methodologyVersion,
+  ].map((value) => encodeURIComponent(value)).join(":");
+}

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -3,7 +3,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { auth } from "@/auth";
 import { shouldBypassAuthForHostname } from "@/lib/auth-bypass";
 
-const LEGACY_APP_PREFIXES = ["/reports", "/compare", "/screeners", "/discovery", "/hit-rate", "/dashboard"];
+const LEGACY_APP_PREFIXES = ["/reports", "/compare", "/screeners", "/discovery", "/hit-rate", "/dashboard", "/trading"];
 
 function workspaceRouting(req: NextRequest) {
   const { pathname } = req.nextUrl;
@@ -53,7 +53,9 @@ export default auth((req) => {
 
   const isPublic =
     pathname.startsWith("/auth/") ||
-    pathname.startsWith("/api/auth/");
+    pathname.startsWith("/api/auth/") ||
+    pathname.startsWith("/api/trading/executor/") ||
+    pathname === "/api/trading/monitor";
 
   if (isPublic) return NextResponse.next();
   if (req.auth) return workspaceRouting(req);

--- a/src/ai_hedge/db/migrations/011_ibkr_paper_trading.sql
+++ b/src/ai_hedge/db/migrations/011_ibkr_paper_trading.sql
@@ -1,0 +1,252 @@
+-- Personal IBKR paper-trading control plane. Broker credentials stay on the
+-- executor VM; this database contains only scoped device-token hashes,
+-- strategy configuration, commands, and an immutable execution audit trail.
+
+CREATE TABLE IF NOT EXISTS portfolio_refresh_runs (
+    id                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    workspace             text NOT NULL CHECK (workspace IN ('analysis', 'nasdaq100')),
+    track                 text NOT NULL CHECK (track IN ('backtest', 'paper')),
+    methodology_version   text NOT NULL,
+    status                text NOT NULL DEFAULT 'running'
+                          CHECK (status IN ('running', 'completed', 'partial', 'failed')),
+    provider_warnings     jsonb NOT NULL DEFAULT '[]'::jsonb,
+    error                 text NOT NULL DEFAULT '',
+    started_at            timestamptz NOT NULL DEFAULT now(),
+    finished_at           timestamptz
+);
+
+CREATE INDEX IF NOT EXISTS portfolio_refresh_runs_recent_idx
+    ON portfolio_refresh_runs (workspace, track, started_at DESC);
+
+CREATE TABLE IF NOT EXISTS portfolio_snapshot_trade_eligibility (
+    snapshot_id           uuid PRIMARY KEY REFERENCES portfolio_snapshots(id) ON DELETE CASCADE,
+    refresh_run_id        uuid NOT NULL REFERENCES portfolio_refresh_runs(id) ON DELETE RESTRICT,
+    eligible              boolean NOT NULL DEFAULT false,
+    reasons               jsonb NOT NULL DEFAULT '[]'::jsonb,
+    checked_at            timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS portfolio_snapshot_trade_eligibility_run_idx
+    ON portfolio_snapshot_trade_eligibility (refresh_run_id, eligible);
+
+CREATE TABLE IF NOT EXISTS trading_connections (
+    id                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id               uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    broker                text NOT NULL DEFAULT 'ibkr' CHECK (broker = 'ibkr'),
+    mode                  text NOT NULL CHECK (mode IN ('paper', 'live')),
+    account_fingerprint   text,
+    account_masked        text NOT NULL DEFAULT '',
+    device_secret_hash    text,
+    status                text NOT NULL DEFAULT 'awaiting_pairing'
+                          CHECK (status IN ('awaiting_pairing', 'disconnected', 'ready', 'paused', 'error', 'revoked')),
+    gateway_connected     boolean NOT NULL DEFAULT false,
+    gateway_authenticated boolean NOT NULL DEFAULT false,
+    executor_version      text NOT NULL DEFAULT '',
+    last_heartbeat_at     timestamptz,
+    last_error            text NOT NULL DEFAULT '',
+    paired_at             timestamptz,
+    created_at            timestamptz NOT NULL DEFAULT now(),
+    updated_at            timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS trading_connections_account_idx
+    ON trading_connections (user_id, mode, account_fingerprint)
+    WHERE account_fingerprint IS NOT NULL AND status <> 'revoked';
+CREATE INDEX IF NOT EXISTS trading_connections_user_idx
+    ON trading_connections (user_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS trading_pairing_codes (
+    id                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    connection_id         uuid NOT NULL REFERENCES trading_connections(id) ON DELETE CASCADE,
+    code_hash             text NOT NULL UNIQUE,
+    expires_at            timestamptz NOT NULL,
+    consumed_at           timestamptz,
+    created_at            timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS trading_pairing_codes_active_idx
+    ON trading_pairing_codes (expires_at)
+    WHERE consumed_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS trading_strategy_previews (
+    id                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id               uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    connection_id         uuid NOT NULL REFERENCES trading_connections(id) ON DELETE CASCADE,
+    workspace             text NOT NULL CHECK (workspace IN ('analysis', 'nasdaq100')),
+    lens_type             text NOT NULL CHECK (lens_type IN ('overall', 'model', 'valuator')),
+    lens_key              text NOT NULL,
+    methodology_version   text NOT NULL,
+    budget_usd            numeric(18, 2) NOT NULL CHECK (budget_usd > 0),
+    arm                   boolean NOT NULL DEFAULT false,
+    snapshot_id           uuid NOT NULL REFERENCES portfolio_snapshots(id) ON DELETE CASCADE,
+    preview_payload       jsonb NOT NULL,
+    expires_at            timestamptz NOT NULL,
+    consumed_at           timestamptz,
+    created_at            timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS trading_strategy_previews_active_idx
+    ON trading_strategy_previews (user_id, expires_at DESC)
+    WHERE consumed_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS trading_strategy_links (
+    id                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    connection_id         uuid NOT NULL UNIQUE REFERENCES trading_connections(id) ON DELETE CASCADE,
+    workspace             text NOT NULL CHECK (workspace IN ('analysis', 'nasdaq100')),
+    lens_type             text NOT NULL CHECK (lens_type IN ('overall', 'model', 'valuator')),
+    lens_key              text NOT NULL,
+    methodology_version   text NOT NULL,
+    budget_usd            numeric(18, 2) NOT NULL CHECK (budget_usd > 0),
+    reserve_fraction      numeric(8, 6) NOT NULL DEFAULT 0.02
+                          CHECK (reserve_fraction >= 0 AND reserve_fraction < 1),
+    status                text NOT NULL DEFAULT 'draft'
+                          CHECK (status IN ('draft', 'armed', 'paused', 'blocked', 'revoked')),
+    latest_snapshot_id    uuid REFERENCES portfolio_snapshots(id) ON DELETE SET NULL,
+    last_error            text NOT NULL DEFAULT '',
+    armed_at              timestamptz,
+    created_at            timestamptz NOT NULL DEFAULT now(),
+    updated_at            timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS trading_strategy_links_lookup_idx
+    ON trading_strategy_links (workspace, lens_type, lens_key, methodology_version, status);
+
+CREATE TABLE IF NOT EXISTS trading_instruments (
+    symbol                text PRIMARY KEY,
+    conid                 bigint NOT NULL UNIQUE,
+    sec_type              text NOT NULL DEFAULT 'STK',
+    exchange              text NOT NULL,
+    primary_exchange      text NOT NULL,
+    currency              text NOT NULL,
+    min_tick              numeric,
+    min_size              numeric,
+    size_increment        numeric,
+    supports_fractional   boolean NOT NULL DEFAULT false,
+    liquid_hours          text NOT NULL DEFAULT '',
+    time_zone             text NOT NULL DEFAULT '',
+    approved              boolean NOT NULL DEFAULT false,
+    approved_at           timestamptz,
+    updated_at            timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS trading_rebalance_plans (
+    id                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    strategy_link_id      uuid NOT NULL REFERENCES trading_strategy_links(id) ON DELETE CASCADE,
+    snapshot_id           uuid NOT NULL REFERENCES portfolio_snapshots(id) ON DELETE RESTRICT,
+    status                text NOT NULL DEFAULT 'queued'
+                          CHECK (status IN (
+                              'queued', 'preflight', 'awaiting_market', 'selling', 'buying',
+                              'completed', 'partial', 'blocked', 'cancel_requested', 'cancelled'
+                          )),
+    target_holdings       jsonb NOT NULL,
+    preflight             jsonb NOT NULL DEFAULT '{}'::jsonb,
+    command_revision      int NOT NULL DEFAULT 1 CHECK (command_revision > 0),
+    not_before            timestamptz,
+    claimed_at            timestamptz,
+    completed_at          timestamptz,
+    error                 text NOT NULL DEFAULT '',
+    created_at            timestamptz NOT NULL DEFAULT now(),
+    updated_at            timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (strategy_link_id, snapshot_id)
+);
+
+CREATE INDEX IF NOT EXISTS trading_rebalance_plans_claim_idx
+    ON trading_rebalance_plans (status, not_before, created_at)
+    WHERE status IN ('queued', 'preflight', 'awaiting_market', 'partial', 'cancel_requested');
+
+CREATE TABLE IF NOT EXISTS trading_orders (
+    id                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    rebalance_plan_id     uuid NOT NULL REFERENCES trading_rebalance_plans(id) ON DELETE CASCADE,
+    client_order_key      text NOT NULL UNIQUE,
+    symbol                text NOT NULL,
+    conid                 bigint,
+    side                  text NOT NULL CHECK (side IN ('BUY', 'SELL')),
+    requested_quantity    numeric NOT NULL CHECK (requested_quantity > 0),
+    limit_price           numeric,
+    ib_order_id           bigint,
+    ib_perm_id            bigint,
+    status                text NOT NULL DEFAULT 'planned'
+                          CHECK (status IN ('planned', 'what_if', 'submitted', 'partially_filled', 'filled', 'cancel_pending', 'cancelled', 'rejected', 'error')),
+    filled_quantity       numeric NOT NULL DEFAULT 0 CHECK (filled_quantity >= 0),
+    average_fill_price    numeric,
+    commission            numeric NOT NULL DEFAULT 0,
+    commission_currency   text NOT NULL DEFAULT 'USD',
+    raw_status            jsonb NOT NULL DEFAULT '{}'::jsonb,
+    submitted_at          timestamptz,
+    completed_at          timestamptz,
+    created_at            timestamptz NOT NULL DEFAULT now(),
+    updated_at            timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS trading_orders_perm_id_idx
+    ON trading_orders (ib_perm_id) WHERE ib_perm_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS trading_orders_plan_idx
+    ON trading_orders (rebalance_plan_id, created_at);
+
+CREATE TABLE IF NOT EXISTS trading_fills (
+    id                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    order_id              uuid REFERENCES trading_orders(id) ON DELETE SET NULL,
+    connection_id         uuid NOT NULL REFERENCES trading_connections(id) ON DELETE CASCADE,
+    exec_id               text NOT NULL UNIQUE,
+    symbol                text NOT NULL,
+    side                  text NOT NULL CHECK (side IN ('BUY', 'SELL')),
+    quantity              numeric NOT NULL CHECK (quantity > 0),
+    price                 numeric NOT NULL CHECK (price > 0),
+    commission            numeric NOT NULL DEFAULT 0,
+    commission_currency   text NOT NULL DEFAULT 'USD',
+    executed_at           timestamptz NOT NULL,
+    raw_execution         jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at            timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS trading_fills_connection_idx
+    ON trading_fills (connection_id, executed_at DESC);
+
+CREATE TABLE IF NOT EXISTS trading_strategy_positions (
+    strategy_link_id      uuid NOT NULL REFERENCES trading_strategy_links(id) ON DELETE CASCADE,
+    symbol                text NOT NULL,
+    conid                 bigint,
+    quantity              numeric NOT NULL DEFAULT 0 CHECK (quantity >= 0),
+    average_cost_usd      numeric,
+    updated_at            timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (strategy_link_id, symbol)
+);
+
+CREATE TABLE IF NOT EXISTS trading_request_nonces (
+    connection_id         uuid NOT NULL REFERENCES trading_connections(id) ON DELETE CASCADE,
+    nonce                 text NOT NULL,
+    seen_at               timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (connection_id, nonce)
+);
+
+CREATE INDEX IF NOT EXISTS trading_request_nonces_recent_idx
+    ON trading_request_nonces (seen_at DESC);
+
+CREATE TABLE IF NOT EXISTS trading_events (
+    id                    uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    connection_id         uuid NOT NULL REFERENCES trading_connections(id) ON DELETE CASCADE,
+    event_id              text NOT NULL,
+    event_type            text NOT NULL,
+    severity              text NOT NULL DEFAULT 'info' CHECK (severity IN ('info', 'warning', 'critical')),
+    message               text NOT NULL DEFAULT '',
+    payload               jsonb NOT NULL DEFAULT '{}'::jsonb,
+    telegram_sent_at      timestamptz,
+    created_at            timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (connection_id, event_id)
+);
+
+CREATE INDEX IF NOT EXISTS trading_events_recent_idx
+    ON trading_events (connection_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS trading_audit_log (
+    id                    bigserial PRIMARY KEY,
+    user_id               uuid REFERENCES users(id) ON DELETE SET NULL,
+    connection_id         uuid REFERENCES trading_connections(id) ON DELETE SET NULL,
+    actor_type            text NOT NULL CHECK (actor_type IN ('user', 'executor', 'monitor', 'system')),
+    action                text NOT NULL,
+    payload               jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at            timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS trading_audit_log_recent_idx
+    ON trading_audit_log (connection_id, created_at DESC);

--- a/src/ai_hedge/db/migrations/012_ibkr_trading_hardening.sql
+++ b/src/ai_hedge/db/migrations/012_ibkr_trading_hardening.sql
@@ -1,0 +1,23 @@
+-- Harden IBKR execution recovery, settled-cash sequencing, and UI preflight reporting.
+
+ALTER TABLE trading_connections
+    ADD COLUMN IF NOT EXISTS account_type text NOT NULL DEFAULT 'UNKNOWN';
+
+ALTER TABLE trading_rebalance_plans
+    DROP CONSTRAINT IF EXISTS trading_rebalance_plans_status_check;
+
+ALTER TABLE trading_rebalance_plans
+    ADD CONSTRAINT trading_rebalance_plans_status_check CHECK (status IN (
+        'queued', 'preflight', 'awaiting_market', 'awaiting_settlement', 'selling', 'buying',
+        'completed', 'partial', 'blocked', 'cancel_requested', 'cancelled'
+    ));
+
+DROP INDEX IF EXISTS trading_rebalance_plans_claim_idx;
+CREATE INDEX trading_rebalance_plans_claim_idx
+    ON trading_rebalance_plans (status, not_before, created_at)
+    WHERE status IN (
+        'queued', 'preflight', 'awaiting_market', 'awaiting_settlement', 'partial', 'cancel_requested'
+    );
+
+ALTER TABLE trading_fills
+    ADD COLUMN IF NOT EXISTS updated_at timestamptz NOT NULL DEFAULT now();

--- a/src/ai_hedge/db/migrations/013_ibkr_executor_durability.sql
+++ b/src/ai_hedge/db/migrations/013_ibkr_executor_durability.sql
@@ -1,0 +1,46 @@
+-- Make Paper execution correction-aware, single-writer, and cash-isolated.
+
+ALTER TABLE trading_connections
+    ADD COLUMN IF NOT EXISTS executor_lease_owner text,
+    ADD COLUMN IF NOT EXISTS executor_lease_expires_at timestamptz;
+
+CREATE INDEX IF NOT EXISTS trading_connections_executor_lease_idx
+    ON trading_connections (executor_lease_expires_at)
+    WHERE executor_lease_owner IS NOT NULL;
+
+ALTER TABLE trading_strategy_links
+    ADD COLUMN IF NOT EXISTS cash_seed_usd numeric(18, 2);
+
+UPDATE trading_strategy_links
+   SET cash_seed_usd = budget_usd
+ WHERE cash_seed_usd IS NULL;
+
+ALTER TABLE trading_strategy_links
+    ALTER COLUMN cash_seed_usd SET NOT NULL;
+
+ALTER TABLE trading_fills
+    ADD COLUMN IF NOT EXISTS exec_family_id text,
+    ADD COLUMN IF NOT EXISTS exec_revision integer;
+
+UPDATE trading_fills
+   SET exec_family_id = CASE
+         WHEN exec_id ~ '[.][0-9]+$' THEN regexp_replace(exec_id, '[.][0-9]+$', '')
+         ELSE exec_id
+       END,
+       exec_revision = CASE
+         WHEN exec_id ~ '[.][0-9]+$' THEN (substring(exec_id FROM '[.]([0-9]+)$'))::integer
+         ELSE 0
+       END
+ WHERE exec_family_id IS NULL OR exec_revision IS NULL;
+
+ALTER TABLE trading_fills
+    ALTER COLUMN exec_family_id SET NOT NULL,
+    ALTER COLUMN exec_revision SET NOT NULL;
+
+CREATE INDEX IF NOT EXISTS trading_fills_execution_revision_idx
+    ON trading_fills (connection_id, exec_family_id, exec_revision);
+
+COMMENT ON COLUMN trading_fills.exec_family_id IS
+    'IBKR correction family. A corrected execution changes only the suffix after the final period.';
+COMMENT ON COLUMN trading_strategy_links.cash_seed_usd IS
+    'Explicit user allocation. Effective strategy cash is seed plus correction-aware net fills.';

--- a/trading_executor/README.md
+++ b/trading_executor/README.md
@@ -36,7 +36,10 @@ never receives the IBKR password, 2FA response, or full account number.
    ```
 
    The device secret and account number are encrypted with Windows DPAPI for
-   the current Windows user under `%LOCALAPPDATA%\HedgeInABox`.
+   the current Windows user under `%LOCALAPPDATA%\HedgeInABox`. A separate
+   SQLite WAL journal is created per connection in the same directory. It has
+   no IBKR password or 2FA secret and durably records the event outbox, broker
+   executions, and order intents before submission.
 
 5. Start in reconciliation-only mode. No order is sent unless the local gate is
    explicitly enabled:
@@ -69,6 +72,15 @@ sends a Telegram alert.
   than Paper port `4002`.
 - Every command is reconciled against account positions, open orders, and
   executions before work starts.
+- A stable executor instance must acquire the server lease before it connects
+  to IB Gateway. A local file lock and the Scheduled Task `IgnoreNew` policy
+  also prevent a second process. The executor renews and checks the lease before
+  every real submission and while an order is open; a remote kill switch stops
+  the next submission and cancels the current system order. Re-pairing
+  explicitly clears a stale lease.
+- Control-plane events are written to a SQLite WAL outbox before transmission
+  and replayed in order. An ambiguous prepared/submitted order intent is
+  blocked for manual reconciliation and is never submitted a second time.
 - Manual overlap in a target or strategy-owned ticker blocks the whole plan.
 - Empty targets never liquidate. Sells complete before buys. Quotes must contain
   a fresh bid and ask, and every order passes IBKR WhatIf before any real order.
@@ -78,14 +90,17 @@ sends a Telegram alert.
   estimated minimum budget.
 - Buys are limited to IBKR `SettledCash` in USD. Margin buying power and
   same-day sale proceeds are never counted; after sells, the plan can wait in
-  `awaiting_settlement` until a later session.
+  `awaiting_settlement` until a later session. Sizing is also capped by the
+  strategy's own correction-aware cash ledger, so unrelated account cash
+  cannot automatically refill strategy losses.
 - Orders are SMART, DAY, regular-hours-only, marketable limits. Unfilled orders
   are cancelled and repriced at most three times; remaining quantity becomes a
   partial plan for the next session.
 - Order references are deterministic by plan, symbol, side, revision, and
   attempt. Each IBKR execution callback is stored separately by `ExecId`, and
   reconciliation reports broker orders/executions before a new command can be
-  retried. Server-side `PermId` and `ExecId` uniqueness protects callback replay.
+  retried. IBKR corrections supersede the prior revision in the same execution
+  family. Server-side `PermId` and `ExecId` uniqueness protects callback replay.
 
 Run the broker-independent tests with:
 

--- a/trading_executor/README.md
+++ b/trading_executor/README.md
@@ -72,11 +72,20 @@ sends a Telegram alert.
 - Manual overlap in a target or strategy-owned ticker blocks the whole plan.
 - Empty targets never liquidate. Sells complete before buys. Quotes must contain
   a fresh bid and ask, and every order passes IBKR WhatIf before any real order.
+- A snapshot may naturally contain fewer than 20 names, but its own target set
+  must have full `N/N` tradable-quantity coverage. If the fixed budget would
+  round even one target to zero, the whole plan is blocked and reports the
+  estimated minimum budget.
+- Buys are limited to IBKR `SettledCash` in USD. Margin buying power and
+  same-day sale proceeds are never counted; after sells, the plan can wait in
+  `awaiting_settlement` until a later session.
 - Orders are SMART, DAY, regular-hours-only, marketable limits. Unfilled orders
   are cancelled and repriced at most three times; remaining quantity becomes a
   partial plan for the next session.
 - Order references are deterministic by plan, symbol, side, revision, and
-  attempt. Server-side `PermId` and `ExecId` uniqueness protects callback replay.
+  attempt. Each IBKR execution callback is stored separately by `ExecId`, and
+  reconciliation reports broker orders/executions before a new command can be
+  retried. Server-side `PermId` and `ExecId` uniqueness protects callback replay.
 
 Run the broker-independent tests with:
 

--- a/trading_executor/README.md
+++ b/trading_executor/README.md
@@ -1,0 +1,85 @@
+# IBKR Paper executor
+
+This process is the only component that talks to IB Gateway. It is designed for
+a persistent Windows VM with an interactive Desktop/RDP session. The website
+never receives the IBKR password, 2FA response, or full account number.
+
+## Install
+
+1. Install IB Gateway and the matching TWS API package from IBKR.
+2. In the extracted TWS API package, install its official Python client into a
+   dedicated virtual environment:
+
+   ```powershell
+   py -3.12 -m venv .venv-ibkr
+   .\.venv-ibkr\Scripts\python.exe -m pip install -r trading_executor\requirements.txt
+   .\.venv-ibkr\Scripts\python.exe -m pip install C:\TWSAPI\source\pythonclient
+   ```
+
+   Do not install an old, independently published `ibapi` build from PyPI. The
+   client and Gateway versions must match.
+
+3. Configure IB Gateway for Paper trading:
+
+   - socket port `4002`;
+   - API connections enabled;
+   - Read-Only API disabled only when Paper orders are ready to be tested;
+   - localhost/trusted IP `127.0.0.1` only;
+   - automatic weekday restart enabled.
+
+4. In the site Trading tab, create a one-time pairing code. On the VM:
+
+   ```powershell
+   .\.venv-ibkr\Scripts\python.exe -m trading_executor pair `
+     --code ABCD-EFGH `
+     --account DU1234567
+   ```
+
+   The device secret and account number are encrypted with Windows DPAPI for
+   the current Windows user under `%LOCALAPPDATA%\HedgeInABox`.
+
+5. Start in reconciliation-only mode. No order is sent unless the local gate is
+   explicitly enabled:
+
+   ```powershell
+   .\.venv-ibkr\Scripts\python.exe -m trading_executor run
+   ```
+
+6. After contract, quote, WhatIf, ownership, and alert validation, set the local
+   environment variable and restart:
+
+   ```powershell
+   [Environment]::SetEnvironmentVariable("IBKR_EXECUTION_ENABLED", "1", "User")
+   ```
+
+7. Install the at-logon scheduled task while logged in as the dedicated Windows
+   user:
+
+   ```powershell
+   .\trading_executor\setup-task.ps1 -PythonExe "$PWD\.venv-ibkr\Scripts\python.exe"
+   ```
+
+IBKR still requires human authentication after its weekend reset. The executor
+stops trading while the session is unavailable and the server-side monitor
+sends a Telegram alert.
+
+## Safety boundary
+
+- This build hard-refuses Live mode, non-localhost Gateway hosts, and ports other
+  than Paper port `4002`.
+- Every command is reconciled against account positions, open orders, and
+  executions before work starts.
+- Manual overlap in a target or strategy-owned ticker blocks the whole plan.
+- Empty targets never liquidate. Sells complete before buys. Quotes must contain
+  a fresh bid and ask, and every order passes IBKR WhatIf before any real order.
+- Orders are SMART, DAY, regular-hours-only, marketable limits. Unfilled orders
+  are cancelled and repriced at most three times; remaining quantity becomes a
+  partial plan for the next session.
+- Order references are deterministic by plan, symbol, side, revision, and
+  attempt. Server-side `PermId` and `ExecId` uniqueness protects callback replay.
+
+Run the broker-independent tests with:
+
+```powershell
+python -m unittest discover -s trading_executor\tests -v
+```

--- a/trading_executor/__init__.py
+++ b/trading_executor/__init__.py
@@ -1,3 +1,3 @@
 """IBKR Paper executor for Hedge in a Box."""
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/trading_executor/__init__.py
+++ b/trading_executor/__init__.py
@@ -1,3 +1,3 @@
 """IBKR Paper executor for Hedge in a Box."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/trading_executor/__init__.py
+++ b/trading_executor/__init__.py
@@ -1,0 +1,3 @@
+"""IBKR Paper executor for Hedge in a Box."""
+
+__version__ = "0.1.0"

--- a/trading_executor/__main__.py
+++ b/trading_executor/__main__.py
@@ -1,0 +1,3 @@
+from .executor import main
+
+raise SystemExit(main())

--- a/trading_executor/control_client.py
+++ b/trading_executor/control_client.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import secrets
+import time
+import urllib.error
+import urllib.request
+from typing import Any
+
+
+class ControlPlaneError(RuntimeError):
+    pass
+
+
+class ControlClient:
+    def __init__(self, base_url: str, connection_id: str = "", device_secret: str = "") -> None:
+        self.base_url = base_url.rstrip("/")
+        self.connection_id = connection_id
+        self.device_secret = device_secret
+
+    def pair(self, *, code: str, account_id: str, executor_version: str) -> dict[str, Any]:
+        return self._request("/api/trading/executor/pair", {
+            "code": code,
+            "account_id": account_id,
+            "mode": "paper",
+            "executor_version": executor_version,
+        }, signed=False)
+
+    def sync(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return self._request("/api/trading/executor/sync", payload, signed=True)
+
+    def event(self, payload: dict[str, Any]) -> dict[str, Any]:
+        return self._request("/api/trading/executor/events", payload, signed=True)
+
+    def _request(self, path: str, payload: dict[str, Any], *, signed: bool) -> dict[str, Any]:
+        body = json.dumps(payload, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+        headers = {"content-type": "application/json", "user-agent": "hib-ibkr-executor"}
+        if signed:
+            timestamp = str(int(time.time()))
+            nonce = secrets.token_urlsafe(18)
+            body_hash = hashlib.sha256(body).hexdigest()
+            signature_payload = f"{timestamp}\n{nonce}\n{body_hash}".encode("utf-8")
+            signature = hmac.new(self.device_secret.encode("utf-8"), signature_payload, hashlib.sha256).hexdigest()
+            headers.update({
+                "authorization": f"Bearer {self.device_secret}",
+                "x-trading-connection": self.connection_id,
+                "x-trading-timestamp": timestamp,
+                "x-trading-nonce": nonce,
+                "x-trading-signature": signature,
+            })
+        request = urllib.request.Request(self.base_url + path, data=body, headers=headers, method="POST")
+        try:
+            with urllib.request.urlopen(request, timeout=20) as response:
+                return json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as error:
+            details = error.read().decode("utf-8", errors="replace")
+            raise ControlPlaneError(f"control plane returned HTTP {error.code}: {details}") from error
+        except (urllib.error.URLError, TimeoutError) as error:
+            raise ControlPlaneError(f"control plane is unavailable: {error}") from error

--- a/trading_executor/control_client.py
+++ b/trading_executor/control_client.py
@@ -7,6 +7,7 @@ import secrets
 import time
 import urllib.error
 import urllib.request
+from urllib.parse import urlparse
 from typing import Any
 
 
@@ -17,6 +18,9 @@ class ControlPlaneError(RuntimeError):
 class ControlClient:
     def __init__(self, base_url: str, connection_id: str = "", device_secret: str = "") -> None:
         self.base_url = base_url.rstrip("/")
+        parsed = urlparse(self.base_url)
+        if parsed.scheme != "https" and parsed.hostname not in {"127.0.0.1", "localhost", "::1"}:
+            raise ValueError("the trading control plane must use HTTPS (HTTP is allowed only for localhost tests)")
         self.connection_id = connection_id
         self.device_secret = device_secret
 

--- a/trading_executor/dpapi_store.py
+++ b/trading_executor/dpapi_store.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import ctypes
+import json
+from ctypes import wintypes
+from pathlib import Path
+from typing import Any
+
+
+class DATA_BLOB(ctypes.Structure):
+    _fields_ = [("cbData", wintypes.DWORD), ("pbData", ctypes.POINTER(ctypes.c_byte))]
+
+
+def _blob(data: bytes) -> tuple[DATA_BLOB, ctypes.Array[ctypes.c_char]]:
+    buffer = ctypes.create_string_buffer(data)
+    return DATA_BLOB(len(data), ctypes.cast(buffer, ctypes.POINTER(ctypes.c_byte))), buffer
+
+
+def protect(data: bytes) -> bytes:
+    if not hasattr(ctypes, "windll"):
+        raise RuntimeError("Windows DPAPI is required for executor secrets.")
+    source, source_buffer = _blob(data)
+    output = DATA_BLOB()
+    if not ctypes.windll.crypt32.CryptProtectData(
+        ctypes.byref(source), "HedgeInABox IBKR Executor", None, None, None, 0, ctypes.byref(output)
+    ):
+        raise ctypes.WinError()
+    try:
+        return ctypes.string_at(output.pbData, output.cbData)
+    finally:
+        ctypes.windll.kernel32.LocalFree(output.pbData)
+        del source_buffer
+
+
+def unprotect(data: bytes) -> bytes:
+    if not hasattr(ctypes, "windll"):
+        raise RuntimeError("Windows DPAPI is required for executor secrets.")
+    source, source_buffer = _blob(data)
+    output = DATA_BLOB()
+    if not ctypes.windll.crypt32.CryptUnprotectData(
+        ctypes.byref(source), None, None, None, None, 0, ctypes.byref(output)
+    ):
+        raise ctypes.WinError()
+    try:
+        return ctypes.string_at(output.pbData, output.cbData)
+    finally:
+        ctypes.windll.kernel32.LocalFree(output.pbData)
+        del source_buffer
+
+
+class ConfigStore:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def save(self, payload: dict[str, Any]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        encrypted = protect(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+        self.path.write_bytes(encrypted)
+
+    def load(self) -> dict[str, Any]:
+        return json.loads(unprotect(self.path.read_bytes()).decode("utf-8"))

--- a/trading_executor/engine.py
+++ b/trading_executor/engine.py
@@ -8,12 +8,14 @@ from typing import Any, Protocol
 from zoneinfo import ZoneInfo
 
 from .policy import (
+    InsufficientTargetCoverageError,
     Instrument,
     OrderIntent,
     Position,
     Quote,
     Target,
     build_order_intents,
+    calculate_sizing_coverage,
     validate_position_ownership,
 )
 
@@ -22,12 +24,58 @@ NEW_YORK = ZoneInfo("America/New_York")
 
 
 @dataclass(frozen=True)
+class ExecutionFill:
+    exec_id: str
+    quantity: Decimal
+    price: Decimal
+    commission: Decimal = Decimal("0")
+    commission_currency: str = "USD"
+    executed_at: str = ""
+    raw_execution: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class BrokerOrder:
+    client_order_key: str
+    symbol: str
+    side: str
+    requested_quantity: Decimal
+    filled_quantity: Decimal
+    status: str
+    limit_price: Decimal
+    conid: int | None = None
+    average_fill_price: Decimal | None = None
+    ib_order_id: int | None = None
+    ib_perm_id: int | None = None
+
+
+@dataclass(frozen=True)
+class BrokerExecution:
+    client_order_key: str
+    symbol: str
+    side: str
+    conid: int | None
+    ib_order_id: int
+    ib_perm_id: int | None
+    fill: ExecutionFill
+
+
+@dataclass(frozen=True)
 class BrokerSnapshot:
     account_id: str
     positions: list[Position]
     settled_cash_usd: Decimal
-    open_order_refs: set[str]
-    execution_refs: set[str]
+    account_type: str = "UNKNOWN"
+    open_orders: tuple[BrokerOrder, ...] = ()
+    executions: tuple[BrokerExecution, ...] = ()
+
+    @property
+    def open_order_refs(self) -> set[str]:
+        return {order.client_order_key for order in self.open_orders}
+
+    @property
+    def execution_refs(self) -> set[str]:
+        return {execution.client_order_key for execution in self.executions}
 
 
 @dataclass(frozen=True)
@@ -40,10 +88,13 @@ class ExecutionResult:
     status: str
     limit_price: Decimal
     average_fill_price: Decimal | None = None
+    conid: int | None = None
     ib_order_id: int | None = None
     ib_perm_id: int | None = None
-    exec_id: str | None = None
     commission: Decimal = Decimal("0")
+    commission_currency: str = "USD"
+    fills: tuple[ExecutionFill, ...] = ()
+    recovered: bool = False
     error: str = ""
 
 
@@ -66,7 +117,7 @@ class Broker(Protocol):
 class Reporter(Protocol):
     def plan_status(self, plan_id: str, status: str, *, error: str = "", preflight: dict[str, Any] | None = None) -> None: ...
     def order(self, plan_id: str, result: ExecutionResult) -> str | None: ...
-    def fill(self, order_id: str | None, result: ExecutionResult) -> None: ...
+    def fill(self, order_id: str | None, result: ExecutionResult, fill: ExecutionFill) -> None: ...
     def positions(self, strategy_link_id: str, positions: list[Position]) -> None: ...
     def instrument(self, instrument: Instrument) -> None: ...
     def alert(self, event_type: str, severity: str, message: str, payload: dict[str, Any] | None = None) -> None: ...
@@ -130,13 +181,20 @@ class ExecutionEngine:
             self.reporter.plan_status(plan_id, "cancelled")
             return
         if not in_execution_window(now):
-            self.reporter.plan_status(plan_id, "awaiting_market", error="Waiting for the 10:00-15:30 New York execution window.")
+            waiting_status = "awaiting_settlement" if status == "awaiting_settlement" else "awaiting_market"
+            message = (
+                "Waiting for settled USD cash before the next buy phase."
+                if waiting_status == "awaiting_settlement"
+                else "Waiting for the 10:00-15:30 New York execution window."
+            )
+            self.reporter.plan_status(plan_id, waiting_status, error=message)
             return
         try:
             self._execute(command, now=now)
         except Exception as error:
             message = str(error)
-            self.reporter.plan_status(plan_id, "blocked", error=message)
+            preflight = error.preflight if isinstance(error, InsufficientTargetCoverageError) else None
+            self.reporter.plan_status(plan_id, "blocked", error=message, preflight=preflight)
             event_type = "rebalance_blocked"
             if "settled cash" in message:
                 event_type = "balance_anomaly"
@@ -174,6 +232,12 @@ class ExecutionEngine:
         quotes = self.broker.fresh_quotes(symbols)
         for instrument in instruments.values():
             self.reporter.instrument(instrument)
+        coverage = calculate_sizing_coverage(
+            budget_usd=_decimal(command["budget_usd"]), targets=targets,
+            quotes=quotes, instruments=instruments,
+        )
+        if not coverage.complete:
+            raise InsufficientTargetCoverageError(coverage)
         sells, buys = build_order_intents(
             budget_usd=_decimal(command["budget_usd"]),
             targets=targets,
@@ -183,14 +247,24 @@ class ExecutionEngine:
         )
         sell_proceeds = sum((intent.quantity * quotes[intent.symbol].bid for intent in sells), Decimal("0"))
         buy_cost = sum((intent.quantity * intent.limit_price for intent in buys), Decimal("0"))
-        if buy_cost > snapshot.settled_cash_usd + sell_proceeds:
-            raise ValueError("settled cash plus same-settlement sale proceeds is insufficient")
-        what_if_errors = self.broker.what_if(sells + buys)
+        has_prior_system_sells = any(
+            str(order.get("side")) == "SELL" and _decimal(order.get("filled_quantity", 0)) > 0
+            for order in command.get("existing_orders", [])
+        )
+        cash_shortfall = max(Decimal("0"), buy_cost - snapshot.settled_cash_usd)
+        what_if_intents = sells if sells and cash_shortfall > 0 else sells + buys
+        what_if_errors = self.broker.what_if(what_if_intents)
         if what_if_errors:
             raise ValueError("IBKR WhatIf failed: " + "; ".join(what_if_errors))
         preflight = {
             "account_match": True,
+            "account_type": snapshot.account_type,
             "manual_overlap": False,
+            "target_count": coverage.target_count,
+            "covered_target_count": coverage.covered_target_count,
+            "target_coverage": f"{coverage.covered_target_count}/{coverage.target_count}",
+            "minimum_budget_usd": str(coverage.minimum_budget_usd),
+            "uncovered_symbols": [],
             "instrument_count": len(instruments),
             "quote_count": len(quotes),
             "sell_count": len(sells),
@@ -198,7 +272,9 @@ class ExecutionEngine:
             "settled_cash_usd": str(snapshot.settled_cash_usd),
             "estimated_sell_proceeds_usd": str(sell_proceeds),
             "estimated_buy_cost_usd": str(buy_cost),
-            "what_if": "passed",
+            "settled_cash_shortfall_usd": str(cash_shortfall),
+            "same_day_sale_proceeds_counted": False,
+            "what_if": "sell_phase_passed_buy_phase_deferred" if what_if_intents == sells and buys else "passed",
         }
         self.reporter.plan_status(plan_id, "preflight", preflight=preflight)
         if not self.execution_enabled:
@@ -208,16 +284,38 @@ class ExecutionEngine:
             self.reporter.plan_status(plan_id, "selling", preflight=preflight)
             sell_results = self.broker.execute_phase(plan_id, sells, revision=revision, max_attempts=3)
             self._report_results(plan_id, sell_results)
-            if any(result.status != "filled" for result in sell_results):
+            if not self._phase_completed(sells, sell_results):
                 self._sync_owned(strategy_link_id, target_symbols, owned_positions)
                 self.reporter.plan_status(plan_id, "partial", error="Sell phase did not fully complete; buys were not submitted.")
                 self.reporter.alert("partial_rebalance", "warning", "Sell phase is partial; buys were not submitted.", {"plan_id": plan_id})
                 return
+            self._sync_owned(strategy_link_id, target_symbols, owned_positions)
+            snapshot = self.broker.reconcile()
+            preflight["settled_cash_after_sells_usd"] = str(snapshot.settled_cash_usd)
+            cash_shortfall = max(Decimal("0"), buy_cost - snapshot.settled_cash_usd)
+            preflight["settled_cash_shortfall_usd"] = str(cash_shortfall)
+        if buys and buy_cost > snapshot.settled_cash_usd:
+            if sells or has_prior_system_sells or str(command.get("status")) == "awaiting_settlement":
+                message = (
+                    "Sell phase completed, but purchases are waiting for IBKR settled USD cash; "
+                    "same-day sale proceeds are never counted."
+                )
+                self.reporter.plan_status(plan_id, "awaiting_settlement", error=message, preflight=preflight)
+                self.reporter.alert("awaiting_settlement", "warning", message, {"plan_id": plan_id})
+                return
+            raise ValueError(
+                f"settled cash is insufficient for purchases: required ${buy_cost}, "
+                f"available ${snapshot.settled_cash_usd}; margin borrowing is disabled"
+            )
         if buys:
+            buy_what_if_errors = self.broker.what_if(buys) if what_if_intents != sells + buys else []
+            if buy_what_if_errors:
+                raise ValueError("IBKR buy-phase WhatIf failed: " + "; ".join(buy_what_if_errors))
+            preflight["what_if"] = "passed"
             self.reporter.plan_status(plan_id, "buying", preflight=preflight)
             buy_results = self.broker.execute_phase(plan_id, buys, revision=revision, max_attempts=3)
             self._report_results(plan_id, buy_results)
-            if any(result.status != "filled" for result in buy_results):
+            if not self._phase_completed(buys, buy_results):
                 self._sync_owned(strategy_link_id, target_symbols, owned_positions)
                 self.reporter.plan_status(plan_id, "partial", error="Buy phase partially filled; remaining quantities will retry next session.")
                 self.reporter.alert("partial_rebalance", "warning", "Buy phase is partial; remaining quantity will retry next session.", {"plan_id": plan_id})
@@ -234,8 +332,8 @@ class ExecutionEngine:
     def _report_results(self, plan_id: str, results: list[ExecutionResult]) -> None:
         for result in results:
             order_id = self.reporter.order(plan_id, result)
-            if result.exec_id and result.filled_quantity > 0 and result.average_fill_price:
-                self.reporter.fill(order_id, result)
+            for fill in result.fills:
+                self.reporter.fill(order_id, result, fill)
             if result.status in {"rejected", "error"}:
                 self.reporter.alert(
                     "order_rejected",
@@ -243,3 +341,11 @@ class ExecutionEngine:
                     result.error or f"{result.side} {result.symbol} was rejected.",
                     {"plan_id": plan_id, "client_order_key": result.client_order_key},
                 )
+
+    @staticmethod
+    def _phase_completed(intents: list[OrderIntent], results: list[ExecutionResult]) -> bool:
+        requested = {intent.symbol: intent.quantity for intent in intents}
+        filled: dict[str, Decimal] = {}
+        for result in results:
+            filled[result.symbol] = filled.get(result.symbol, Decimal("0")) + result.filled_quantity
+        return all(filled.get(symbol, Decimal("0")) >= quantity for symbol, quantity in requested.items())

--- a/trading_executor/engine.py
+++ b/trading_executor/engine.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime, time
+from decimal import Decimal
+from typing import Any, Protocol
+from zoneinfo import ZoneInfo
+
+from .policy import (
+    Instrument,
+    OrderIntent,
+    Position,
+    Quote,
+    Target,
+    build_order_intents,
+    validate_position_ownership,
+)
+
+
+NEW_YORK = ZoneInfo("America/New_York")
+
+
+@dataclass(frozen=True)
+class BrokerSnapshot:
+    account_id: str
+    positions: list[Position]
+    settled_cash_usd: Decimal
+    open_order_refs: set[str]
+    execution_refs: set[str]
+
+
+@dataclass(frozen=True)
+class ExecutionResult:
+    client_order_key: str
+    symbol: str
+    side: str
+    requested_quantity: Decimal
+    filled_quantity: Decimal
+    status: str
+    limit_price: Decimal
+    average_fill_price: Decimal | None = None
+    ib_order_id: int | None = None
+    ib_perm_id: int | None = None
+    exec_id: str | None = None
+    commission: Decimal = Decimal("0")
+    error: str = ""
+
+
+class Broker(Protocol):
+    def reconcile(self) -> BrokerSnapshot: ...
+    def resolve_instruments(self, symbols: list[str]) -> dict[str, Instrument]: ...
+    def fresh_quotes(self, symbols: list[str]) -> dict[str, Quote]: ...
+    def what_if(self, intents: list[OrderIntent]) -> list[str]: ...
+    def execute_phase(
+        self,
+        plan_id: str,
+        intents: list[OrderIntent],
+        *,
+        revision: int,
+        max_attempts: int,
+    ) -> list[ExecutionResult]: ...
+    def cancel_plan_orders(self, plan_id: str) -> None: ...
+
+
+class Reporter(Protocol):
+    def plan_status(self, plan_id: str, status: str, *, error: str = "", preflight: dict[str, Any] | None = None) -> None: ...
+    def order(self, plan_id: str, result: ExecutionResult) -> str | None: ...
+    def fill(self, order_id: str | None, result: ExecutionResult) -> None: ...
+    def positions(self, strategy_link_id: str, positions: list[Position]) -> None: ...
+    def instrument(self, instrument: Instrument) -> None: ...
+    def alert(self, event_type: str, severity: str, message: str, payload: dict[str, Any] | None = None) -> None: ...
+
+
+def in_execution_window(now: datetime) -> bool:
+    local = now.astimezone(NEW_YORK)
+    return local.weekday() < 5 and time(10, 0) <= local.time().replace(tzinfo=None) <= time(15, 30)
+
+
+def instrument_session_is_open(instrument: Instrument, now: datetime) -> bool:
+    if not instrument.liquid_hours:
+        return instrument.approved
+    zone_name = {
+        "US/Eastern": "America/New_York",
+        "EST5EDT": "America/New_York",
+    }.get(instrument.time_zone, instrument.time_zone or "America/New_York")
+    local = now.astimezone(ZoneInfo(zone_name))
+    for segment in instrument.liquid_hours.split(";"):
+        if not segment or "CLOSED" in segment or "-" not in segment:
+            continue
+        start_raw, end_raw = segment.split("-", 1)
+        if ":" not in start_raw:
+            continue
+        start_date, start_time = start_raw.split(":", 1)
+        if ":" in end_raw:
+            end_date, end_time = end_raw.split(":", 1)
+        else:
+            end_date, end_time = start_date, end_raw
+        try:
+            start = datetime.strptime(start_date + start_time, "%Y%m%d%H%M").replace(tzinfo=local.tzinfo)
+            end = datetime.strptime(end_date + end_time, "%Y%m%d%H%M").replace(tzinfo=local.tzinfo)
+        except ValueError:
+            continue
+        if start <= local <= end:
+            return True
+    return False
+
+
+def _decimal(value: Any) -> Decimal:
+    return Decimal(str(value))
+
+
+def _event_id(plan_id: str, kind: str, message: str) -> str:
+    digest = hashlib.sha256(message.encode("utf-8")).hexdigest()[:12]
+    return f"{plan_id}:{kind}:{digest}"
+
+
+class ExecutionEngine:
+    def __init__(self, broker: Broker, reporter: Reporter, *, account_id: str, execution_enabled: bool) -> None:
+        self.broker = broker
+        self.reporter = reporter
+        self.account_id = account_id.upper()
+        self.execution_enabled = execution_enabled
+
+    def handle(self, command: dict[str, Any], *, now: datetime) -> None:
+        plan_id = str(command["plan_id"])
+        status = str(command["status"])
+        if status == "cancel_requested":
+            self.broker.cancel_plan_orders(plan_id)
+            self.reporter.plan_status(plan_id, "cancelled")
+            return
+        if not in_execution_window(now):
+            self.reporter.plan_status(plan_id, "awaiting_market", error="Waiting for the 10:00-15:30 New York execution window.")
+            return
+        try:
+            self._execute(command, now=now)
+        except Exception as error:
+            message = str(error)
+            self.reporter.plan_status(plan_id, "blocked", error=message)
+            event_type = "rebalance_blocked"
+            if "settled cash" in message:
+                event_type = "balance_anomaly"
+            elif "manual position" in message:
+                event_type = "manual_position_conflict"
+            self.reporter.alert(event_type, "critical", message, {"plan_id": plan_id})
+
+    def _execute(self, command: dict[str, Any], *, now: datetime) -> None:
+        plan_id = str(command["plan_id"])
+        strategy_link_id = str(command["strategy_link_id"])
+        if str(command.get("mode")) != "paper":
+            raise ValueError("executor refuses non-Paper commands")
+        targets = [
+            Target(symbol=str(row["ticker"]).upper(), weight=_decimal(row["weight"]))
+            for row in command.get("target_holdings", [])
+        ]
+        if not targets:
+            raise ValueError("empty targets require explicit liquidation approval")
+        owned_positions = [
+            Position(symbol=str(row["symbol"]).upper(), quantity=_decimal(row["quantity"]))
+            for row in command.get("owned_positions", [])
+        ]
+        snapshot = self.broker.reconcile()
+        if snapshot.account_id.upper() != self.account_id:
+            raise ValueError("IBKR account does not match paired account")
+        target_symbols = [target.symbol for target in targets]
+        conflicts = validate_position_ownership(snapshot.positions, owned_positions, target_symbols)
+        if conflicts:
+            raise ValueError(f"manual position overlap or drift: {', '.join(conflicts)}")
+        symbols = sorted(set(target_symbols) | {position.symbol for position in owned_positions})
+        instruments = self.broker.resolve_instruments(symbols)
+        closed = [symbol for symbol, instrument in instruments.items() if not instrument_session_is_open(instrument, now)]
+        if closed:
+            raise ValueError(f"regular trading session is closed or ambiguous: {', '.join(sorted(closed))}")
+        quotes = self.broker.fresh_quotes(symbols)
+        for instrument in instruments.values():
+            self.reporter.instrument(instrument)
+        sells, buys = build_order_intents(
+            budget_usd=_decimal(command["budget_usd"]),
+            targets=targets,
+            owned_positions=owned_positions,
+            quotes=quotes,
+            instruments=instruments,
+        )
+        sell_proceeds = sum((intent.quantity * quotes[intent.symbol].bid for intent in sells), Decimal("0"))
+        buy_cost = sum((intent.quantity * intent.limit_price for intent in buys), Decimal("0"))
+        if buy_cost > snapshot.settled_cash_usd + sell_proceeds:
+            raise ValueError("settled cash plus same-settlement sale proceeds is insufficient")
+        what_if_errors = self.broker.what_if(sells + buys)
+        if what_if_errors:
+            raise ValueError("IBKR WhatIf failed: " + "; ".join(what_if_errors))
+        preflight = {
+            "account_match": True,
+            "manual_overlap": False,
+            "instrument_count": len(instruments),
+            "quote_count": len(quotes),
+            "sell_count": len(sells),
+            "buy_count": len(buys),
+            "settled_cash_usd": str(snapshot.settled_cash_usd),
+            "estimated_sell_proceeds_usd": str(sell_proceeds),
+            "estimated_buy_cost_usd": str(buy_cost),
+            "what_if": "passed",
+        }
+        self.reporter.plan_status(plan_id, "preflight", preflight=preflight)
+        if not self.execution_enabled:
+            raise ValueError("local execution gate IBKR_EXECUTION_ENABLED is disabled")
+        revision = int(command.get("command_revision", 1))
+        if sells:
+            self.reporter.plan_status(plan_id, "selling", preflight=preflight)
+            sell_results = self.broker.execute_phase(plan_id, sells, revision=revision, max_attempts=3)
+            self._report_results(plan_id, sell_results)
+            if any(result.status != "filled" for result in sell_results):
+                self._sync_owned(strategy_link_id, target_symbols, owned_positions)
+                self.reporter.plan_status(plan_id, "partial", error="Sell phase did not fully complete; buys were not submitted.")
+                self.reporter.alert("partial_rebalance", "warning", "Sell phase is partial; buys were not submitted.", {"plan_id": plan_id})
+                return
+        if buys:
+            self.reporter.plan_status(plan_id, "buying", preflight=preflight)
+            buy_results = self.broker.execute_phase(plan_id, buys, revision=revision, max_attempts=3)
+            self._report_results(plan_id, buy_results)
+            if any(result.status != "filled" for result in buy_results):
+                self._sync_owned(strategy_link_id, target_symbols, owned_positions)
+                self.reporter.plan_status(plan_id, "partial", error="Buy phase partially filled; remaining quantities will retry next session.")
+                self.reporter.alert("partial_rebalance", "warning", "Buy phase is partial; remaining quantity will retry next session.", {"plan_id": plan_id})
+                return
+        self._sync_owned(strategy_link_id, target_symbols, owned_positions)
+        self.reporter.plan_status(plan_id, "completed", preflight=preflight)
+
+    def _sync_owned(self, strategy_link_id: str, target_symbols: list[str], owned_positions: list[Position]) -> None:
+        final_snapshot = self.broker.reconcile()
+        relevant = set(target_symbols) | {item.symbol for item in owned_positions}
+        final_owned = [position for position in final_snapshot.positions if position.symbol in relevant]
+        self.reporter.positions(strategy_link_id, final_owned)
+
+    def _report_results(self, plan_id: str, results: list[ExecutionResult]) -> None:
+        for result in results:
+            order_id = self.reporter.order(plan_id, result)
+            if result.exec_id and result.filled_quantity > 0 and result.average_fill_price:
+                self.reporter.fill(order_id, result)
+            if result.status in {"rejected", "error"}:
+                self.reporter.alert(
+                    "order_rejected",
+                    "critical",
+                    result.error or f"{result.side} {result.symbol} was rejected.",
+                    {"plan_id": plan_id, "client_order_key": result.client_order_key},
+                )

--- a/trading_executor/engine.py
+++ b/trading_executor/engine.py
@@ -118,7 +118,6 @@ class Reporter(Protocol):
     def plan_status(self, plan_id: str, status: str, *, error: str = "", preflight: dict[str, Any] | None = None) -> None: ...
     def order(self, plan_id: str, result: ExecutionResult) -> str | None: ...
     def fill(self, order_id: str | None, result: ExecutionResult, fill: ExecutionFill) -> None: ...
-    def positions(self, strategy_link_id: str, positions: list[Position]) -> None: ...
     def instrument(self, instrument: Instrument) -> None: ...
     def alert(self, event_type: str, severity: str, message: str, payload: dict[str, Any] | None = None) -> None: ...
 
@@ -166,6 +165,14 @@ def _event_id(plan_id: str, kind: str, message: str) -> str:
     return f"{plan_id}:{kind}:{digest}"
 
 
+class MarketUnavailableError(RuntimeError):
+    pass
+
+
+class ExecutionCancelledError(RuntimeError):
+    pass
+
+
 class ExecutionEngine:
     def __init__(self, broker: Broker, reporter: Reporter, *, account_id: str, execution_enabled: bool) -> None:
         self.broker = broker
@@ -191,6 +198,13 @@ class ExecutionEngine:
             return
         try:
             self._execute(command, now=now)
+        except ExecutionCancelledError:
+            self.broker.cancel_plan_orders(plan_id)
+            self.reporter.plan_status(plan_id, "cancelled", error="Execution stopped by the remote kill switch.")
+        except MarketUnavailableError as error:
+            message = str(error)
+            self.reporter.plan_status(plan_id, "awaiting_market", error=message)
+            self.reporter.alert("awaiting_market", "warning", message, {"plan_id": plan_id})
         except Exception as error:
             message = str(error)
             preflight = error.preflight if isinstance(error, InsufficientTargetCoverageError) else None
@@ -198,13 +212,12 @@ class ExecutionEngine:
             event_type = "rebalance_blocked"
             if "settled cash" in message:
                 event_type = "balance_anomaly"
-            elif "manual position" in message:
+            elif "manual position" in message or "manual open order" in message:
                 event_type = "manual_position_conflict"
             self.reporter.alert(event_type, "critical", message, {"plan_id": plan_id})
 
     def _execute(self, command: dict[str, Any], *, now: datetime) -> None:
         plan_id = str(command["plan_id"])
-        strategy_link_id = str(command["strategy_link_id"])
         if str(command.get("mode")) != "paper":
             raise ValueError("executor refuses non-Paper commands")
         targets = [
@@ -225,21 +238,37 @@ class ExecutionEngine:
         if conflicts:
             raise ValueError(f"manual position overlap or drift: {', '.join(conflicts)}")
         symbols = sorted(set(target_symbols) | {position.symbol for position in owned_positions})
+        manual_open_orders = sorted({
+            order.symbol for order in snapshot.open_orders
+            if order.symbol in symbols and not order.client_order_key.startswith("hib:")
+        })
+        if manual_open_orders:
+            raise ValueError(f"manual open order overlap: {', '.join(manual_open_orders)}")
         instruments = self.broker.resolve_instruments(symbols)
         closed = [symbol for symbol, instrument in instruments.items() if not instrument_session_is_open(instrument, now)]
         if closed:
-            raise ValueError(f"regular trading session is closed or ambiguous: {', '.join(sorted(closed))}")
+            raise MarketUnavailableError(
+                f"regular trading session is closed or ambiguous: {', '.join(sorted(closed))}"
+            )
         quotes = self.broker.fresh_quotes(symbols)
         for instrument in instruments.values():
             self.reporter.instrument(instrument)
+        configured_budget = _decimal(command["budget_usd"])
+        strategy_cash = max(Decimal("0"), _decimal(command.get("strategy_cash_usd", configured_budget)))
+        owned_market_value = sum(
+            (position.quantity * quotes[position.symbol].bid for position in owned_positions),
+            Decimal("0"),
+        )
+        strategy_equity = strategy_cash + owned_market_value
+        capital_base = min(configured_budget, max(Decimal("0"), strategy_equity))
         coverage = calculate_sizing_coverage(
-            budget_usd=_decimal(command["budget_usd"]), targets=targets,
+            budget_usd=capital_base, targets=targets,
             quotes=quotes, instruments=instruments,
         )
         if not coverage.complete:
             raise InsufficientTargetCoverageError(coverage)
         sells, buys = build_order_intents(
-            budget_usd=_decimal(command["budget_usd"]),
+            budget_usd=capital_base,
             targets=targets,
             owned_positions=owned_positions,
             quotes=quotes,
@@ -251,8 +280,9 @@ class ExecutionEngine:
             str(order.get("side")) == "SELL" and _decimal(order.get("filled_quantity", 0)) > 0
             for order in command.get("existing_orders", [])
         )
-        cash_shortfall = max(Decimal("0"), buy_cost - snapshot.settled_cash_usd)
-        what_if_intents = sells if sells and cash_shortfall > 0 else sells + buys
+        broker_cash_shortfall = max(Decimal("0"), buy_cost - snapshot.settled_cash_usd)
+        strategy_cash_shortfall = max(Decimal("0"), buy_cost - strategy_cash)
+        what_if_intents = sells if sells and (broker_cash_shortfall > 0 or strategy_cash_shortfall > 0) else sells + buys
         what_if_errors = self.broker.what_if(what_if_intents)
         if what_if_errors:
             raise ValueError("IBKR WhatIf failed: " + "; ".join(what_if_errors))
@@ -270,9 +300,13 @@ class ExecutionEngine:
             "sell_count": len(sells),
             "buy_count": len(buys),
             "settled_cash_usd": str(snapshot.settled_cash_usd),
+            "strategy_cash_usd": str(strategy_cash),
+            "strategy_equity_usd": str(strategy_equity),
+            "capital_base_usd": str(capital_base),
             "estimated_sell_proceeds_usd": str(sell_proceeds),
             "estimated_buy_cost_usd": str(buy_cost),
-            "settled_cash_shortfall_usd": str(cash_shortfall),
+            "settled_cash_shortfall_usd": str(broker_cash_shortfall),
+            "strategy_cash_shortfall_usd": str(strategy_cash_shortfall),
             "same_day_sale_proceeds_counted": False,
             "what_if": "sell_phase_passed_buy_phase_deferred" if what_if_intents == sells and buys else "passed",
         }
@@ -285,15 +319,29 @@ class ExecutionEngine:
             sell_results = self.broker.execute_phase(plan_id, sells, revision=revision, max_attempts=3)
             self._report_results(plan_id, sell_results)
             if not self._phase_completed(sells, sell_results):
-                self._sync_owned(strategy_link_id, target_symbols, owned_positions)
                 self.reporter.plan_status(plan_id, "partial", error="Sell phase did not fully complete; buys were not submitted.")
                 self.reporter.alert("partial_rebalance", "warning", "Sell phase is partial; buys were not submitted.", {"plan_id": plan_id})
                 return
-            self._sync_owned(strategy_link_id, target_symbols, owned_positions)
+            strategy_cash += sum(
+                (
+                    fill.quantity * fill.price - fill.commission
+                    for result in sell_results
+                    for fill in result.fills
+                ),
+                Decimal("0"),
+            )
             snapshot = self.broker.reconcile()
             preflight["settled_cash_after_sells_usd"] = str(snapshot.settled_cash_usd)
-            cash_shortfall = max(Decimal("0"), buy_cost - snapshot.settled_cash_usd)
-            preflight["settled_cash_shortfall_usd"] = str(cash_shortfall)
+            preflight["strategy_cash_after_sells_usd"] = str(strategy_cash)
+            broker_cash_shortfall = max(Decimal("0"), buy_cost - snapshot.settled_cash_usd)
+            strategy_cash_shortfall = max(Decimal("0"), buy_cost - strategy_cash)
+            preflight["settled_cash_shortfall_usd"] = str(broker_cash_shortfall)
+            preflight["strategy_cash_shortfall_usd"] = str(strategy_cash_shortfall)
+        if buys and buy_cost > strategy_cash:
+            raise ValueError(
+                f"strategy-owned cash is insufficient for purchases: required ${buy_cost}, "
+                f"available ${strategy_cash}; unrelated account cash cannot top up this strategy"
+            )
         if buys and buy_cost > snapshot.settled_cash_usd:
             if sells or has_prior_system_sells or str(command.get("status")) == "awaiting_settlement":
                 message = (
@@ -316,18 +364,10 @@ class ExecutionEngine:
             buy_results = self.broker.execute_phase(plan_id, buys, revision=revision, max_attempts=3)
             self._report_results(plan_id, buy_results)
             if not self._phase_completed(buys, buy_results):
-                self._sync_owned(strategy_link_id, target_symbols, owned_positions)
                 self.reporter.plan_status(plan_id, "partial", error="Buy phase partially filled; remaining quantities will retry next session.")
                 self.reporter.alert("partial_rebalance", "warning", "Buy phase is partial; remaining quantity will retry next session.", {"plan_id": plan_id})
                 return
-        self._sync_owned(strategy_link_id, target_symbols, owned_positions)
         self.reporter.plan_status(plan_id, "completed", preflight=preflight)
-
-    def _sync_owned(self, strategy_link_id: str, target_symbols: list[str], owned_positions: list[Position]) -> None:
-        final_snapshot = self.broker.reconcile()
-        relevant = set(target_symbols) | {item.symbol for item in owned_positions}
-        final_owned = [position for position in final_snapshot.positions if position.symbol in relevant]
-        self.reporter.positions(strategy_link_id, final_owned)
 
     def _report_results(self, plan_id: str, results: list[ExecutionResult]) -> None:
         for result in results:

--- a/trading_executor/executor.py
+++ b/trading_executor/executor.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import argparse
+import os
+import signal
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+from . import __version__
+from .control_client import ControlClient, ControlPlaneError
+from .dpapi_store import ConfigStore
+from .engine import ExecutionEngine
+from .reporter import ControlReporter
+
+
+DEFAULT_CONFIG = Path(os.environ.get("LOCALAPPDATA", ".")) / "HedgeInABox" / "ibkr-executor.dpapi"
+
+
+def pair(args: argparse.Namespace) -> int:
+    account_id = args.account.strip().upper()
+    if not account_id or args.mode != "paper":
+        raise SystemExit("Only a non-empty IBKR Paper account may be paired in v1.")
+    client = ControlClient(args.site)
+    response = client.pair(code=args.code, account_id=account_id, executor_version=__version__)
+    ConfigStore(args.config).save({
+        "site": args.site.rstrip("/"),
+        "connection_id": response["connection_id"],
+        "device_secret": response["device_secret"],
+        "account_id": account_id,
+        "mode": "paper",
+    })
+    print(f"Paired {response['account_masked']} in Paper mode. Secret saved with Windows DPAPI at {args.config}.")
+    return 0
+
+
+def run(args: argparse.Namespace) -> int:
+    config = ConfigStore(args.config).load()
+    if config.get("mode") != "paper":
+        raise SystemExit("This executor build refuses Live connections.")
+    if args.host not in {"127.0.0.1", "localhost"}:
+        raise SystemExit("IB Gateway host must be localhost; never expose the socket to a network.")
+    if args.port != 4002:
+        raise SystemExit("Paper mode requires IB Gateway port 4002.")
+    from .ib_gateway import IbGateway
+
+    client = ControlClient(config["site"], config["connection_id"], config["device_secret"])
+    reporter = ControlReporter(client)
+    gateway = IbGateway(
+        host=args.host, port=args.port, client_id=args.client_id,
+        expected_account=config["account_id"],
+    )
+    engine = ExecutionEngine(
+        gateway, reporter, account_id=config["account_id"],
+        execution_enabled=os.environ.get("IBKR_EXECUTION_ENABLED", "").lower() in {"1", "true", "yes", "on"},
+    )
+    stopping = False
+
+    def stop(_signum: int, _frame: object) -> None:
+        nonlocal stopping
+        stopping = True
+
+    signal.signal(signal.SIGINT, stop)
+    signal.signal(signal.SIGTERM, stop)
+    try:
+        while not stopping:
+            gateway_ready = False
+            gateway_error = ""
+            try:
+                gateway.connect_and_start()
+                gateway.reconcile()
+                gateway_ready = True
+            except Exception as error:
+                gateway_error = str(error)
+                gateway.close()
+            try:
+                response = client.sync({
+                    "account_id": config["account_id"], "mode": "paper",
+                    "executor_version": __version__, "gateway_connected": gateway_ready,
+                    "gateway_authenticated": gateway_ready, "error": gateway_error,
+                })
+                if gateway_ready:
+                    for command in response.get("commands", []):
+                        engine.handle(command, now=datetime.now(timezone.utc))
+            except ControlPlaneError as error:
+                print(f"[{datetime.now(timezone.utc).isoformat()}] {error}", file=sys.stderr)
+            deadline = time.monotonic() + args.poll_seconds
+            while not stopping and time.monotonic() < deadline:
+                time.sleep(min(1, max(0, deadline - time.monotonic())))
+    finally:
+        gateway.close()
+    return 0
+
+
+def status(args: argparse.Namespace) -> int:
+    config = ConfigStore(args.config).load()
+    print(f"Site: {config['site']}")
+    print(f"Connection: {config['connection_id']}")
+    print(f"Account: {config['account_id'][0]}***{config['account_id'][-4:]}")
+    print(f"Mode: {config['mode']}")
+    return 0
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description="Hedge in a Box IBKR Paper executor")
+    result.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    subparsers = result.add_subparsers(dest="command", required=True)
+    pair_parser = subparsers.add_parser("pair")
+    pair_parser.add_argument("--site", default="https://hedge-in-a-box.com")
+    pair_parser.add_argument("--code", required=True)
+    pair_parser.add_argument("--account", required=True)
+    pair_parser.add_argument("--mode", default="paper", choices=["paper"])
+    pair_parser.set_defaults(handler=pair)
+    run_parser = subparsers.add_parser("run")
+    run_parser.add_argument("--host", default="127.0.0.1")
+    run_parser.add_argument("--port", type=int, default=4002)
+    run_parser.add_argument("--client-id", type=int, default=71)
+    run_parser.add_argument("--poll-seconds", type=int, default=30)
+    run_parser.set_defaults(handler=run)
+    status_parser = subparsers.add_parser("status")
+    status_parser.set_defaults(handler=status)
+    return result
+
+
+def main() -> int:
+    args = parser().parse_args()
+    return int(args.handler(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/trading_executor/executor.py
+++ b/trading_executor/executor.py
@@ -69,7 +69,8 @@ def run(args: argparse.Namespace) -> int:
             gateway_error = ""
             try:
                 gateway.connect_and_start()
-                gateway.reconcile()
+                snapshot = gateway.reconcile()
+                reporter.recover(snapshot)
                 gateway_ready = True
             except Exception as error:
                 gateway_error = str(error)
@@ -78,7 +79,9 @@ def run(args: argparse.Namespace) -> int:
                 response = client.sync({
                     "account_id": config["account_id"], "mode": "paper",
                     "executor_version": __version__, "gateway_connected": gateway_ready,
-                    "gateway_authenticated": gateway_ready, "error": gateway_error,
+                    "gateway_authenticated": gateway_ready,
+                    "account_type": snapshot.account_type if gateway_ready else "UNKNOWN",
+                    "error": gateway_error,
                 })
                 if gateway_ready:
                     for command in response.get("commands", []):

--- a/trading_executor/executor.py
+++ b/trading_executor/executor.py
@@ -7,15 +7,20 @@ import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
+from uuid import uuid4
 
 from . import __version__
 from .control_client import ControlClient, ControlPlaneError
 from .dpapi_store import ConfigStore
-from .engine import ExecutionEngine
+from .engine import ExecutionCancelledError, ExecutionEngine
+from .instance_lock import SingleInstanceLock
+from .journal import LocalJournal
 from .reporter import ControlReporter
 
 
 DEFAULT_CONFIG = Path(os.environ.get("LOCALAPPDATA", ".")) / "HedgeInABox" / "ibkr-executor.dpapi"
+DEFAULT_STATE_DIR = Path(os.environ.get("LOCALAPPDATA", ".")) / "HedgeInABox"
+DEFAULT_LOCK = Path(os.environ.get("LOCALAPPDATA", ".")) / "HedgeInABox" / "ibkr-executor.lock"
 
 
 def pair(args: argparse.Namespace) -> int:
@@ -30,13 +35,18 @@ def pair(args: argparse.Namespace) -> int:
         "device_secret": response["device_secret"],
         "account_id": account_id,
         "mode": "paper",
+        "executor_instance_id": str(uuid4()),
     })
     print(f"Paired {response['account_masked']} in Paper mode. Secret saved with Windows DPAPI at {args.config}.")
     return 0
 
 
 def run(args: argparse.Namespace) -> int:
-    config = ConfigStore(args.config).load()
+    store = ConfigStore(args.config)
+    config = store.load()
+    if not config.get("executor_instance_id"):
+        config["executor_instance_id"] = str(uuid4())
+        store.save(config)
     if config.get("mode") != "paper":
         raise SystemExit("This executor build refuses Live connections.")
     if args.host not in {"127.0.0.1", "localhost"}:
@@ -45,11 +55,36 @@ def run(args: argparse.Namespace) -> int:
         raise SystemExit("Paper mode requires IB Gateway port 4002.")
     from .ib_gateway import IbGateway
 
+    instance_lock = SingleInstanceLock(args.lock)
+    instance_lock.__enter__()
+    journal_path = args.journal or DEFAULT_STATE_DIR / f"ibkr-executor-{config['connection_id']}.sqlite3"
+    journal = LocalJournal(journal_path)
     client = ControlClient(config["site"], config["connection_id"], config["device_secret"])
-    reporter = ControlReporter(client)
+    reporter = ControlReporter(client, journal)
+    lease_payload = {
+        "account_id": config["account_id"], "mode": "paper",
+        "executor_version": __version__, "gateway_connected": False,
+        "gateway_authenticated": False, "account_type": "UNKNOWN",
+        "error": "", "executor_instance_id": config["executor_instance_id"],
+        "lease_only": True,
+    }
+    try:
+        client.sync(lease_payload)
+    except ControlPlaneError as error:
+        journal.close()
+        instance_lock.__exit__(None, None, None)
+        raise SystemExit(f"Could not acquire the server executor lease before connecting to IB Gateway: {error}") from error
+
+    def submission_guard(plan_id: str) -> None:
+        response = client.sync(lease_payload)
+        cancelled = {str(value) for value in response.get("cancel_requested_plan_ids", [])}
+        if plan_id in cancelled:
+            raise ExecutionCancelledError("remote kill switch requested cancellation")
+
     gateway = IbGateway(
         host=args.host, port=args.port, client_id=args.client_id,
-        expected_account=config["account_id"],
+        expected_account=config["account_id"], journal=journal,
+        submission_guard=submission_guard,
     )
     engine = ExecutionEngine(
         gateway, reporter, account_id=config["account_id"],
@@ -76,12 +111,14 @@ def run(args: argparse.Namespace) -> int:
                 gateway_error = str(error)
                 gateway.close()
             try:
+                reporter.flush()
                 response = client.sync({
                     "account_id": config["account_id"], "mode": "paper",
                     "executor_version": __version__, "gateway_connected": gateway_ready,
                     "gateway_authenticated": gateway_ready,
                     "account_type": snapshot.account_type if gateway_ready else "UNKNOWN",
                     "error": gateway_error,
+                    "executor_instance_id": config["executor_instance_id"],
                 })
                 if gateway_ready:
                     for command in response.get("commands", []):
@@ -93,6 +130,8 @@ def run(args: argparse.Namespace) -> int:
                 time.sleep(min(1, max(0, deadline - time.monotonic())))
     finally:
         gateway.close()
+        journal.close()
+        instance_lock.__exit__(None, None, None)
     return 0
 
 
@@ -120,6 +159,8 @@ def parser() -> argparse.ArgumentParser:
     run_parser.add_argument("--port", type=int, default=4002)
     run_parser.add_argument("--client-id", type=int, default=71)
     run_parser.add_argument("--poll-seconds", type=int, default=30)
+    run_parser.add_argument("--journal", type=Path)
+    run_parser.add_argument("--lock", type=Path, default=DEFAULT_LOCK)
     run_parser.set_defaults(handler=run)
     status_parser = subparsers.add_parser("status")
     status_parser.set_defaults(handler=status)

--- a/trading_executor/ib_gateway.py
+++ b/trading_executor/ib_gateway.py
@@ -1,0 +1,393 @@
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import replace
+from decimal import Decimal
+from typing import Any
+
+try:
+    from ibapi.client import EClient
+    from ibapi.contract import Contract
+    from ibapi.execution import ExecutionFilter
+    from ibapi.order import Order
+    from ibapi.wrapper import EWrapper
+except ImportError as error:  # pragma: no cover - depends on the official IBKR install
+    raise RuntimeError(
+        "Install ibapi from the TWS API package matching the installed IB Gateway version. "
+        "Do not use an unversioned third-party PyPI copy."
+    ) from error
+
+from .engine import BrokerSnapshot, ExecutionResult
+from .policy import Instrument, OrderIntent, Position, Quote, marketable_limit
+
+
+class IbGateway(EWrapper, EClient):
+    def __init__(self, *, host: str, port: int, client_id: int, expected_account: str) -> None:
+        EWrapper.__init__(self)
+        EClient.__init__(self, self)
+        self.host = host
+        self.port = port
+        self.client_id = client_id
+        self.expected_account = expected_account.upper()
+        self._thread: threading.Thread | None = None
+        self._lock = threading.RLock()
+        self._request_id = 10_000
+        self._next_order_id: int | None = None
+        self._managed_accounts: list[str] = []
+        self._positions: list[Position] = []
+        self._settled_cash = Decimal("0")
+        self._open_orders: dict[int, dict[str, Any]] = {}
+        self._executions: dict[str, dict[str, Any]] = {}
+        self._order_status: dict[int, dict[str, Any]] = {}
+        self._commissions: dict[str, Decimal] = {}
+        self._contracts: dict[int, list[Any]] = {}
+        self._quotes: dict[int, dict[str, Any]] = {}
+        self._what_if: dict[int, Any] = {}
+        self._errors: dict[int, list[str]] = {}
+        self._events = {name: threading.Event() for name in (
+            "ready", "positions", "orders", "executions", "account",
+        )}
+        self._request_events: dict[int, threading.Event] = {}
+
+    def connect_and_start(self, timeout: float = 15) -> None:
+        if self.isConnected():
+            return
+        self.connect(self.host, self.port, self.client_id)
+        self._thread = threading.Thread(target=self.run, name="ibapi-network", daemon=True)
+        self._thread.start()
+        if not self._events["ready"].wait(timeout):
+            self.disconnect()
+            raise RuntimeError("IB Gateway did not provide nextValidId and managed account in time")
+        if self.expected_account not in self._managed_accounts:
+            self.disconnect()
+            raise RuntimeError("IB Gateway is authenticated to a different account")
+
+    def close(self) -> None:
+        if self.isConnected():
+            self.disconnect()
+
+    def nextValidId(self, orderId: int) -> None:  # noqa: N802
+        with self._lock:
+            self._next_order_id = max(orderId, self._next_order_id or orderId)
+        if self._managed_accounts:
+            self._events["ready"].set()
+
+    def managedAccounts(self, accountsList: str) -> None:  # noqa: N802
+        self._managed_accounts = [item.strip().upper() for item in accountsList.split(",") if item.strip()]
+        if self._next_order_id is not None:
+            self._events["ready"].set()
+
+    def error(self, reqId: int, errorCode: int, errorString: str, advancedOrderRejectJson: str = "") -> None:  # noqa: N802
+        if errorCode in {2104, 2106, 2107, 2108, 2158}:
+            return
+        details = f"{errorCode}: {errorString}"
+        if advancedOrderRejectJson:
+            details += f" ({advancedOrderRejectJson})"
+        with self._lock:
+            self._errors.setdefault(reqId, []).append(details)
+        event = self._request_events.get(reqId)
+        if event and errorCode not in {2103, 2105, 2110}:
+            event.set()
+
+    def position(self, account: str, contract: Any, position: Decimal, avgCost: float) -> None:
+        if account.upper() == self.expected_account and str(contract.secType) == "STK":
+            self._positions.append(Position(str(contract.symbol).upper(), Decimal(str(position))))
+
+    def positionEnd(self) -> None:  # noqa: N802
+        self._events["positions"].set()
+
+    def openOrder(self, orderId: int, contract: Any, order: Any, orderState: Any) -> None:  # noqa: N802
+        order_ref = str(getattr(order, "orderRef", "") or "")
+        self._open_orders[orderId] = {"ref": order_ref, "contract": contract, "order": order, "state": orderState}
+        if bool(getattr(order, "whatIf", False)):
+            self._what_if[orderId] = orderState
+            event = self._request_events.get(orderId)
+            if event:
+                event.set()
+
+    def openOrderEnd(self) -> None:  # noqa: N802
+        self._events["orders"].set()
+
+    def orderStatus(  # noqa: N802
+        self, orderId: int, status: str, filled: Decimal, remaining: Decimal,
+        avgFillPrice: float, permId: int, parentId: int, lastFillPrice: float,
+        clientId: int, whyHeld: str, mktCapPrice: float,
+    ) -> None:
+        self._order_status[orderId] = {
+            "status": status, "filled": Decimal(str(filled)), "remaining": Decimal(str(remaining)),
+            "average_fill_price": Decimal(str(avgFillPrice)), "perm_id": permId,
+        }
+
+    def execDetails(self, reqId: int, contract: Any, execution: Any) -> None:  # noqa: N802
+        self._executions[str(execution.execId)] = {
+            "req_id": reqId, "order_id": int(execution.orderId), "perm_id": int(execution.permId),
+            "ref": str(getattr(execution, "orderRef", "") or ""), "symbol": str(contract.symbol).upper(),
+            "shares": Decimal(str(execution.shares)), "price": Decimal(str(execution.price)),
+        }
+
+    def execDetailsEnd(self, reqId: int) -> None:  # noqa: N802
+        event = self._request_events.get(reqId)
+        if event:
+            event.set()
+        self._events["executions"].set()
+
+    def commissionReport(self, commissionReport: Any) -> None:  # noqa: N802
+        self._commissions[str(commissionReport.execId)] = Decimal(str(commissionReport.commission))
+
+    def accountSummary(self, reqId: int, account: str, tag: str, value: str, currency: str) -> None:  # noqa: N802
+        if account.upper() == self.expected_account and tag == "SettledCash" and currency == "USD":
+            self._settled_cash = Decimal(value)
+
+    def accountSummaryEnd(self, reqId: int) -> None:  # noqa: N802
+        event = self._request_events.get(reqId)
+        if event:
+            event.set()
+        self._events["account"].set()
+
+    def contractDetails(self, reqId: int, contractDetails: Any) -> None:  # noqa: N802
+        self._contracts.setdefault(reqId, []).append(contractDetails)
+
+    def contractDetailsEnd(self, reqId: int) -> None:  # noqa: N802
+        event = self._request_events.get(reqId)
+        if event:
+            event.set()
+
+    def tickPrice(self, reqId: int, tickType: int, price: float, attrib: Any) -> None:  # noqa: N802
+        if price <= 0:
+            return
+        quote = self._quotes.setdefault(reqId, {"received": time.monotonic()})
+        if tickType == 1:
+            quote["bid"] = Decimal(str(price))
+        elif tickType == 2:
+            quote["ask"] = Decimal(str(price))
+        quote["received"] = time.monotonic()
+        if "bid" in quote and "ask" in quote:
+            event = self._request_events.get(reqId)
+            if event:
+                event.set()
+
+    def tickSnapshotEnd(self, reqId: int) -> None:  # noqa: N802
+        event = self._request_events.get(reqId)
+        if event:
+            event.set()
+
+    def reconcile(self) -> BrokerSnapshot:
+        self.connect_and_start()
+        for event in ("positions", "orders", "executions", "account"):
+            self._events[event].clear()
+        self._positions = []
+        self._open_orders = {}
+        self._executions = {}
+        self._settled_cash = Decimal("0")
+        execution_request = self._new_request()
+        account_request = self._new_request()
+        self.reqPositions()
+        self.reqOpenOrders()
+        self.reqExecutions(execution_request, ExecutionFilter())
+        self.reqAccountSummary(account_request, "All", "SettledCash")
+        self._wait(self._events["positions"], 15, "positions reconciliation")
+        self._wait(self._events["orders"], 15, "open-order reconciliation")
+        self._wait(self._events["executions"], 15, "execution reconciliation")
+        self._wait(self._events["account"], 15, "account reconciliation")
+        self.cancelAccountSummary(account_request)
+        return BrokerSnapshot(
+            account_id=self.expected_account,
+            positions=list(self._positions),
+            settled_cash_usd=self._settled_cash,
+            open_order_refs={str(item["ref"]) for item in self._open_orders.values() if item["ref"]},
+            execution_refs={str(item["ref"]) for item in self._executions.values() if item["ref"]},
+        )
+
+    def resolve_instruments(self, symbols: list[str]) -> dict[str, Instrument]:
+        resolved: dict[str, Instrument] = {}
+        for symbol in symbols:
+            request_id = self._new_request()
+            contract = Contract()
+            contract.symbol = symbol
+            contract.secType = "STK"
+            contract.exchange = "SMART"
+            contract.currency = "USD"
+            self.reqContractDetails(request_id, contract)
+            self._wait_request(request_id, 15, f"contract details for {symbol}")
+            matches = [
+                item for item in self._contracts.get(request_id, [])
+                if str(item.contract.symbol).upper() == symbol and str(item.contract.currency) == "USD"
+                and str(getattr(item.contract, "primaryExchange", "") or "")
+            ]
+            if len(matches) != 1:
+                raise RuntimeError(f"contract mapping for {symbol} is not unique")
+            details = matches[0]
+            increment = Decimal(str(getattr(details, "sizeIncrement", 1) or 1))
+            liquid_hours = str(getattr(details, "liquidHours", "") or "")
+            time_zone = str(getattr(details, "timeZoneId", "") or "")
+            resolved[symbol] = Instrument(
+                symbol=symbol, conid=int(details.contract.conId), currency="USD",
+                primary_exchange=str(details.contract.primaryExchange),
+                min_tick=Decimal(str(details.minTick)), size_increment=increment,
+                supports_fractional=False, approved=bool(liquid_hours and time_zone),
+                exchange="SMART",
+                min_size=Decimal(str(getattr(details, "minSize", 1) or 1)),
+                liquid_hours=liquid_hours,
+                time_zone=time_zone,
+            )
+        return resolved
+
+    def fresh_quotes(self, symbols: list[str]) -> dict[str, Quote]:
+        quotes: dict[str, Quote] = {}
+        instruments = self.resolve_instruments(symbols)
+        for symbol in symbols:
+            request_id = self._new_request()
+            contract = self._contract(instruments[symbol])
+            self.reqMktData(request_id, contract, "", True, False, [])
+            self._wait_request(request_id, 12, f"NBBO for {symbol}")
+            raw = self._quotes.get(request_id, {})
+            if "bid" not in raw or "ask" not in raw:
+                raise RuntimeError(f"fresh NBBO unavailable for {symbol}")
+            quotes[symbol] = Quote(symbol, raw["bid"], raw["ask"], time.monotonic() - raw["received"])
+        return quotes
+
+    def what_if(self, intents: list[OrderIntent]) -> list[str]:
+        failures: list[str] = []
+        for intent in intents:
+            order_id = self._take_order_id()
+            order = self._order(intent, f"hib-whatif:{order_id}")
+            order.whatIf = True
+            self.placeOrder(order_id, self._contract_from_intent(intent), order)
+            self._wait_request(order_id, 15, f"WhatIf {intent.symbol}", allow_errors=True)
+            errors = self._errors.pop(order_id, [])
+            state = self._what_if.pop(order_id, None)
+            warning = str(getattr(state, "warningText", "") or "") if state else ""
+            if errors or not state:
+                failures.append(f"{intent.symbol}: {'; '.join(errors) or 'no WhatIf response'}")
+            elif warning:
+                failures.append(f"{intent.symbol}: {warning}")
+        return failures
+
+    def execute_phase(self, plan_id: str, intents: list[OrderIntent], *, revision: int, max_attempts: int) -> list[ExecutionResult]:
+        return [self._execute_one(plan_id, intent, revision, max_attempts) for intent in intents]
+
+    def _execute_one(self, plan_id: str, intent: OrderIntent, revision: int, max_attempts: int) -> ExecutionResult:
+        filled_total = Decimal("0")
+        average_numerator = Decimal("0")
+        last_result: ExecutionResult | None = None
+        for attempt in range(1, max_attempts + 1):
+            remaining = intent.quantity - filled_total
+            if remaining <= 0:
+                break
+            client_key = f"hib:{plan_id}:{intent.symbol}:{intent.side}:r{revision}:a{attempt}"
+            snapshot = self.reconcile()
+            if client_key in snapshot.open_order_refs or client_key in snapshot.execution_refs:
+                return ExecutionResult(client_key, intent.symbol, intent.side, intent.quantity, filled_total, "partially_filled", intent.limit_price, error="existing broker order requires reconciliation")
+            current_intent = replace(intent, quantity=remaining)
+            if attempt > 1:
+                quote = self.fresh_quotes([intent.symbol])[intent.symbol]
+                current_intent = replace(current_intent, limit_price=marketable_limit(intent.side, quote, intent.min_tick))
+            order_id = self._take_order_id()
+            order = self._order(current_intent, client_key)
+            self.placeOrder(order_id, self._contract_from_intent(current_intent), order)
+            deadline = time.monotonic() + 90
+            while time.monotonic() < deadline:
+                status = self._order_status.get(order_id, {})
+                if str(status.get("status")) in {"Filled", "Cancelled", "ApiCancelled", "Inactive"}:
+                    break
+                time.sleep(0.25)
+            status = self._order_status.get(order_id, {})
+            attempt_filled = Decimal(str(status.get("filled", 0)))
+            average_price = Decimal(str(status.get("average_fill_price", 0)))
+            if attempt_filled > 0:
+                filled_total += attempt_filled
+                average_numerator += attempt_filled * average_price
+            if filled_total < intent.quantity:
+                self.cancelOrder(order_id, "")
+                time.sleep(1)
+            executions = [item for item in self._executions.items() if int(item[1].get("order_id", -1)) == order_id]
+            exec_id = executions[-1][0] if executions else None
+            commission = sum((self._commissions.get(item[0], Decimal("0")) for item in executions), Decimal("0"))
+            final_status = "filled" if filled_total >= intent.quantity else "partially_filled"
+            if str(status.get("status")) == "Inactive" or self._errors.get(order_id):
+                final_status = "rejected"
+            last_result = ExecutionResult(
+                client_order_key=client_key, symbol=intent.symbol, side=intent.side,
+                requested_quantity=intent.quantity, filled_quantity=filled_total, status=final_status,
+                limit_price=current_intent.limit_price,
+                average_fill_price=(average_numerator / filled_total if filled_total else None),
+                ib_order_id=order_id, ib_perm_id=int(status.get("perm_id") or 0) or None,
+                exec_id=exec_id, commission=commission,
+                error="; ".join(self._errors.get(order_id, [])),
+            )
+            if final_status == "filled" or final_status == "rejected":
+                break
+        return last_result or ExecutionResult(
+            f"hib:{plan_id}:{intent.symbol}:{intent.side}:r{revision}:a0",
+            intent.symbol, intent.side, intent.quantity, Decimal("0"), "error", intent.limit_price,
+            error="order was not submitted",
+        )
+
+    def cancel_plan_orders(self, plan_id: str) -> None:
+        self.reconcile()
+        prefix = f"hib:{plan_id}:"
+        for order_id, details in list(self._open_orders.items()):
+            if str(details.get("ref", "")).startswith(prefix):
+                self.cancelOrder(order_id, "")
+
+    def _new_request(self) -> int:
+        with self._lock:
+            self._request_id += 1
+            request_id = self._request_id
+            self._request_events[request_id] = threading.Event()
+            return request_id
+
+    def _take_order_id(self) -> int:
+        with self._lock:
+            if self._next_order_id is None:
+                raise RuntimeError("IBKR did not provide nextValidId")
+            order_id = self._next_order_id
+            self._next_order_id += 1
+            self._request_events[order_id] = threading.Event()
+            return order_id
+
+    def _wait_request(self, request_id: int, timeout: float, label: str, allow_errors: bool = False) -> None:
+        event = self._request_events[request_id]
+        self._wait(event, timeout, label)
+        if self._errors.get(request_id) and not allow_errors:
+            raise RuntimeError(f"{label}: {'; '.join(self._errors[request_id])}")
+
+    @staticmethod
+    def _wait(event: threading.Event, timeout: float, label: str) -> None:
+        if not event.wait(timeout):
+            raise TimeoutError(f"timed out waiting for {label}")
+
+    @staticmethod
+    def _contract(instrument: Instrument) -> Contract:
+        contract = Contract()
+        contract.conId = instrument.conid
+        contract.symbol = instrument.symbol
+        contract.secType = "STK"
+        contract.exchange = "SMART"
+        contract.primaryExchange = instrument.primary_exchange
+        contract.currency = instrument.currency
+        return contract
+
+    @staticmethod
+    def _contract_from_intent(intent: OrderIntent) -> Contract:
+        contract = Contract()
+        contract.conId = intent.conid
+        contract.symbol = intent.symbol
+        contract.secType = "STK"
+        contract.exchange = "SMART"
+        contract.currency = "USD"
+        return contract
+
+    @staticmethod
+    def _order(intent: OrderIntent, order_ref: str) -> Order:
+        order = Order()
+        order.action = intent.side
+        order.orderType = "LMT"
+        order.totalQuantity = intent.quantity
+        order.lmtPrice = float(intent.limit_price)
+        order.tif = "DAY"
+        order.outsideRth = False
+        order.transmit = True
+        order.orderRef = order_ref
+        return order

--- a/trading_executor/ib_gateway.py
+++ b/trading_executor/ib_gateway.py
@@ -5,7 +5,7 @@ import time
 from dataclasses import replace
 from datetime import datetime, timezone
 from decimal import Decimal
-from typing import Any
+from typing import Any, Callable
 from zoneinfo import ZoneInfo
 
 try:
@@ -21,17 +21,29 @@ except ImportError as error:  # pragma: no cover - depends on the official IBKR 
     ) from error
 
 from .engine import BrokerExecution, BrokerOrder, BrokerSnapshot, ExecutionFill, ExecutionResult
+from .journal import LocalJournal, execution_identity
 from .policy import Instrument, OrderIntent, Position, Quote, marketable_limit
 
 
 class IbGateway(EWrapper, EClient):
-    def __init__(self, *, host: str, port: int, client_id: int, expected_account: str) -> None:
+    def __init__(
+        self,
+        *,
+        host: str,
+        port: int,
+        client_id: int,
+        expected_account: str,
+        journal: LocalJournal | None = None,
+        submission_guard: Callable[[str], None] | None = None,
+    ) -> None:
         EWrapper.__init__(self)
         EClient.__init__(self, self)
         self.host = host
         self.port = port
         self.client_id = client_id
         self.expected_account = expected_account.upper()
+        self.journal = journal
+        self.submission_guard = submission_guard
         self._thread: threading.Thread | None = None
         self._lock = threading.RLock()
         self._request_id = 10_000
@@ -84,7 +96,19 @@ class IbGateway(EWrapper, EClient):
         if self._next_order_id is not None:
             self._events["ready"].set()
 
-    def error(self, reqId: int, errorCode: int, errorString: str, advancedOrderRejectJson: str = "") -> None:  # noqa: N802
+    def error(self, reqId: int, *args: Any) -> None:  # noqa: N802
+        # TWS API 10.33 added errorTime between reqId and errorCode. Accept the
+        # current callback and the older shape so a Gateway/client upgrade
+        # cannot terminate the network thread with a Python TypeError.
+        if len(args) >= 3 and isinstance(args[1], int):
+            _error_time, errorCode, errorString, *remaining = args
+        elif len(args) >= 2:
+            errorCode, errorString, *remaining = args
+        else:
+            return
+        advancedOrderRejectJson = str(remaining[0]) if remaining else ""
+        errorCode = int(errorCode)
+        errorString = str(errorString)
         if errorCode in {2104, 2106, 2107, 2108, 2158}:
             return
         details = f"{errorCode}: {errorString}"
@@ -126,7 +150,8 @@ class IbGateway(EWrapper, EClient):
         }
 
     def execDetails(self, reqId: int, contract: Any, execution: Any) -> None:  # noqa: N802
-        self._executions[str(execution.execId)] = {
+        exec_id = str(execution.execId)
+        details = {
             "req_id": reqId, "order_id": int(execution.orderId), "perm_id": int(execution.permId),
             "ref": str(getattr(execution, "orderRef", "") or ""), "symbol": str(contract.symbol).upper(),
             "conid": int(getattr(contract, "conId", 0) or 0) or None,
@@ -134,6 +159,13 @@ class IbGateway(EWrapper, EClient):
             "shares": Decimal(str(execution.shares)), "price": Decimal(str(execution.price)),
             "time": self._execution_time(str(getattr(execution, "time", "") or "")),
         }
+        self._executions[exec_id] = details
+        if self.journal and details["ref"].startswith("hib:"):
+            self.journal.record_broker_execution(exec_id, {
+                **details,
+                "shares": str(details["shares"]),
+                "price": str(details["price"]),
+            })
 
     def execDetailsEnd(self, reqId: int) -> None:  # noqa: N802
         event = self._request_events.get(reqId)
@@ -142,10 +174,16 @@ class IbGateway(EWrapper, EClient):
         self._events["executions"].set()
 
     def commissionReport(self, commissionReport: Any) -> None:  # noqa: N802
-        self._commissions[str(commissionReport.execId)] = {
+        exec_id = str(commissionReport.execId)
+        details = {
             "commission": Decimal(str(commissionReport.commission)),
             "currency": str(getattr(commissionReport, "currency", "USD") or "USD"),
         }
+        self._commissions[exec_id] = details
+        if self.journal:
+            self.journal.record_commission(exec_id, {
+                "commission": str(details["commission"]), "currency": details["currency"],
+            })
 
     def accountSummary(self, reqId: int, account: str, tag: str, value: str, currency: str) -> None:  # noqa: N802
         if account.upper() != self.expected_account:
@@ -201,18 +239,29 @@ class IbGateway(EWrapper, EClient):
         account_request = self._new_request()
         self.reqPositions()
         self.reqOpenOrders()
-        self.reqExecutions(execution_request, ExecutionFilter())
+        execution_filter = ExecutionFilter()
+        if hasattr(execution_filter, "acctCode"):
+            execution_filter.acctCode = self.expected_account
+        if hasattr(execution_filter, "lastNDays"):
+            execution_filter.lastNDays = 7
+        self.reqExecutions(execution_request, execution_filter)
         self.reqAccountSummary(account_request, "All", "SettledCash,AccountType")
         self._wait(self._events["positions"], 15, "positions reconciliation")
         self._wait(self._events["orders"], 15, "open-order reconciliation")
         self._wait(self._events["executions"], 15, "execution reconciliation")
         self._wait(self._events["account"], 15, "account reconciliation")
         self.cancelAccountSummary(account_request)
+        if self.journal:
+            for exec_id, details, commission in self.journal.broker_executions():
+                self._executions.setdefault(exec_id, details)
+                if commission:
+                    self._commissions.setdefault(exec_id, commission)
         open_orders = tuple(self._broker_order(order_id, details) for order_id, details in self._open_orders.items())
+        effective_ids = self._effective_execution_ids(list(self._executions))
         executions = tuple(
             self._broker_execution(exec_id, details)
             for exec_id, details in self._executions.items()
-            if details.get("ref") and details.get("side") in {"BUY", "SELL"}
+            if exec_id in effective_ids and details.get("ref") and details.get("side") in {"BUY", "SELL"}
         )
         return BrokerSnapshot(
             account_id=self.expected_account,
@@ -303,39 +352,79 @@ class IbGateway(EWrapper, EClient):
                 break
             client_key = f"hib:{plan_id}:{intent.symbol}:{intent.side}:r{revision}:a{attempt}"
             snapshot = self.reconcile()
+            if any(
+                order.symbol == intent.symbol and not order.client_order_key.startswith("hib:")
+                for order in snapshot.open_orders
+            ):
+                raise RuntimeError(f"manual open order overlap appeared for {intent.symbol}")
             if client_key in snapshot.open_order_refs or client_key in snapshot.execution_refs:
                 recovered = self._result_from_snapshot(snapshot, client_key, intent)
                 if recovered:
                     results.append(recovered)
                     filled_total += recovered.filled_quantity
+                if self.journal:
+                    self.journal.mark_order_resolved(client_key)
                 break
+            if self.submission_guard:
+                self.submission_guard(plan_id)
             current_intent = replace(intent, quantity=remaining)
-            if attempt > 1:
-                quote = self.fresh_quotes([intent.symbol])[intent.symbol]
-                current_intent = replace(current_intent, limit_price=marketable_limit(intent.side, quote, intent.min_tick))
+            quote = self.fresh_quotes([intent.symbol])[intent.symbol]
+            repriced_limit = marketable_limit(intent.side, quote, intent.min_tick)
+            safe_limit = min(intent.limit_price, repriced_limit) if intent.side == "BUY" else max(intent.limit_price, repriced_limit)
+            current_intent = replace(current_intent, limit_price=safe_limit)
+            retry_what_if_errors = self.what_if([current_intent])
+            if retry_what_if_errors:
+                raise RuntimeError("IBKR retry WhatIf failed: " + "; ".join(retry_what_if_errors))
             order_id = self._take_order_id()
             order = self._order(current_intent, client_key)
+            if self.journal:
+                self.journal.prepare_order(client_key, {
+                    "plan_id": plan_id, "symbol": current_intent.symbol, "side": current_intent.side,
+                    "quantity": str(current_intent.quantity), "limit_price": str(current_intent.limit_price),
+                    "conid": current_intent.conid,
+                }, order_id)
             self.placeOrder(order_id, self._contract_from_intent(current_intent), order)
+            if self.journal:
+                self.journal.mark_order_submitted(client_key)
             deadline = time.monotonic() + 90
+            next_guard_check = time.monotonic() + 10
             while time.monotonic() < deadline:
                 status = self._order_status.get(order_id, {})
                 if str(status.get("status")) in {"Filled", "Cancelled", "ApiCancelled", "Inactive"}:
                     break
+                if self.submission_guard and time.monotonic() >= next_guard_check:
+                    try:
+                        self.submission_guard(plan_id)
+                    except Exception:
+                        self.cancelOrder(order_id, "")
+                        raise
+                    next_guard_check = time.monotonic() + 10
                 time.sleep(0.25)
             status = self._order_status.get(order_id, {})
-            attempt_filled = Decimal(str(status.get("filled", 0)))
+            reported_filled = Decimal(str(status.get("filled", 0)))
             average_price = Decimal(str(status.get("average_fill_price", 0)))
-            if attempt_filled > 0:
-                filled_total += attempt_filled
-            if filled_total < intent.quantity:
+            if filled_total + reported_filled < intent.quantity:
                 self.cancelOrder(order_id, "")
                 time.sleep(1)
-            executions = [item for item in self._executions.items() if int(item[1].get("order_id", -1)) == order_id]
+            executions = [
+                item for item in self._executions.items()
+                if int(item[1].get("order_id", -1)) == order_id
+                and item[0] in self._effective_execution_ids([
+                    candidate_id for candidate_id, candidate in self._executions.items()
+                    if int(candidate.get("order_id", -1)) == order_id
+                ])
+            ]
             if executions:
                 deadline = time.monotonic() + 2
                 while time.monotonic() < deadline and any(exec_id not in self._commissions for exec_id, _ in executions):
                     time.sleep(0.05)
             fills = tuple(self._execution_fill(exec_id, details) for exec_id, details in executions)
+            attempt_filled = (
+                sum((fill.quantity for fill in fills), Decimal("0"))
+                if fills else reported_filled
+            )
+            if attempt_filled > 0:
+                filled_total += attempt_filled
             commission = sum((fill.commission for fill in fills), Decimal("0"))
             final_status = "filled" if attempt_filled >= remaining else "partially_filled"
             if str(status.get("status")) == "Inactive" or self._errors.get(order_id):
@@ -349,6 +438,8 @@ class IbGateway(EWrapper, EClient):
                 commission=commission, fills=fills,
                 error="; ".join(self._errors.get(order_id, [])),
             ))
+            if self.journal:
+                self.journal.mark_order_resolved(client_key)
             if filled_total >= intent.quantity or final_status == "rejected":
                 break
         if results:
@@ -413,9 +504,11 @@ class IbGateway(EWrapper, EClient):
         matching_orders = [item for item in snapshot.open_orders if item.client_order_key == client_key]
         if matching_orders:
             order = matching_orders[0]
+            effective_filled = sum((item.fill.quantity for item in matching_executions), Decimal("0"))
             return ExecutionResult(
                 client_order_key=client_key, symbol=order.symbol, side=order.side,
-                requested_quantity=order.requested_quantity, filled_quantity=order.filled_quantity,
+                requested_quantity=order.requested_quantity,
+                filled_quantity=effective_filled if matching_executions else order.filled_quantity,
                 status=order.status, limit_price=order.limit_price, conid=order.conid,
                 average_fill_price=order.average_fill_price, ib_order_id=order.ib_order_id,
                 ib_perm_id=order.ib_perm_id,
@@ -438,6 +531,16 @@ class IbGateway(EWrapper, EClient):
                 error="recovered from IBKR before retry; no duplicate order was submitted",
             )
         return None
+
+    @staticmethod
+    def _effective_execution_ids(exec_ids: list[str]) -> set[str]:
+        latest: dict[str, tuple[int, str]] = {}
+        for exec_id in exec_ids:
+            family, revision = execution_identity(exec_id)
+            current = latest.get(family)
+            if current is None or revision > current[0]:
+                latest[family] = (revision, exec_id)
+        return {item[1] for item in latest.values()}
 
     @staticmethod
     def _normalize_side(side: str) -> str:

--- a/trading_executor/ib_gateway.py
+++ b/trading_executor/ib_gateway.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import threading
 import time
 from dataclasses import replace
+from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any
+from zoneinfo import ZoneInfo
 
 try:
     from ibapi.client import EClient
@@ -18,7 +20,7 @@ except ImportError as error:  # pragma: no cover - depends on the official IBKR 
         "Do not use an unversioned third-party PyPI copy."
     ) from error
 
-from .engine import BrokerSnapshot, ExecutionResult
+from .engine import BrokerExecution, BrokerOrder, BrokerSnapshot, ExecutionFill, ExecutionResult
 from .policy import Instrument, OrderIntent, Position, Quote, marketable_limit
 
 
@@ -37,10 +39,11 @@ class IbGateway(EWrapper, EClient):
         self._managed_accounts: list[str] = []
         self._positions: list[Position] = []
         self._settled_cash = Decimal("0")
+        self._account_type = "UNKNOWN"
         self._open_orders: dict[int, dict[str, Any]] = {}
         self._executions: dict[str, dict[str, Any]] = {}
         self._order_status: dict[int, dict[str, Any]] = {}
-        self._commissions: dict[str, Decimal] = {}
+        self._commissions: dict[str, dict[str, Any]] = {}
         self._contracts: dict[int, list[Any]] = {}
         self._quotes: dict[int, dict[str, Any]] = {}
         self._what_if: dict[int, Any] = {}
@@ -53,6 +56,9 @@ class IbGateway(EWrapper, EClient):
     def connect_and_start(self, timeout: float = 15) -> None:
         if self.isConnected():
             return
+        self._events["ready"].clear()
+        self._managed_accounts = []
+        self._next_order_id = None
         self.connect(self.host, self.port, self.client_id)
         self._thread = threading.Thread(target=self.run, name="ibapi-network", daemon=True)
         self._thread.start()
@@ -123,7 +129,10 @@ class IbGateway(EWrapper, EClient):
         self._executions[str(execution.execId)] = {
             "req_id": reqId, "order_id": int(execution.orderId), "perm_id": int(execution.permId),
             "ref": str(getattr(execution, "orderRef", "") or ""), "symbol": str(contract.symbol).upper(),
+            "conid": int(getattr(contract, "conId", 0) or 0) or None,
+            "side": self._normalize_side(str(getattr(execution, "side", "") or "")),
             "shares": Decimal(str(execution.shares)), "price": Decimal(str(execution.price)),
+            "time": self._execution_time(str(getattr(execution, "time", "") or "")),
         }
 
     def execDetailsEnd(self, reqId: int) -> None:  # noqa: N802
@@ -133,11 +142,18 @@ class IbGateway(EWrapper, EClient):
         self._events["executions"].set()
 
     def commissionReport(self, commissionReport: Any) -> None:  # noqa: N802
-        self._commissions[str(commissionReport.execId)] = Decimal(str(commissionReport.commission))
+        self._commissions[str(commissionReport.execId)] = {
+            "commission": Decimal(str(commissionReport.commission)),
+            "currency": str(getattr(commissionReport, "currency", "USD") or "USD"),
+        }
 
     def accountSummary(self, reqId: int, account: str, tag: str, value: str, currency: str) -> None:  # noqa: N802
-        if account.upper() == self.expected_account and tag == "SettledCash" and currency == "USD":
+        if account.upper() != self.expected_account:
+            return
+        if tag == "SettledCash" and currency == "USD":
             self._settled_cash = Decimal(value)
+        elif tag == "AccountType":
+            self._account_type = value.strip().upper() or "UNKNOWN"
 
     def accountSummaryEnd(self, reqId: int) -> None:  # noqa: N802
         event = self._request_events.get(reqId)
@@ -180,23 +196,31 @@ class IbGateway(EWrapper, EClient):
         self._open_orders = {}
         self._executions = {}
         self._settled_cash = Decimal("0")
+        self._account_type = "UNKNOWN"
         execution_request = self._new_request()
         account_request = self._new_request()
         self.reqPositions()
         self.reqOpenOrders()
         self.reqExecutions(execution_request, ExecutionFilter())
-        self.reqAccountSummary(account_request, "All", "SettledCash")
+        self.reqAccountSummary(account_request, "All", "SettledCash,AccountType")
         self._wait(self._events["positions"], 15, "positions reconciliation")
         self._wait(self._events["orders"], 15, "open-order reconciliation")
         self._wait(self._events["executions"], 15, "execution reconciliation")
         self._wait(self._events["account"], 15, "account reconciliation")
         self.cancelAccountSummary(account_request)
+        open_orders = tuple(self._broker_order(order_id, details) for order_id, details in self._open_orders.items())
+        executions = tuple(
+            self._broker_execution(exec_id, details)
+            for exec_id, details in self._executions.items()
+            if details.get("ref") and details.get("side") in {"BUY", "SELL"}
+        )
         return BrokerSnapshot(
             account_id=self.expected_account,
             positions=list(self._positions),
             settled_cash_usd=self._settled_cash,
-            open_order_refs={str(item["ref"]) for item in self._open_orders.values() if item["ref"]},
-            execution_refs={str(item["ref"]) for item in self._executions.values() if item["ref"]},
+            account_type=self._account_type,
+            open_orders=open_orders,
+            executions=executions,
         )
 
     def resolve_instruments(self, symbols: list[str]) -> dict[str, Instrument]:
@@ -265,12 +289,14 @@ class IbGateway(EWrapper, EClient):
         return failures
 
     def execute_phase(self, plan_id: str, intents: list[OrderIntent], *, revision: int, max_attempts: int) -> list[ExecutionResult]:
-        return [self._execute_one(plan_id, intent, revision, max_attempts) for intent in intents]
+        results: list[ExecutionResult] = []
+        for intent in intents:
+            results.extend(self._execute_one(plan_id, intent, revision, max_attempts))
+        return results
 
-    def _execute_one(self, plan_id: str, intent: OrderIntent, revision: int, max_attempts: int) -> ExecutionResult:
+    def _execute_one(self, plan_id: str, intent: OrderIntent, revision: int, max_attempts: int) -> list[ExecutionResult]:
         filled_total = Decimal("0")
-        average_numerator = Decimal("0")
-        last_result: ExecutionResult | None = None
+        results: list[ExecutionResult] = []
         for attempt in range(1, max_attempts + 1):
             remaining = intent.quantity - filled_total
             if remaining <= 0:
@@ -278,7 +304,11 @@ class IbGateway(EWrapper, EClient):
             client_key = f"hib:{plan_id}:{intent.symbol}:{intent.side}:r{revision}:a{attempt}"
             snapshot = self.reconcile()
             if client_key in snapshot.open_order_refs or client_key in snapshot.execution_refs:
-                return ExecutionResult(client_key, intent.symbol, intent.side, intent.quantity, filled_total, "partially_filled", intent.limit_price, error="existing broker order requires reconciliation")
+                recovered = self._result_from_snapshot(snapshot, client_key, intent)
+                if recovered:
+                    results.append(recovered)
+                    filled_total += recovered.filled_quantity
+                break
             current_intent = replace(intent, quantity=remaining)
             if attempt > 1:
                 quote = self.fresh_quotes([intent.symbol])[intent.symbol]
@@ -297,32 +327,37 @@ class IbGateway(EWrapper, EClient):
             average_price = Decimal(str(status.get("average_fill_price", 0)))
             if attempt_filled > 0:
                 filled_total += attempt_filled
-                average_numerator += attempt_filled * average_price
             if filled_total < intent.quantity:
                 self.cancelOrder(order_id, "")
                 time.sleep(1)
             executions = [item for item in self._executions.items() if int(item[1].get("order_id", -1)) == order_id]
-            exec_id = executions[-1][0] if executions else None
-            commission = sum((self._commissions.get(item[0], Decimal("0")) for item in executions), Decimal("0"))
-            final_status = "filled" if filled_total >= intent.quantity else "partially_filled"
+            if executions:
+                deadline = time.monotonic() + 2
+                while time.monotonic() < deadline and any(exec_id not in self._commissions for exec_id, _ in executions):
+                    time.sleep(0.05)
+            fills = tuple(self._execution_fill(exec_id, details) for exec_id, details in executions)
+            commission = sum((fill.commission for fill in fills), Decimal("0"))
+            final_status = "filled" if attempt_filled >= remaining else "partially_filled"
             if str(status.get("status")) == "Inactive" or self._errors.get(order_id):
                 final_status = "rejected"
-            last_result = ExecutionResult(
+            results.append(ExecutionResult(
                 client_order_key=client_key, symbol=intent.symbol, side=intent.side,
-                requested_quantity=intent.quantity, filled_quantity=filled_total, status=final_status,
+                requested_quantity=remaining, filled_quantity=attempt_filled, status=final_status,
                 limit_price=current_intent.limit_price,
-                average_fill_price=(average_numerator / filled_total if filled_total else None),
+                average_fill_price=(average_price if attempt_filled else None), conid=intent.conid,
                 ib_order_id=order_id, ib_perm_id=int(status.get("perm_id") or 0) or None,
-                exec_id=exec_id, commission=commission,
+                commission=commission, fills=fills,
                 error="; ".join(self._errors.get(order_id, [])),
-            )
-            if final_status == "filled" or final_status == "rejected":
+            ))
+            if filled_total >= intent.quantity or final_status == "rejected":
                 break
-        return last_result or ExecutionResult(
+        if results:
+            return results
+        return [ExecutionResult(
             f"hib:{plan_id}:{intent.symbol}:{intent.side}:r{revision}:a0",
             intent.symbol, intent.side, intent.quantity, Decimal("0"), "error", intent.limit_price,
-            error="order was not submitted",
-        )
+            conid=intent.conid, error="order was not submitted",
+        )]
 
     def cancel_plan_orders(self, plan_id: str) -> None:
         self.reconcile()
@@ -330,6 +365,109 @@ class IbGateway(EWrapper, EClient):
         for order_id, details in list(self._open_orders.items()):
             if str(details.get("ref", "")).startswith(prefix):
                 self.cancelOrder(order_id, "")
+
+    def _broker_order(self, order_id: int, details: dict[str, Any]) -> BrokerOrder:
+        order = details["order"]
+        contract = details["contract"]
+        state = self._order_status.get(order_id, {})
+        status = self._normalize_order_status(str(state.get("status") or getattr(details["state"], "status", "Submitted")))
+        return BrokerOrder(
+            client_order_key=str(details.get("ref", "")),
+            symbol=str(getattr(contract, "symbol", "")).upper(),
+            side=self._normalize_side(str(getattr(order, "action", ""))),
+            requested_quantity=Decimal(str(getattr(order, "totalQuantity", 0))),
+            filled_quantity=Decimal(str(state.get("filled", 0))),
+            status=status,
+            limit_price=Decimal(str(getattr(order, "lmtPrice", 0))),
+            conid=int(getattr(contract, "conId", 0) or 0) or None,
+            average_fill_price=Decimal(str(state["average_fill_price"])) if state.get("average_fill_price") else None,
+            ib_order_id=order_id,
+            ib_perm_id=int(state.get("perm_id") or getattr(order, "permId", 0) or 0) or None,
+        )
+
+    def _broker_execution(self, exec_id: str, details: dict[str, Any]) -> BrokerExecution:
+        return BrokerExecution(
+            client_order_key=str(details["ref"]), symbol=str(details["symbol"]), side=str(details["side"]),
+            conid=details.get("conid"), ib_order_id=int(details["order_id"]),
+            ib_perm_id=int(details.get("perm_id") or 0) or None,
+            fill=self._execution_fill(exec_id, details),
+        )
+
+    def _execution_fill(self, exec_id: str, details: dict[str, Any]) -> ExecutionFill:
+        commission = self._commissions.get(exec_id, {})
+        return ExecutionFill(
+            exec_id=exec_id,
+            quantity=Decimal(str(details["shares"])),
+            price=Decimal(str(details["price"])),
+            commission=Decimal(str(commission.get("commission", 0))),
+            commission_currency=str(commission.get("currency", "USD")),
+            executed_at=str(details.get("time") or datetime.now(timezone.utc).isoformat()),
+            raw_execution={
+                "ib_order_id": details.get("order_id"), "ib_perm_id": details.get("perm_id"),
+                "order_ref": details.get("ref"), "raw_time": details.get("time"),
+            },
+        )
+
+    def _result_from_snapshot(self, snapshot: BrokerSnapshot, client_key: str, intent: OrderIntent) -> ExecutionResult | None:
+        matching_executions = [item for item in snapshot.executions if item.client_order_key == client_key]
+        matching_orders = [item for item in snapshot.open_orders if item.client_order_key == client_key]
+        if matching_orders:
+            order = matching_orders[0]
+            return ExecutionResult(
+                client_order_key=client_key, symbol=order.symbol, side=order.side,
+                requested_quantity=order.requested_quantity, filled_quantity=order.filled_quantity,
+                status=order.status, limit_price=order.limit_price, conid=order.conid,
+                average_fill_price=order.average_fill_price, ib_order_id=order.ib_order_id,
+                ib_perm_id=order.ib_perm_id,
+                commission=sum((item.fill.commission for item in matching_executions), Decimal("0")),
+                fills=tuple(item.fill for item in matching_executions),
+                error="recovered from IBKR before retry; no duplicate order was submitted",
+            )
+        if matching_executions:
+            filled = sum((item.fill.quantity for item in matching_executions), Decimal("0"))
+            value = sum((item.fill.quantity * item.fill.price for item in matching_executions), Decimal("0"))
+            first = matching_executions[0]
+            return ExecutionResult(
+                client_order_key=client_key, symbol=first.symbol, side=first.side,
+                requested_quantity=filled, filled_quantity=filled, status="filled",
+                limit_price=intent.limit_price, conid=first.conid,
+                average_fill_price=value / filled if filled else None,
+                ib_order_id=first.ib_order_id, ib_perm_id=first.ib_perm_id,
+                commission=sum((item.fill.commission for item in matching_executions), Decimal("0")),
+                fills=tuple(item.fill for item in matching_executions),
+                error="recovered from IBKR before retry; no duplicate order was submitted",
+            )
+        return None
+
+    @staticmethod
+    def _normalize_side(side: str) -> str:
+        return {"BOT": "BUY", "BUY": "BUY", "SLD": "SELL", "SELL": "SELL"}.get(side.upper(), side.upper())
+
+    @staticmethod
+    def _normalize_order_status(status: str) -> str:
+        return {
+            "PRESUBMITTED": "submitted", "SUBMITTED": "submitted", "PENDINGSUBMIT": "submitted",
+            "PENDINGCANCEL": "cancel_pending", "APICANCELLED": "cancelled", "CANCELLED": "cancelled",
+            "FILLED": "filled", "INACTIVE": "rejected",
+        }.get(status.replace(" ", "").upper(), "submitted")
+
+    @staticmethod
+    def _execution_time(value: str) -> str:
+        raw = value.strip()
+        parts = raw.rsplit(" ", 1)
+        if len(parts) == 2 and "/" in parts[1]:
+            try:
+                parsed = datetime.strptime(parts[0], "%Y%m%d %H:%M:%S")
+                return parsed.replace(tzinfo=ZoneInfo(parts[1])).astimezone(timezone.utc).isoformat()
+            except (ValueError, KeyError):
+                pass
+        for pattern in ("%Y%m%d-%H:%M:%S", "%Y%m%d %H:%M:%S"):
+            try:
+                parsed = datetime.strptime(raw, pattern)
+                return parsed.replace(tzinfo=timezone.utc).isoformat()
+            except ValueError:
+                continue
+        return datetime.now(timezone.utc).isoformat()
 
     def _new_request(self) -> int:
         with self._lock:

--- a/trading_executor/instance_lock.py
+++ b/trading_executor/instance_lock.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import BinaryIO
+
+
+class ExecutorAlreadyRunningError(RuntimeError):
+    pass
+
+
+class SingleInstanceLock:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._handle: BinaryIO | None = None
+
+    def __enter__(self) -> "SingleInstanceLock":
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        handle = self.path.open("a+b")
+        handle.seek(0, os.SEEK_END)
+        if handle.tell() == 0:
+            handle.write(b"0")
+            handle.flush()
+        handle.seek(0)
+        try:
+            if os.name == "nt":
+                import msvcrt
+
+                msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+            else:  # pragma: no cover - Windows is the production target
+                import fcntl
+
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as error:
+            handle.close()
+            raise ExecutorAlreadyRunningError("another local executor instance is already running") from error
+        self._handle = handle
+        return self
+
+    def __exit__(self, _type: object, _value: object, _traceback: object) -> None:
+        if not self._handle:
+            return
+        try:
+            self._handle.seek(0)
+            if os.name == "nt":
+                import msvcrt
+
+                msvcrt.locking(self._handle.fileno(), msvcrt.LK_UNLCK, 1)
+            else:  # pragma: no cover - Windows is the production target
+                import fcntl
+
+                fcntl.flock(self._handle.fileno(), fcntl.LOCK_UN)
+        finally:
+            self._handle.close()
+            self._handle = None

--- a/trading_executor/journal.py
+++ b/trading_executor/journal.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import threading
+from pathlib import Path
+from typing import Any
+
+from .control_client import ControlClient, ControlPlaneError
+
+
+def execution_identity(exec_id: str) -> tuple[str, int]:
+    family, separator, suffix = exec_id.rpartition(".")
+    if separator and family and suffix.isdigit():
+        return family, int(suffix)
+    return exec_id, 0
+
+
+class AmbiguousOrderIntentError(RuntimeError):
+    pass
+
+
+class LocalJournal:
+    """Durable, non-secret executor journal.
+
+    WAL-backed writes happen before an HTTP event or IBKR order submission. The
+    journal is deliberately conservative: an order intent whose broker outcome
+    cannot be proved is never submitted again automatically.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.RLock()
+        self._db = sqlite3.connect(path, timeout=10, check_same_thread=False)
+        self._db.row_factory = sqlite3.Row
+        with self._db:
+            self._db.execute("PRAGMA journal_mode=WAL")
+            self._db.execute("PRAGMA synchronous=FULL")
+            self._db.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS outbox (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    event_key TEXT NOT NULL UNIQUE,
+                    payload_json TEXT NOT NULL,
+                    response_json TEXT,
+                    delivered_at TEXT,
+                    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+                );
+                CREATE TABLE IF NOT EXISTS order_intents (
+                    client_order_key TEXT PRIMARY KEY,
+                    payload_json TEXT NOT NULL,
+                    ib_order_id INTEGER NOT NULL,
+                    state TEXT NOT NULL CHECK (state IN ('prepared', 'submitted', 'resolved')),
+                    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+                );
+                CREATE TABLE IF NOT EXISTS broker_executions (
+                    exec_id TEXT PRIMARY KEY,
+                    payload_json TEXT NOT NULL,
+                    commission_json TEXT,
+                    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+                );
+                CREATE TABLE IF NOT EXISTS broker_commissions (
+                    exec_id TEXT PRIMARY KEY,
+                    payload_json TEXT NOT NULL,
+                    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+                );
+                """
+            )
+
+    def close(self) -> None:
+        with self._lock:
+            self._db.close()
+
+    @staticmethod
+    def _event_key(payload: dict[str, Any]) -> str:
+        action = str(payload.get("action", "event"))
+        if action == "event":
+            return f"event:{payload.get('event_id', '')}"
+        canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+        digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+        if action == "fill":
+            return f"fill:{payload.get('exec_id', '')}:{digest}"
+        return f"{action}:{digest}"
+
+    def enqueue(self, payload: dict[str, Any]) -> int:
+        event_key = self._event_key(payload)
+        encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+        with self._lock, self._db:
+            self._db.execute(
+                "INSERT OR IGNORE INTO outbox (event_key, payload_json) VALUES (?, ?)",
+                (event_key, encoded),
+            )
+            row = self._db.execute("SELECT id FROM outbox WHERE event_key = ?", (event_key,)).fetchone()
+        return int(row["id"])
+
+    def send(
+        self,
+        client: ControlClient,
+        payload: dict[str, Any],
+        *,
+        strict: bool,
+    ) -> dict[str, Any] | None:
+        row_id = self.enqueue(payload)
+        try:
+            self.flush(client)
+        except ControlPlaneError:
+            if strict:
+                raise
+            return None
+        with self._lock:
+            row = self._db.execute(
+                "SELECT response_json FROM outbox WHERE id = ? AND delivered_at IS NOT NULL",
+                (row_id,),
+            ).fetchone()
+        return json.loads(row["response_json"]) if row and row["response_json"] else None
+
+    def flush(self, client: ControlClient) -> int:
+        delivered = 0
+        while True:
+            with self._lock:
+                row = self._db.execute(
+                    "SELECT id, payload_json FROM outbox WHERE delivered_at IS NULL ORDER BY id LIMIT 1"
+                ).fetchone()
+            if not row:
+                return delivered
+            response = client.event(json.loads(row["payload_json"]))
+            if response.get("accepted") is False:
+                raise ControlPlaneError(
+                    f"control plane rejected durable outbox event {int(row['id'])}"
+                )
+            with self._lock, self._db:
+                self._db.execute(
+                    "UPDATE outbox SET response_json = ?, delivered_at = CURRENT_TIMESTAMP WHERE id = ?",
+                    (json.dumps(response, separators=(",", ":"), ensure_ascii=True), int(row["id"])),
+                )
+            delivered += 1
+
+    def pending_count(self) -> int:
+        with self._lock:
+            row = self._db.execute("SELECT COUNT(*) AS count FROM outbox WHERE delivered_at IS NULL").fetchone()
+        return int(row["count"])
+
+    def prepare_order(self, client_order_key: str, payload: dict[str, Any], ib_order_id: int) -> None:
+        encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+        with self._lock, self._db:
+            existing = self._db.execute(
+                "SELECT state FROM order_intents WHERE client_order_key = ?", (client_order_key,)
+            ).fetchone()
+            if existing:
+                raise AmbiguousOrderIntentError(
+                    f"order intent {client_order_key} already exists with state {existing['state']}; "
+                    "broker reconciliation is required before any retry"
+                )
+            self._db.execute(
+                "INSERT INTO order_intents (client_order_key, payload_json, ib_order_id, state) VALUES (?, ?, ?, 'prepared')",
+                (client_order_key, encoded, ib_order_id),
+            )
+
+    def mark_order_submitted(self, client_order_key: str) -> None:
+        self._set_order_state(client_order_key, "submitted")
+
+    def mark_order_resolved(self, client_order_key: str) -> None:
+        self._set_order_state(client_order_key, "resolved")
+
+    def _set_order_state(self, client_order_key: str, state: str) -> None:
+        with self._lock, self._db:
+            self._db.execute(
+                "UPDATE order_intents SET state = ?, updated_at = CURRENT_TIMESTAMP WHERE client_order_key = ?",
+                (state, client_order_key),
+            )
+
+    def unresolved_order_keys(self) -> set[str]:
+        with self._lock:
+            rows = self._db.execute(
+                "SELECT client_order_key FROM order_intents WHERE state <> 'resolved'"
+            ).fetchall()
+        return {str(row["client_order_key"]) for row in rows}
+
+    def record_broker_execution(self, exec_id: str, payload: dict[str, Any]) -> None:
+        encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+        with self._lock, self._db:
+            self._db.execute(
+                """
+                INSERT INTO broker_executions (exec_id, payload_json)
+                VALUES (?, ?)
+                ON CONFLICT(exec_id) DO UPDATE SET
+                    payload_json = excluded.payload_json,
+                    updated_at = CURRENT_TIMESTAMP
+                """,
+                (exec_id, encoded),
+            )
+
+    def record_commission(self, exec_id: str, payload: dict[str, Any]) -> None:
+        encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+        with self._lock, self._db:
+            self._db.execute(
+                """
+                INSERT INTO broker_commissions (exec_id, payload_json)
+                VALUES (?, ?)
+                ON CONFLICT(exec_id) DO UPDATE SET
+                    payload_json = excluded.payload_json,
+                    updated_at = CURRENT_TIMESTAMP
+                """,
+                (exec_id, encoded),
+            )
+
+    def broker_executions(self) -> list[tuple[str, dict[str, Any], dict[str, Any]]]:
+        with self._lock:
+            rows = self._db.execute(
+                """
+                SELECT execution.exec_id, execution.payload_json,
+                       COALESCE(commission.payload_json, execution.commission_json) AS commission_json
+                  FROM broker_executions execution
+                  LEFT JOIN broker_commissions commission ON commission.exec_id = execution.exec_id
+                 ORDER BY execution.updated_at
+                """
+            ).fetchall()
+        return [
+            (
+                str(row["exec_id"]),
+                json.loads(row["payload_json"]),
+                json.loads(row["commission_json"]) if row["commission_json"] else {},
+            )
+            for row in rows
+        ]
+
+    def effective_execution_ids(self, exec_ids: list[str]) -> set[str]:
+        latest: dict[str, tuple[int, str]] = {}
+        for exec_id in exec_ids:
+            family, revision = execution_identity(exec_id)
+            current = latest.get(family)
+            if current is None or revision > current[0]:
+                latest[family] = (revision, exec_id)
+        return {item[1] for item in latest.values()}

--- a/trading_executor/policy.py
+++ b/trading_executor/policy.py
@@ -55,6 +55,39 @@ class OrderIntent:
     min_tick: Decimal
 
 
+@dataclass(frozen=True)
+class SizingCoverage:
+    target_count: int
+    covered_target_count: int
+    minimum_budget_usd: Decimal
+    uncovered_symbols: tuple[str, ...]
+    desired_quantities: dict[str, Decimal]
+
+    @property
+    def complete(self) -> bool:
+        return self.target_count > 0 and self.covered_target_count == self.target_count
+
+
+class InsufficientTargetCoverageError(ValueError):
+    def __init__(self, coverage: SizingCoverage) -> None:
+        self.coverage = coverage
+        symbols = ", ".join(coverage.uncovered_symbols)
+        super().__init__(
+            f"budget cannot buy a tradable quantity for all {coverage.target_count} targets; "
+            f"minimum estimated budget is ${coverage.minimum_budget_usd} (uncovered: {symbols})"
+        )
+
+    @property
+    def preflight(self) -> dict[str, object]:
+        return {
+            "target_count": self.coverage.target_count,
+            "covered_target_count": self.coverage.covered_target_count,
+            "target_coverage": f"{self.coverage.covered_target_count}/{self.coverage.target_count}",
+            "minimum_budget_usd": str(self.coverage.minimum_budget_usd),
+            "uncovered_symbols": list(self.coverage.uncovered_symbols),
+        }
+
+
 def investable_budget(budget_usd: Decimal) -> Decimal:
     if budget_usd <= 0:
         raise ValueError("budget must be positive")
@@ -66,6 +99,13 @@ def round_quantity(quantity: Decimal, increment: Decimal, fractional: bool) -> D
     if effective_increment <= 0:
         raise ValueError("size increment must be positive")
     return (quantity / effective_increment).to_integral_value(rounding=ROUND_FLOOR) * effective_increment
+
+
+def minimum_tradable_quantity(instrument: Instrument) -> Decimal:
+    increment = instrument.size_increment if instrument.supports_fractional else max(Decimal("1"), instrument.size_increment)
+    if increment <= 0 or instrument.min_size <= 0:
+        raise ValueError(f"invalid size rules for {instrument.symbol}")
+    return (max(increment, instrument.min_size) / increment).to_integral_value(rounding=ROUND_CEILING) * increment
 
 
 def marketable_limit(side: str, quote: Quote, min_tick: Decimal, cushion_bps: Decimal = Decimal("10")) -> Decimal:
@@ -98,23 +138,27 @@ def validate_position_ownership(
     return conflicts
 
 
-def build_order_intents(
+def calculate_sizing_coverage(
     *,
     budget_usd: Decimal,
     targets: Iterable[Target],
-    owned_positions: Iterable[Position],
     quotes: dict[str, Quote],
     instruments: dict[str, Instrument],
-) -> tuple[list[OrderIntent], list[OrderIntent]]:
+) -> SizingCoverage:
     budget = investable_budget(budget_usd)
-    owned = {position.symbol.upper(): position.quantity for position in owned_positions}
     target_list = list(targets)
-    weight_total = sum((target.weight for target in target_list), Decimal("0"))
     if not target_list:
         raise ValueError("empty targets require explicit liquidation approval")
-    if weight_total > Decimal("1.000001") or weight_total <= 0:
+    symbols = [target.symbol.upper() for target in target_list]
+    if len(set(symbols)) != len(symbols):
+        raise ValueError("duplicate target symbols are not allowed")
+    weight_total = sum((target.weight for target in target_list), Decimal("0"))
+    if any(target.weight <= 0 for target in target_list) or weight_total > Decimal("1.000001") or weight_total <= 0:
         raise ValueError("invalid target weights")
+
     desired: dict[str, Decimal] = {}
+    minimum_investable = Decimal("0")
+    uncovered: list[str] = []
     for target in target_list:
         symbol = target.symbol.upper()
         instrument = instruments.get(symbol)
@@ -124,8 +168,45 @@ def build_order_intents(
         if not quote:
             raise ValueError(f"quote is unavailable: {symbol}")
         buy_limit = marketable_limit("BUY", quote, instrument.min_tick)
+        minimum_quantity = minimum_tradable_quantity(instrument)
+        minimum_investable = max(minimum_investable, buy_limit * minimum_quantity / target.weight)
         raw_quantity = budget * target.weight / buy_limit
-        desired[symbol] = round_quantity(raw_quantity, instrument.size_increment, instrument.supports_fractional)
+        quantity = round_quantity(raw_quantity, instrument.size_increment, instrument.supports_fractional)
+        if quantity < minimum_quantity:
+            quantity = Decimal("0")
+            uncovered.append(symbol)
+        desired[symbol] = quantity
+
+    minimum_budget = (minimum_investable / (Decimal("1") - RESERVE_FRACTION)).quantize(
+        Decimal("0.01"), rounding=ROUND_CEILING,
+    )
+    while investable_budget(minimum_budget) < minimum_investable:
+        minimum_budget += Decimal("0.01")
+    return SizingCoverage(
+        target_count=len(target_list),
+        covered_target_count=len(target_list) - len(uncovered),
+        minimum_budget_usd=minimum_budget,
+        uncovered_symbols=tuple(sorted(uncovered)),
+        desired_quantities=desired,
+    )
+
+
+def build_order_intents(
+    *,
+    budget_usd: Decimal,
+    targets: Iterable[Target],
+    owned_positions: Iterable[Position],
+    quotes: dict[str, Quote],
+    instruments: dict[str, Instrument],
+) -> tuple[list[OrderIntent], list[OrderIntent]]:
+    owned = {position.symbol.upper(): position.quantity for position in owned_positions}
+    target_list = list(targets)
+    coverage = calculate_sizing_coverage(
+        budget_usd=budget_usd, targets=target_list, quotes=quotes, instruments=instruments,
+    )
+    if not coverage.complete:
+        raise InsufficientTargetCoverageError(coverage)
+    desired = coverage.desired_quantities
 
     sells: list[OrderIntent] = []
     buys: list[OrderIntent] = []

--- a/trading_executor/policy.py
+++ b/trading_executor/policy.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal, ROUND_CEILING, ROUND_FLOOR
+from typing import Iterable
+
+
+RESERVE_FRACTION = Decimal("0.02")
+QUANTITY_TOLERANCE = Decimal("0.000001")
+
+
+@dataclass(frozen=True)
+class Instrument:
+    symbol: str
+    conid: int
+    currency: str
+    primary_exchange: str
+    min_tick: Decimal
+    size_increment: Decimal
+    supports_fractional: bool
+    approved: bool
+    exchange: str = "SMART"
+    min_size: Decimal = Decimal("1")
+    liquid_hours: str = ""
+    time_zone: str = ""
+
+
+@dataclass(frozen=True)
+class Target:
+    symbol: str
+    weight: Decimal
+
+
+@dataclass(frozen=True)
+class Position:
+    symbol: str
+    quantity: Decimal
+
+
+@dataclass(frozen=True)
+class Quote:
+    symbol: str
+    bid: Decimal
+    ask: Decimal
+    age_seconds: float
+
+
+@dataclass(frozen=True)
+class OrderIntent:
+    symbol: str
+    conid: int
+    side: str
+    quantity: Decimal
+    limit_price: Decimal
+    min_tick: Decimal
+
+
+def investable_budget(budget_usd: Decimal) -> Decimal:
+    if budget_usd <= 0:
+        raise ValueError("budget must be positive")
+    return (budget_usd * (Decimal("1") - RESERVE_FRACTION)).quantize(Decimal("0.01"))
+
+
+def round_quantity(quantity: Decimal, increment: Decimal, fractional: bool) -> Decimal:
+    effective_increment = increment if fractional else max(Decimal("1"), increment)
+    if effective_increment <= 0:
+        raise ValueError("size increment must be positive")
+    return (quantity / effective_increment).to_integral_value(rounding=ROUND_FLOOR) * effective_increment
+
+
+def marketable_limit(side: str, quote: Quote, min_tick: Decimal, cushion_bps: Decimal = Decimal("10")) -> Decimal:
+    if quote.bid <= 0 or quote.ask <= 0 or quote.ask < quote.bid:
+        raise ValueError(f"invalid NBBO for {quote.symbol}")
+    if quote.age_seconds > 15:
+        raise ValueError(f"stale NBBO for {quote.symbol}")
+    if min_tick <= 0:
+        raise ValueError(f"invalid tick increment for {quote.symbol}")
+    multiplier = Decimal("1") + cushion_bps / Decimal("10000") if side == "BUY" else Decimal("1") - cushion_bps / Decimal("10000")
+    raw = (quote.ask if side == "BUY" else quote.bid) * multiplier
+    rounding = ROUND_CEILING if side == "BUY" else ROUND_FLOOR
+    return (raw / min_tick).to_integral_value(rounding=rounding) * min_tick
+
+
+def validate_position_ownership(
+    broker_positions: Iterable[Position],
+    owned_positions: Iterable[Position],
+    target_symbols: Iterable[str],
+) -> list[str]:
+    broker = {item.symbol.upper(): item.quantity for item in broker_positions if item.quantity != 0}
+    owned = {item.symbol.upper(): item.quantity for item in owned_positions if item.quantity != 0}
+    relevant = set(target.upper() for target in target_symbols) | set(owned)
+    conflicts: list[str] = []
+    for symbol in sorted(relevant):
+        broker_quantity = broker.get(symbol, Decimal("0"))
+        owned_quantity = owned.get(symbol, Decimal("0"))
+        if abs(broker_quantity - owned_quantity) > QUANTITY_TOLERANCE:
+            conflicts.append(symbol)
+    return conflicts
+
+
+def build_order_intents(
+    *,
+    budget_usd: Decimal,
+    targets: Iterable[Target],
+    owned_positions: Iterable[Position],
+    quotes: dict[str, Quote],
+    instruments: dict[str, Instrument],
+) -> tuple[list[OrderIntent], list[OrderIntent]]:
+    budget = investable_budget(budget_usd)
+    owned = {position.symbol.upper(): position.quantity for position in owned_positions}
+    target_list = list(targets)
+    weight_total = sum((target.weight for target in target_list), Decimal("0"))
+    if not target_list:
+        raise ValueError("empty targets require explicit liquidation approval")
+    if weight_total > Decimal("1.000001") or weight_total <= 0:
+        raise ValueError("invalid target weights")
+    desired: dict[str, Decimal] = {}
+    for target in target_list:
+        symbol = target.symbol.upper()
+        instrument = instruments.get(symbol)
+        quote = quotes.get(symbol)
+        if not instrument or not instrument.approved or instrument.currency != "USD" or not instrument.primary_exchange:
+            raise ValueError(f"instrument is not approved: {symbol}")
+        if not quote:
+            raise ValueError(f"quote is unavailable: {symbol}")
+        buy_limit = marketable_limit("BUY", quote, instrument.min_tick)
+        raw_quantity = budget * target.weight / buy_limit
+        desired[symbol] = round_quantity(raw_quantity, instrument.size_increment, instrument.supports_fractional)
+
+    sells: list[OrderIntent] = []
+    buys: list[OrderIntent] = []
+    for symbol in sorted(set(owned) | set(desired)):
+        current = owned.get(symbol, Decimal("0"))
+        target_quantity = desired.get(symbol, Decimal("0"))
+        delta = target_quantity - current
+        if abs(delta) <= QUANTITY_TOLERANCE:
+            continue
+        instrument = instruments.get(symbol)
+        quote = quotes.get(symbol)
+        if not instrument or not quote:
+            raise ValueError(f"cannot price owned position: {symbol}")
+        side = "BUY" if delta > 0 else "SELL"
+        quantity = round_quantity(abs(delta), instrument.size_increment, instrument.supports_fractional)
+        if quantity <= 0:
+            continue
+        intent = OrderIntent(
+            symbol=symbol,
+            conid=instrument.conid,
+            side=side,
+            quantity=quantity,
+            limit_price=marketable_limit(side, quote, instrument.min_tick),
+            min_tick=instrument.min_tick,
+        )
+        (buys if side == "BUY" else sells).append(intent)
+    return sells, buys

--- a/trading_executor/reporter.py
+++ b/trading_executor/reporter.py
@@ -6,20 +6,32 @@ import hashlib
 from typing import Any
 from uuid import UUID
 
-from .control_client import ControlClient
+from .control_client import ControlClient, ControlPlaneError
 from .engine import BrokerSnapshot, ExecutionFill, ExecutionResult
-from .policy import Instrument, Position
+from .journal import LocalJournal, execution_identity
+from .policy import Instrument
 
 
 class ControlReporter:
-    def __init__(self, client: ControlClient) -> None:
+    def __init__(self, client: ControlClient, journal: LocalJournal | None = None) -> None:
         self.client = client
+        self.journal = journal
+
+    def _send(self, payload: dict[str, Any], *, strict: bool) -> dict[str, Any] | None:
+        if self.journal:
+            return self.journal.send(self.client, payload, strict=strict)
+        return self.client.event(payload)
+
+    def flush(self) -> int:
+        return self.journal.flush(self.client) if self.journal else 0
 
     def plan_status(self, plan_id: str, status: str, *, error: str = "", preflight: dict[str, Any] | None = None) -> None:
-        self.client.event({"action": "plan_status", "plan_id": plan_id, "status": status, "error": error, "preflight": preflight or {}})
+        response = self._send({"action": "plan_status", "plan_id": plan_id, "status": status, "error": error, "preflight": preflight or {}}, strict=True)
+        if not response or response.get("accepted") is not True:
+            raise ControlPlaneError(f"control plane rejected plan status {status} for {plan_id}")
 
     def order(self, plan_id: str, result: ExecutionResult) -> str | None:
-        response = self.client.event({
+        response = self._send({
             "action": "order", "plan_id": plan_id, "client_order_key": result.client_order_key,
             "symbol": result.symbol, "side": result.side,
             "requested_quantity": str(result.requested_quantity), "filled_quantity": str(result.filled_quantity),
@@ -30,18 +42,19 @@ class ControlReporter:
             "status": result.status, "commission": str(result.commission),
             "commission_currency": result.commission_currency,
             "raw_status": {"error": result.error, "recovered": result.recovered},
-        })
+        }, strict=False) or {}
         return str(response.get("order_id")) if response.get("order_id") else None
 
     def fill(self, order_id: str | None, result: ExecutionResult, fill: ExecutionFill) -> None:
-        self.client.event({
-            "action": "fill", "order_id": order_id, "exec_id": fill.exec_id,
+        self._send({
+            "action": "fill", "order_id": order_id,
+            "client_order_key": result.client_order_key, "exec_id": fill.exec_id,
             "symbol": result.symbol, "side": result.side, "quantity": str(fill.quantity),
             "price": str(fill.price), "commission": str(fill.commission),
             "commission_currency": fill.commission_currency,
             "executed_at": fill.executed_at or datetime.now(timezone.utc).isoformat(),
             "raw_execution": fill.raw_execution or {},
-        })
+        }, strict=False)
 
     def recover(self, snapshot: BrokerSnapshot) -> int:
         system_orders = {order.client_order_key: order for order in snapshot.open_orders if order.client_order_key.startswith("hib:")}
@@ -55,11 +68,11 @@ class ControlReporter:
             if not plan_id:
                 continue
             broker_order = system_orders.get(client_key)
-            executions = executions_by_key.get(client_key, [])
+            executions = self._effective_executions(executions_by_key.get(client_key, []))
             fills = tuple(item.fill for item in executions)
             fill_quantity = sum((fill.quantity for fill in fills), start=Decimal("0"))
             if broker_order:
-                filled_quantity = max(broker_order.filled_quantity, fill_quantity)
+                filled_quantity = fill_quantity if fills else broker_order.filled_quantity
                 status = broker_order.status
                 if filled_quantity > 0 and status == "submitted":
                     status = "partially_filled"
@@ -94,6 +107,16 @@ class ControlReporter:
         return recovered
 
     @staticmethod
+    def _effective_executions(executions: list) -> list:
+        latest: dict[str, tuple[int, Any]] = {}
+        for execution in executions:
+            family, revision = execution_identity(execution.fill.exec_id)
+            current = latest.get(family)
+            if current is None or revision > current[0]:
+                latest[family] = (revision, execution)
+        return [item[1] for item in latest.values()]
+
+    @staticmethod
     def _plan_id(client_order_key: str) -> str | None:
         parts = client_order_key.split(":", 2)
         if len(parts) < 3 or parts[0] != "hib":
@@ -103,14 +126,8 @@ class ControlReporter:
         except ValueError:
             return None
 
-    def positions(self, strategy_link_id: str, positions: list[Position]) -> None:
-        self.client.event({
-            "action": "positions", "strategy_link_id": strategy_link_id,
-            "positions": [{"symbol": item.symbol, "quantity": str(item.quantity)} for item in positions],
-        })
-
     def instrument(self, instrument: Instrument) -> None:
-        self.client.event({
+        response = self._send({
             "action": "instrument", "symbol": instrument.symbol, "conid": instrument.conid,
             "sec_type": "STK", "exchange": instrument.exchange,
             "primary_exchange": instrument.primary_exchange, "currency": instrument.currency,
@@ -119,12 +136,14 @@ class ControlReporter:
             "supports_fractional": instrument.supports_fractional,
             "liquid_hours": instrument.liquid_hours, "time_zone": instrument.time_zone,
             "approved": instrument.approved,
-        })
+        }, strict=True)
+        if not response or response.get("accepted") is not True:
+            raise ControlPlaneError(f"control plane rejected instrument {instrument.symbol}")
 
     def alert(self, event_type: str, severity: str, message: str, payload: dict[str, Any] | None = None) -> None:
         digest = hashlib.sha256(message.encode("utf-8")).hexdigest()[:12]
         event_id = f"{event_type}:{datetime.now(timezone.utc).strftime('%Y%m%d%H%M')}:{digest}"
-        self.client.event({
+        self._send({
             "action": "event", "event_id": event_id, "event_type": event_type,
             "severity": severity, "message": message, "payload": payload or {},
-        })
+        }, strict=False)

--- a/trading_executor/reporter.py
+++ b/trading_executor/reporter.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+from typing import Any
+
+from .control_client import ControlClient
+from .engine import ExecutionResult
+from .policy import Instrument, Position
+
+
+class ControlReporter:
+    def __init__(self, client: ControlClient) -> None:
+        self.client = client
+
+    def plan_status(self, plan_id: str, status: str, *, error: str = "", preflight: dict[str, Any] | None = None) -> None:
+        self.client.event({"action": "plan_status", "plan_id": plan_id, "status": status, "error": error, "preflight": preflight or {}})
+
+    def order(self, plan_id: str, result: ExecutionResult) -> str | None:
+        response = self.client.event({
+            "action": "order", "plan_id": plan_id, "client_order_key": result.client_order_key,
+            "symbol": result.symbol, "side": result.side,
+            "requested_quantity": str(result.requested_quantity), "filled_quantity": str(result.filled_quantity),
+            "limit_price": str(result.limit_price),
+            "average_fill_price": str(result.average_fill_price) if result.average_fill_price is not None else None,
+            "ib_order_id": result.ib_order_id, "ib_perm_id": result.ib_perm_id,
+            "status": result.status, "commission": str(result.commission), "commission_currency": "USD",
+            "raw_status": {"error": result.error},
+        })
+        return str(response.get("order_id")) if response.get("order_id") else None
+
+    def fill(self, order_id: str | None, result: ExecutionResult) -> None:
+        self.client.event({
+            "action": "fill", "order_id": order_id, "exec_id": result.exec_id,
+            "symbol": result.symbol, "side": result.side, "quantity": str(result.filled_quantity),
+            "price": str(result.average_fill_price), "commission": str(result.commission),
+            "commission_currency": "USD", "executed_at": datetime.now(timezone.utc).isoformat(),
+        })
+
+    def positions(self, strategy_link_id: str, positions: list[Position]) -> None:
+        self.client.event({
+            "action": "positions", "strategy_link_id": strategy_link_id,
+            "positions": [{"symbol": item.symbol, "quantity": str(item.quantity)} for item in positions],
+        })
+
+    def instrument(self, instrument: Instrument) -> None:
+        self.client.event({
+            "action": "instrument", "symbol": instrument.symbol, "conid": instrument.conid,
+            "sec_type": "STK", "exchange": instrument.exchange,
+            "primary_exchange": instrument.primary_exchange, "currency": instrument.currency,
+            "min_tick": str(instrument.min_tick), "min_size": str(instrument.min_size),
+            "size_increment": str(instrument.size_increment),
+            "supports_fractional": instrument.supports_fractional,
+            "liquid_hours": instrument.liquid_hours, "time_zone": instrument.time_zone,
+            "approved": instrument.approved,
+        })
+
+    def alert(self, event_type: str, severity: str, message: str, payload: dict[str, Any] | None = None) -> None:
+        digest = hashlib.sha256(message.encode("utf-8")).hexdigest()[:12]
+        event_id = f"{event_type}:{datetime.now(timezone.utc).strftime('%Y%m%d%H%M')}:{digest}"
+        self.client.event({
+            "action": "event", "event_id": event_id, "event_type": event_type,
+            "severity": severity, "message": message, "payload": payload or {},
+        })

--- a/trading_executor/reporter.py
+++ b/trading_executor/reporter.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from decimal import Decimal
 import hashlib
 from typing import Any
+from uuid import UUID
 
 from .control_client import ControlClient
-from .engine import ExecutionResult
+from .engine import BrokerSnapshot, ExecutionFill, ExecutionResult
 from .policy import Instrument, Position
 
 
@@ -23,19 +25,83 @@ class ControlReporter:
             "requested_quantity": str(result.requested_quantity), "filled_quantity": str(result.filled_quantity),
             "limit_price": str(result.limit_price),
             "average_fill_price": str(result.average_fill_price) if result.average_fill_price is not None else None,
+            "conid": result.conid,
             "ib_order_id": result.ib_order_id, "ib_perm_id": result.ib_perm_id,
-            "status": result.status, "commission": str(result.commission), "commission_currency": "USD",
-            "raw_status": {"error": result.error},
+            "status": result.status, "commission": str(result.commission),
+            "commission_currency": result.commission_currency,
+            "raw_status": {"error": result.error, "recovered": result.recovered},
         })
         return str(response.get("order_id")) if response.get("order_id") else None
 
-    def fill(self, order_id: str | None, result: ExecutionResult) -> None:
+    def fill(self, order_id: str | None, result: ExecutionResult, fill: ExecutionFill) -> None:
         self.client.event({
-            "action": "fill", "order_id": order_id, "exec_id": result.exec_id,
-            "symbol": result.symbol, "side": result.side, "quantity": str(result.filled_quantity),
-            "price": str(result.average_fill_price), "commission": str(result.commission),
-            "commission_currency": "USD", "executed_at": datetime.now(timezone.utc).isoformat(),
+            "action": "fill", "order_id": order_id, "exec_id": fill.exec_id,
+            "symbol": result.symbol, "side": result.side, "quantity": str(fill.quantity),
+            "price": str(fill.price), "commission": str(fill.commission),
+            "commission_currency": fill.commission_currency,
+            "executed_at": fill.executed_at or datetime.now(timezone.utc).isoformat(),
+            "raw_execution": fill.raw_execution or {},
         })
+
+    def recover(self, snapshot: BrokerSnapshot) -> int:
+        system_orders = {order.client_order_key: order for order in snapshot.open_orders if order.client_order_key.startswith("hib:")}
+        executions_by_key: dict[str, list] = {}
+        for execution in snapshot.executions:
+            if execution.client_order_key.startswith("hib:"):
+                executions_by_key.setdefault(execution.client_order_key, []).append(execution)
+        recovered = 0
+        for client_key in sorted(set(system_orders) | set(executions_by_key)):
+            plan_id = self._plan_id(client_key)
+            if not plan_id:
+                continue
+            broker_order = system_orders.get(client_key)
+            executions = executions_by_key.get(client_key, [])
+            fills = tuple(item.fill for item in executions)
+            fill_quantity = sum((fill.quantity for fill in fills), start=Decimal("0"))
+            if broker_order:
+                filled_quantity = max(broker_order.filled_quantity, fill_quantity)
+                status = broker_order.status
+                if filled_quantity > 0 and status == "submitted":
+                    status = "partially_filled"
+                result = ExecutionResult(
+                    client_order_key=client_key, symbol=broker_order.symbol, side=broker_order.side,
+                    requested_quantity=broker_order.requested_quantity,
+                    filled_quantity=filled_quantity, status=status,
+                    limit_price=broker_order.limit_price, average_fill_price=broker_order.average_fill_price,
+                    conid=broker_order.conid, ib_order_id=broker_order.ib_order_id,
+                    ib_perm_id=broker_order.ib_perm_id,
+                    commission=sum((fill.commission for fill in fills), start=Decimal("0")), fills=fills,
+                    recovered=True, error="recovered from IBKR reconciliation",
+                )
+            elif executions:
+                value = sum((fill.quantity * fill.price for fill in fills), start=Decimal("0"))
+                first = executions[0]
+                result = ExecutionResult(
+                    client_order_key=client_key, symbol=first.symbol, side=first.side,
+                    requested_quantity=fill_quantity, filled_quantity=fill_quantity, status="filled",
+                    limit_price=value / fill_quantity if fill_quantity else Decimal("0"),
+                    average_fill_price=value / fill_quantity if fill_quantity else None,
+                    conid=first.conid, ib_order_id=first.ib_order_id, ib_perm_id=first.ib_perm_id,
+                    commission=sum((fill.commission for fill in fills), start=Decimal("0")), fills=fills,
+                    recovered=True, error="recovered from IBKR reconciliation",
+                )
+            else:
+                continue
+            order_id = self.order(plan_id, result)
+            for fill in fills:
+                self.fill(order_id, result, fill)
+            recovered += 1
+        return recovered
+
+    @staticmethod
+    def _plan_id(client_order_key: str) -> str | None:
+        parts = client_order_key.split(":", 2)
+        if len(parts) < 3 or parts[0] != "hib":
+            return None
+        try:
+            return str(UUID(parts[1]))
+        except ValueError:
+            return None
 
     def positions(self, strategy_link_id: str, positions: list[Position]) -> None:
         self.client.event({

--- a/trading_executor/requirements.txt
+++ b/trading_executor/requirements.txt
@@ -1,0 +1,2 @@
+# Windows needs the IANA timezone database used for America/New_York checks.
+tzdata

--- a/trading_executor/setup-task.ps1
+++ b/trading_executor/setup-task.ps1
@@ -1,0 +1,15 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$PythonExe,
+    [string]$TaskName = "HedgeInABox-IBKR-Paper-Executor"
+)
+
+$ErrorActionPreference = "Stop"
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$arguments = "-m trading_executor run"
+$action = New-ScheduledTaskAction -Execute $PythonExe -Argument $arguments -WorkingDirectory $repoRoot
+$trigger = New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME
+$settings = New-ScheduledTaskSettingsSet -RestartCount 10 -RestartInterval (New-TimeSpan -Minutes 1) -ExecutionTimeLimit (New-TimeSpan -Days 7)
+$principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive -RunLevel Highest
+Register-ScheduledTask -TaskName $TaskName -Action $action -Trigger $trigger -Settings $settings -Principal $principal -Description "Localhost-only IBKR Paper executor" -Force
+Write-Host "Installed scheduled task $TaskName. It starts at interactive logon and stores no IBKR password."

--- a/trading_executor/setup-task.ps1
+++ b/trading_executor/setup-task.ps1
@@ -9,7 +9,7 @@ $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
 $arguments = "-m trading_executor run"
 $action = New-ScheduledTaskAction -Execute $PythonExe -Argument $arguments -WorkingDirectory $repoRoot
 $trigger = New-ScheduledTaskTrigger -AtLogOn -User $env:USERNAME
-$settings = New-ScheduledTaskSettingsSet -RestartCount 10 -RestartInterval (New-TimeSpan -Minutes 1) -ExecutionTimeLimit (New-TimeSpan -Days 7)
+$settings = New-ScheduledTaskSettingsSet -RestartCount 10 -RestartInterval (New-TimeSpan -Minutes 1) -ExecutionTimeLimit (New-TimeSpan -Days 7) -MultipleInstances IgnoreNew
 $principal = New-ScheduledTaskPrincipal -UserId $env:USERNAME -LogonType Interactive -RunLevel Highest
 Register-ScheduledTask -TaskName $TaskName -Action $action -Trigger $trigger -Settings $settings -Principal $principal -Description "Localhost-only IBKR Paper executor" -Force
 Write-Host "Installed scheduled task $TaskName. It starts at interactive logon and stores no IBKR password."

--- a/trading_executor/tests/test_engine.py
+++ b/trading_executor/tests/test_engine.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from decimal import Decimal
 from zoneinfo import ZoneInfo
 
-from trading_executor.engine import BrokerSnapshot, ExecutionEngine, ExecutionResult
+from trading_executor.engine import BrokerSnapshot, ExecutionEngine, ExecutionFill, ExecutionResult
 from trading_executor.policy import Instrument, OrderIntent, Position, Quote
 
 
@@ -24,9 +24,14 @@ class FakeBroker:
         self.phases: list[str] = []
         self.partial_side = ""
         self.cancelled: list[str] = []
+        self.settled_cash = Decimal("1000")
+        self.account_type = "INDIVIDUAL"
 
     def reconcile(self) -> BrokerSnapshot:
-        return BrokerSnapshot("DU12345", list(self.positions), Decimal("1000"), set(), set())
+        return BrokerSnapshot(
+            account_id="DU12345", positions=list(self.positions), settled_cash_usd=self.settled_cash,
+            account_type=self.account_type,
+        )
 
     def resolve_instruments(self, symbols: list[str]) -> dict[str, Instrument]:
         return {symbol: self.instruments[symbol] for symbol in symbols}
@@ -44,10 +49,16 @@ class FakeBroker:
         for index, intent in enumerate(intents):
             fill = intent.quantity / 2 if self.partial_side == intent.side else intent.quantity
             current[intent.symbol] = current.get(intent.symbol, Decimal("0")) + (fill if intent.side == "BUY" else -fill)
+            execution_fill = ExecutionFill(
+                exec_id=f"exec-{intent.side.lower()}-{revision}-{index}", quantity=fill, price=intent.limit_price,
+                commission=Decimal("0.25"), executed_at="2026-08-24T14:05:00+00:00",
+            )
             results.append(ExecutionResult(
-                f"key-{revision}-{index}", intent.symbol, intent.side, intent.quantity, fill,
-                "filled" if fill == intent.quantity else "partially_filled", intent.limit_price,
-                average_fill_price=intent.limit_price, exec_id=f"exec-{revision}-{index}",
+                client_order_key=f"key-{revision}-{index}", symbol=intent.symbol, side=intent.side,
+                requested_quantity=intent.quantity, filled_quantity=fill,
+                status="filled" if fill == intent.quantity else "partially_filled",
+                limit_price=intent.limit_price, average_fill_price=intent.limit_price,
+                commission=Decimal("0.25"), fills=(execution_fill,),
             ))
         self.positions = [Position(symbol, quantity) for symbol, quantity in current.items() if quantity > 0]
         return results
@@ -62,16 +73,19 @@ class FakeReporter:
         self.orders: list[ExecutionResult] = []
         self.position_updates: list[list[Position]] = []
         self.alerts: list[str] = []
+        self.fills: list[ExecutionFill] = []
+        self.preflights: list[dict] = []
 
     def plan_status(self, plan_id: str, status: str, *, error: str = "", preflight: dict | None = None) -> None:
         self.statuses.append(status)
+        self.preflights.append(preflight or {})
 
     def order(self, plan_id: str, result: ExecutionResult) -> str:
         self.orders.append(result)
         return "order-id"
 
-    def fill(self, order_id: str | None, result: ExecutionResult) -> None:
-        pass
+    def fill(self, order_id: str | None, result: ExecutionResult, fill: ExecutionFill) -> None:
+        self.fills.append(fill)
 
     def positions(self, strategy_link_id: str, positions: list[Position]) -> None:
         self.position_updates.append(positions)
@@ -107,6 +121,47 @@ class EngineTests(unittest.TestCase):
         self.engine.handle(command(), now=self.now)
         self.assertEqual(self.broker.phases, ["SELL", "BUY"])
         self.assertEqual(self.reporter.statuses[-1], "completed")
+        self.assertEqual(len(self.reporter.fills), 2)
+        self.assertEqual({fill.exec_id for fill in self.reporter.fills}, {"exec-sell-1-0", "exec-buy-1-0"})
+
+    def test_sale_proceeds_are_not_used_until_ibkr_reports_settled_cash(self) -> None:
+        self.broker.settled_cash = Decimal("0")
+        self.engine.handle(command(), now=self.now)
+        self.assertEqual(self.broker.phases, ["SELL"])
+        self.assertEqual(self.reporter.statuses[-1], "awaiting_settlement")
+        self.assertEqual(self.reporter.preflights[-1]["same_day_sale_proceeds_counted"], False)
+
+    def test_buy_only_plan_cannot_borrow_on_margin(self) -> None:
+        self.broker.positions = []
+        self.broker.settled_cash = Decimal("100")
+        buy_only = command()
+        buy_only["owned_positions"] = []
+        self.engine.handle(buy_only, now=self.now)
+        self.assertEqual(self.broker.phases, [])
+        self.assertEqual(self.reporter.statuses[-1], "blocked")
+        self.assertIn("balance_anomaly", self.reporter.alerts)
+
+    def test_restart_after_reported_sell_waits_instead_of_blocking_or_reordering(self) -> None:
+        self.broker.positions = []
+        self.broker.settled_cash = Decimal("0")
+        recovered = command("selling")
+        recovered["owned_positions"] = []
+        recovered["existing_orders"] = [{"side": "SELL", "filled_quantity": 5}]
+        self.engine.handle(recovered, now=self.now)
+        self.assertEqual(self.broker.phases, [])
+        self.assertEqual(self.reporter.statuses[-1], "awaiting_settlement")
+
+    def test_zero_quantity_target_reports_n_over_n_and_minimum_budget(self) -> None:
+        self.broker.positions = []
+        self.broker.quotes["MSFT"] = Quote("MSFT", Decimal("499"), Decimal("500"), 1)
+        too_small = command()
+        too_small["owned_positions"] = []
+        too_small["budget_usd"] = 300
+        self.engine.handle(too_small, now=self.now)
+        self.assertEqual(self.broker.phases, [])
+        self.assertEqual(self.reporter.statuses[-1], "blocked")
+        self.assertEqual(self.reporter.preflights[-1]["target_coverage"], "0/1")
+        self.assertGreater(Decimal(self.reporter.preflights[-1]["minimum_budget_usd"]), Decimal("500"))
 
     def test_what_if_failure_is_atomic(self) -> None:
         self.broker.what_if_errors = ["insufficient permissions"]

--- a/trading_executor/tests/test_engine.py
+++ b/trading_executor/tests/test_engine.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from decimal import Decimal
 from zoneinfo import ZoneInfo
 
-from trading_executor.engine import BrokerSnapshot, ExecutionEngine, ExecutionFill, ExecutionResult
+from trading_executor.engine import BrokerOrder, BrokerSnapshot, ExecutionEngine, ExecutionFill, ExecutionResult
 from trading_executor.policy import Instrument, OrderIntent, Position, Quote
 
 
@@ -26,11 +26,13 @@ class FakeBroker:
         self.cancelled: list[str] = []
         self.settled_cash = Decimal("1000")
         self.account_type = "INDIVIDUAL"
+        self.open_orders: tuple[BrokerOrder, ...] = ()
 
     def reconcile(self) -> BrokerSnapshot:
         return BrokerSnapshot(
             account_id="DU12345", positions=list(self.positions), settled_cash_usd=self.settled_cash,
             account_type=self.account_type,
+            open_orders=self.open_orders,
         )
 
     def resolve_instruments(self, symbols: list[str]) -> dict[str, Instrument]:
@@ -169,15 +171,35 @@ class EngineTests(unittest.TestCase):
         self.assertEqual(self.broker.phases, [])
         self.assertEqual(self.reporter.statuses[-1], "blocked")
 
-    def test_partial_sell_prevents_buys_and_updates_ownership(self) -> None:
+    def test_partial_sell_prevents_buys_without_claiming_broker_positions(self) -> None:
         self.broker.partial_side = "SELL"
         self.engine.handle(command(), now=self.now)
         self.assertEqual(self.broker.phases, ["SELL"])
         self.assertEqual(self.reporter.statuses[-1], "partial")
-        self.assertTrue(self.reporter.position_updates)
+        self.assertEqual(self.reporter.position_updates, [])
+
+    def test_strategy_sizing_cannot_use_unrelated_account_cash(self) -> None:
+        self.broker.positions = []
+        isolated = command()
+        isolated["owned_positions"] = []
+        isolated["strategy_cash_usd"] = 500
+        self.engine.handle(isolated, now=self.now)
+        self.assertEqual(self.reporter.statuses[-1], "completed")
+        self.assertEqual(self.reporter.preflights[-1]["capital_base_usd"], "500")
+        self.assertEqual(self.reporter.orders[0].requested_quantity, Decimal("4"))
 
     def test_stale_quote_blocks_all_orders(self) -> None:
         self.broker.quotes["MSFT"] = Quote("MSFT", Decimal("99"), Decimal("100"), 30)
+        self.engine.handle(command(), now=self.now)
+        self.assertEqual(self.broker.phases, [])
+        self.assertEqual(self.reporter.statuses[-1], "blocked")
+
+    def test_manual_open_order_overlap_blocks_before_system_orders(self) -> None:
+        self.broker.open_orders = (BrokerOrder(
+            client_order_key="", symbol="MSFT", side="BUY",
+            requested_quantity=Decimal("1"), filled_quantity=Decimal("0"),
+            status="submitted", limit_price=Decimal("100"),
+        ),)
         self.engine.handle(command(), now=self.now)
         self.assertEqual(self.broker.phases, [])
         self.assertEqual(self.reporter.statuses[-1], "blocked")

--- a/trading_executor/tests/test_engine.py
+++ b/trading_executor/tests/test_engine.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import unittest
+from datetime import datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+from trading_executor.engine import BrokerSnapshot, ExecutionEngine, ExecutionResult
+from trading_executor.policy import Instrument, OrderIntent, Position, Quote
+
+
+class FakeBroker:
+    def __init__(self) -> None:
+        self.positions = [Position("AAPL", Decimal("5"))]
+        self.instruments = {
+            symbol: Instrument(symbol, index + 1, "USD", "NASDAQ", Decimal("0.01"), Decimal("1"), False, True)
+            for index, symbol in enumerate(["AAPL", "MSFT"])
+        }
+        self.quotes = {
+            "AAPL": Quote("AAPL", Decimal("99"), Decimal("100"), 1),
+            "MSFT": Quote("MSFT", Decimal("99"), Decimal("100"), 1),
+        }
+        self.what_if_errors: list[str] = []
+        self.phases: list[str] = []
+        self.partial_side = ""
+        self.cancelled: list[str] = []
+
+    def reconcile(self) -> BrokerSnapshot:
+        return BrokerSnapshot("DU12345", list(self.positions), Decimal("1000"), set(), set())
+
+    def resolve_instruments(self, symbols: list[str]) -> dict[str, Instrument]:
+        return {symbol: self.instruments[symbol] for symbol in symbols}
+
+    def fresh_quotes(self, symbols: list[str]) -> dict[str, Quote]:
+        return {symbol: self.quotes[symbol] for symbol in symbols}
+
+    def what_if(self, intents: list[OrderIntent]) -> list[str]:
+        return self.what_if_errors
+
+    def execute_phase(self, plan_id: str, intents: list[OrderIntent], *, revision: int, max_attempts: int) -> list[ExecutionResult]:
+        self.phases.append(intents[0].side)
+        results: list[ExecutionResult] = []
+        current = {position.symbol: position.quantity for position in self.positions}
+        for index, intent in enumerate(intents):
+            fill = intent.quantity / 2 if self.partial_side == intent.side else intent.quantity
+            current[intent.symbol] = current.get(intent.symbol, Decimal("0")) + (fill if intent.side == "BUY" else -fill)
+            results.append(ExecutionResult(
+                f"key-{revision}-{index}", intent.symbol, intent.side, intent.quantity, fill,
+                "filled" if fill == intent.quantity else "partially_filled", intent.limit_price,
+                average_fill_price=intent.limit_price, exec_id=f"exec-{revision}-{index}",
+            ))
+        self.positions = [Position(symbol, quantity) for symbol, quantity in current.items() if quantity > 0]
+        return results
+
+    def cancel_plan_orders(self, plan_id: str) -> None:
+        self.cancelled.append(plan_id)
+
+
+class FakeReporter:
+    def __init__(self) -> None:
+        self.statuses: list[str] = []
+        self.orders: list[ExecutionResult] = []
+        self.position_updates: list[list[Position]] = []
+        self.alerts: list[str] = []
+
+    def plan_status(self, plan_id: str, status: str, *, error: str = "", preflight: dict | None = None) -> None:
+        self.statuses.append(status)
+
+    def order(self, plan_id: str, result: ExecutionResult) -> str:
+        self.orders.append(result)
+        return "order-id"
+
+    def fill(self, order_id: str | None, result: ExecutionResult) -> None:
+        pass
+
+    def positions(self, strategy_link_id: str, positions: list[Position]) -> None:
+        self.position_updates.append(positions)
+
+    def instrument(self, instrument: Instrument) -> None:
+        pass
+
+    def alert(self, event_type: str, severity: str, message: str, payload: dict | None = None) -> None:
+        self.alerts.append(event_type)
+
+
+def command(status: str = "queued") -> dict:
+    return {
+        "plan_id": "00000000-0000-4000-8000-000000000001",
+        "strategy_link_id": "00000000-0000-4000-8000-000000000002",
+        "status": status,
+        "mode": "paper",
+        "budget_usd": 1000,
+        "command_revision": 1,
+        "target_holdings": [{"ticker": "MSFT", "weight": 1}],
+        "owned_positions": [{"symbol": "AAPL", "quantity": 5}],
+    }
+
+
+class EngineTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.broker = FakeBroker()
+        self.reporter = FakeReporter()
+        self.engine = ExecutionEngine(self.broker, self.reporter, account_id="DU12345", execution_enabled=True)
+        self.now = datetime(2026, 8, 24, 10, 5, tzinfo=ZoneInfo("America/New_York"))
+
+    def test_sells_finish_before_buys(self) -> None:
+        self.engine.handle(command(), now=self.now)
+        self.assertEqual(self.broker.phases, ["SELL", "BUY"])
+        self.assertEqual(self.reporter.statuses[-1], "completed")
+
+    def test_what_if_failure_is_atomic(self) -> None:
+        self.broker.what_if_errors = ["insufficient permissions"]
+        self.engine.handle(command(), now=self.now)
+        self.assertEqual(self.broker.phases, [])
+        self.assertEqual(self.reporter.statuses[-1], "blocked")
+
+    def test_partial_sell_prevents_buys_and_updates_ownership(self) -> None:
+        self.broker.partial_side = "SELL"
+        self.engine.handle(command(), now=self.now)
+        self.assertEqual(self.broker.phases, ["SELL"])
+        self.assertEqual(self.reporter.statuses[-1], "partial")
+        self.assertTrue(self.reporter.position_updates)
+
+    def test_stale_quote_blocks_all_orders(self) -> None:
+        self.broker.quotes["MSFT"] = Quote("MSFT", Decimal("99"), Decimal("100"), 30)
+        self.engine.handle(command(), now=self.now)
+        self.assertEqual(self.broker.phases, [])
+        self.assertEqual(self.reporter.statuses[-1], "blocked")
+
+    def test_cancel_request_only_cancels_system_orders(self) -> None:
+        self.engine.handle(command("cancel_requested"), now=self.now)
+        self.assertEqual(self.broker.cancelled, [command()["plan_id"]])
+        self.assertEqual(self.reporter.statuses, ["cancelled"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/trading_executor/tests/test_integration.py
+++ b/trading_executor/tests/test_integration.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import threading
+import types
+import unittest
+from decimal import Decimal
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def _install_fake_official_ibapi() -> None:
+    if "ibapi.client" in sys.modules:
+        return
+    package = types.ModuleType("ibapi")
+    client_module = types.ModuleType("ibapi.client")
+    contract_module = types.ModuleType("ibapi.contract")
+    execution_module = types.ModuleType("ibapi.execution")
+    order_module = types.ModuleType("ibapi.order")
+    wrapper_module = types.ModuleType("ibapi.wrapper")
+
+    class EWrapper:
+        pass
+
+    class Contract:
+        pass
+
+    class Order:
+        pass
+
+    class ExecutionFilter:
+        def __init__(self) -> None:
+            self.acctCode = ""
+            self.lastNDays = 0
+
+    class EClient:
+        def __init__(self, wrapper: EWrapper) -> None:
+            self.wrapper = wrapper
+            self.connected = False
+            self.placed_orders: list[tuple[int, object, object]] = []
+
+        def connect(self, _host: str, _port: int, _client_id: int) -> None:
+            self.connected = True
+            self.wrapper.nextValidId(100)
+            self.wrapper.managedAccounts("DU12345")
+
+        def isConnected(self) -> bool:  # noqa: N802
+            return self.connected
+
+        def disconnect(self) -> None:
+            self.connected = False
+
+        def run(self) -> None:
+            return
+
+        def reqPositions(self) -> None:  # noqa: N802
+            self.wrapper.positionEnd()
+
+        def reqOpenOrders(self) -> None:  # noqa: N802
+            self.wrapper.openOrderEnd()
+
+        def reqExecutions(self, request_id: int, execution_filter: object) -> None:  # noqa: N802
+            self.last_execution_filter = execution_filter
+            self.wrapper.execDetailsEnd(request_id)
+
+        def reqAccountSummary(self, request_id: int, _group: str, _tags: str) -> None:  # noqa: N802
+            self.wrapper.accountSummary(request_id, "DU12345", "SettledCash", "10000", "USD")
+            self.wrapper.accountSummary(request_id, "DU12345", "AccountType", "INDIVIDUAL", "")
+            self.wrapper.accountSummaryEnd(request_id)
+
+        def cancelAccountSummary(self, _request_id: int) -> None:  # noqa: N802
+            return
+
+        def placeOrder(self, order_id: int, contract: object, order: object) -> None:  # noqa: N802
+            self.placed_orders.append((order_id, contract, order))
+
+        def cancelOrder(self, _order_id: int, _manual_time: str) -> None:  # noqa: N802
+            return
+
+    client_module.EClient = EClient
+    contract_module.Contract = Contract
+    execution_module.ExecutionFilter = ExecutionFilter
+    order_module.Order = Order
+    wrapper_module.EWrapper = EWrapper
+    sys.modules.update({
+        "ibapi": package,
+        "ibapi.client": client_module,
+        "ibapi.contract": contract_module,
+        "ibapi.execution": execution_module,
+        "ibapi.order": order_module,
+        "ibapi.wrapper": wrapper_module,
+    })
+
+
+_install_fake_official_ibapi()
+
+from trading_executor.control_client import ControlClient  # noqa: E402
+from trading_executor.engine import BrokerSnapshot, ExecutionCancelledError  # noqa: E402
+from trading_executor.ib_gateway import IbGateway  # noqa: E402
+from trading_executor.instance_lock import ExecutorAlreadyRunningError, SingleInstanceLock  # noqa: E402
+from trading_executor.journal import AmbiguousOrderIntentError, LocalJournal  # noqa: E402
+from trading_executor.policy import OrderIntent, Quote  # noqa: E402
+from trading_executor.reporter import ControlReporter  # noqa: E402
+from trading_executor.engine import ExecutionFill, ExecutionResult  # noqa: E402
+
+
+class _ControlHandler(BaseHTTPRequestHandler):
+    accepting = False
+    requests: list[dict] = []
+
+    def do_POST(self) -> None:  # noqa: N802
+        length = int(self.headers.get("content-length", "0"))
+        payload = json.loads(self.rfile.read(length).decode("utf-8"))
+        type(self).requests.append({"payload": payload, "headers": dict(self.headers)})
+        if not type(self).accepting:
+            self.send_response(503)
+            self.send_header("content-type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"error":"temporary outage"}')
+            return
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.end_headers()
+        response = {"accepted": True}
+        if payload.get("action") == "order":
+            response["order_id"] = "00000000-0000-4000-8000-000000000099"
+        self.wfile.write(json.dumps(response).encode("utf-8"))
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        return
+
+
+class TradingIntegrationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def test_durable_outbox_replays_order_before_fill_over_signed_http(self) -> None:
+        _ControlHandler.accepting = False
+        _ControlHandler.requests = []
+        server = ThreadingHTTPServer(("127.0.0.1", 0), _ControlHandler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            client = ControlClient(
+                f"http://127.0.0.1:{server.server_port}",
+                "00000000-0000-4000-8000-000000000010",
+                "integration-secret",
+            )
+            journal = LocalJournal(self.root / "journal.sqlite3")
+            reporter = ControlReporter(client, journal)
+            result = ExecutionResult(
+                client_order_key="hib:00000000-0000-4000-8000-000000000001:MSFT:BUY:r1:a1",
+                symbol="MSFT", side="BUY", requested_quantity=Decimal("1"),
+                filled_quantity=Decimal("1"), status="filled", limit_price=Decimal("100"),
+                ib_order_id=42, ib_perm_id=84,
+            )
+            fill = ExecutionFill("0001.01", Decimal("1"), Decimal("99.5"))
+            self.assertIsNone(reporter.order("00000000-0000-4000-8000-000000000001", result))
+            reporter.fill(None, result, fill)
+            self.assertEqual(journal.pending_count(), 2)
+
+            _ControlHandler.accepting = True
+            self.assertEqual(reporter.flush(), 2)
+            self.assertEqual(journal.pending_count(), 0)
+            delivered = [row["payload"] for row in _ControlHandler.requests if row["payload"].get("action") in {"order", "fill"}]
+            self.assertEqual([row["action"] for row in delivered[-2:]], ["order", "fill"])
+            self.assertEqual(delivered[-1]["client_order_key"], result.client_order_key)
+            headers = _ControlHandler.requests[-1]["headers"]
+            self.assertIn("X-Trading-Signature", headers)
+            self.assertIn("X-Trading-Nonce", headers)
+            journal.close()
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=5)
+
+    def test_gateway_accepts_new_error_shape_and_recovers_latest_execution_correction(self) -> None:
+        journal_path = self.root / "journal.sqlite3"
+        journal = LocalJournal(journal_path)
+        gateway = IbGateway(
+            host="127.0.0.1", port=4002, client_id=71,
+            expected_account="DU12345", journal=journal,
+        )
+        gateway.error(17, 1_724_000_000, 201, "order rejected", "{}")
+        self.assertEqual(gateway._errors[17], ["201: order rejected ({})"])
+
+        contract = SimpleNamespace(symbol="MSFT", conId=123)
+        base = {
+            "orderId": 42, "permId": 84,
+            "orderRef": "hib:00000000-0000-4000-8000-000000000001:MSFT:BUY:r1:a1",
+            "side": "BOT", "time": "20260824 10:01:00 America/New_York",
+        }
+        gateway.execDetails(1, contract, SimpleNamespace(execId="0001.01", shares="1", price="100", **base))
+        gateway.execDetails(1, contract, SimpleNamespace(execId="0001.02", shares="0.5", price="99", **base))
+        gateway.commissionReport(SimpleNamespace(execId="0001.02", commission="0.25", currency="USD"))
+        journal.close()
+
+        restored_journal = LocalJournal(journal_path)
+        restored = IbGateway(
+            host="127.0.0.1", port=4002, client_id=71,
+            expected_account="DU12345", journal=restored_journal,
+        )
+        snapshot = restored.reconcile()
+        self.assertEqual(len(snapshot.executions), 1)
+        self.assertEqual(snapshot.executions[0].fill.exec_id, "0001.02")
+        self.assertEqual(snapshot.executions[0].fill.quantity, Decimal("0.5"))
+        self.assertEqual(snapshot.executions[0].fill.commission, Decimal("0.25"))
+        self.assertEqual(restored.last_execution_filter.lastNDays, 7)
+        restored_journal.close()
+
+    def test_ambiguous_prepared_order_is_never_resubmitted(self) -> None:
+        journal = LocalJournal(self.root / "journal.sqlite3")
+        plan_id = "00000000-0000-4000-8000-000000000001"
+        client_key = f"hib:{plan_id}:MSFT:BUY:r1:a1"
+        journal.prepare_order(client_key, {"symbol": "MSFT"}, 100)
+        gateway = IbGateway(
+            host="127.0.0.1", port=4002, client_id=71,
+            expected_account="DU12345", journal=journal,
+        )
+        gateway.reconcile = lambda: BrokerSnapshot("DU12345", [], Decimal("1000"))  # type: ignore[method-assign]
+        gateway.fresh_quotes = lambda _symbols: {  # type: ignore[method-assign]
+            "MSFT": Quote("MSFT", Decimal("99"), Decimal("100"), 1)
+        }
+        gateway.what_if = lambda _intents: []  # type: ignore[method-assign]
+        gateway._next_order_id = 100
+        intent = OrderIntent("MSFT", 123, "BUY", Decimal("1"), Decimal("101"), Decimal("0.01"))
+        with self.assertRaises(AmbiguousOrderIntentError):
+            gateway._execute_one(plan_id, intent, 1, 3)
+        self.assertEqual(gateway.placed_orders, [])
+        journal.close()
+
+    def test_retry_quote_can_never_worsen_the_preflight_limit(self) -> None:
+        journal = LocalJournal(self.root / "journal.sqlite3")
+        plan_id = "00000000-0000-4000-8000-000000000001"
+        gateway = IbGateway(
+            host="127.0.0.1", port=4002, client_id=71,
+            expected_account="DU12345", journal=journal,
+        )
+        gateway.reconcile = lambda: BrokerSnapshot("DU12345", [], Decimal("1000"))  # type: ignore[method-assign]
+        gateway.fresh_quotes = lambda _symbols: {  # type: ignore[method-assign]
+            "MSFT": Quote("MSFT", Decimal("109"), Decimal("110"), 1)
+        }
+        gateway.what_if = lambda _intents: []  # type: ignore[method-assign]
+        gateway._next_order_id = 100
+
+        placed_limits: list[float] = []
+
+        def place_and_fill(order_id: int, contract: object, order: object) -> None:
+            gateway.placed_orders.append((order_id, contract, order))
+            placed_limits.append(float(order.lmtPrice))
+            gateway.orderStatus(order_id, "Filled", Decimal("1"), Decimal("0"), 101, 84, 0, 101, 71, "", 0)
+            execution = SimpleNamespace(
+                execId="0002.01", orderId=order_id, permId=84, orderRef=order.orderRef,
+                side="BOT", shares="1", price="101", time="20260824 10:01:00 America/New_York",
+            )
+            gateway.execDetails(1, SimpleNamespace(symbol="MSFT", conId=123), execution)
+            gateway.commissionReport(SimpleNamespace(execId="0002.01", commission="0.25", currency="USD"))
+
+        gateway.placeOrder = place_and_fill  # type: ignore[method-assign]
+        intent = OrderIntent("MSFT", 123, "BUY", Decimal("1"), Decimal("101"), Decimal("0.01"))
+        results = gateway._execute_one(plan_id, intent, 1, 3)
+        self.assertEqual(placed_limits, [101.0])
+        self.assertEqual(results[0].status, "filled")
+        journal.close()
+
+    def test_remote_kill_switch_guard_stops_before_order_submission(self) -> None:
+        journal = LocalJournal(self.root / "journal.sqlite3")
+        plan_id = "00000000-0000-4000-8000-000000000001"
+
+        def cancelled(_plan_id: str) -> None:
+            raise ExecutionCancelledError("kill switch")
+
+        gateway = IbGateway(
+            host="127.0.0.1", port=4002, client_id=71,
+            expected_account="DU12345", journal=journal, submission_guard=cancelled,
+        )
+        gateway.reconcile = lambda: BrokerSnapshot("DU12345", [], Decimal("1000"))  # type: ignore[method-assign]
+        gateway._next_order_id = 100
+        intent = OrderIntent("MSFT", 123, "BUY", Decimal("1"), Decimal("101"), Decimal("0.01"))
+        with self.assertRaises(ExecutionCancelledError):
+            gateway._execute_one(plan_id, intent, 1, 3)
+        self.assertEqual(gateway.placed_orders, [])
+        self.assertEqual(journal.unresolved_order_keys(), set())
+        journal.close()
+
+    def test_local_single_instance_lock_rejects_a_second_executor(self) -> None:
+        lock_path = self.root / "executor.lock"
+        with SingleInstanceLock(lock_path):
+            with self.assertRaises(ExecutorAlreadyRunningError):
+                with SingleInstanceLock(lock_path):
+                    pass
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/trading_executor/tests/test_policy.py
+++ b/trading_executor/tests/test_policy.py
@@ -12,6 +12,8 @@ from trading_executor.policy import (
     Quote,
     Target,
     build_order_intents,
+    calculate_sizing_coverage,
+    InsufficientTargetCoverageError,
     investable_budget,
     validate_position_ownership,
 )
@@ -41,6 +43,35 @@ class PolicyTests(unittest.TestCase):
             owned_positions=[], quotes={"AAPL": self.quote}, instruments={"AAPL": fractional},
         )
         self.assertLessEqual(buys[0].quantity * buys[0].limit_price, Decimal("980"))
+
+    def test_natural_portfolio_smaller_than_twenty_requires_its_own_n_over_n_coverage(self) -> None:
+        instruments = {
+            symbol: Instrument(symbol, index, "USD", "NASDAQ", Decimal("0.01"), Decimal("1"), False, True)
+            for index, symbol in enumerate(["AAPL", "MSFT"], start=1)
+        }
+        quotes = {symbol: Quote(symbol, Decimal("99.90"), Decimal("100"), 1) for symbol in instruments}
+        coverage = calculate_sizing_coverage(
+            budget_usd=Decimal("1000"),
+            targets=[Target("AAPL", Decimal("0.5")), Target("MSFT", Decimal("0.5"))],
+            quotes=quotes, instruments=instruments,
+        )
+        self.assertEqual((coverage.covered_target_count, coverage.target_count), (2, 2))
+        self.assertTrue(coverage.complete)
+
+    def test_budget_that_drops_one_target_blocks_the_entire_rebalance(self) -> None:
+        expensive = Instrument("MSFT", 2, "USD", "NASDAQ", Decimal("0.01"), Decimal("1"), False, True)
+        targets = [Target("AAPL", Decimal("0.5")), Target("MSFT", Decimal("0.5"))]
+        quotes = {"AAPL": self.quote, "MSFT": Quote("MSFT", Decimal("499.9"), Decimal("500"), 1)}
+        instruments = {"AAPL": self.instrument, "MSFT": expensive}
+        with self.assertRaises(InsufficientTargetCoverageError) as raised:
+            build_order_intents(
+                budget_usd=Decimal("300"), targets=targets, owned_positions=[],
+                quotes=quotes, instruments=instruments,
+            )
+        self.assertEqual(raised.exception.coverage.target_count, 2)
+        self.assertEqual(raised.exception.coverage.covered_target_count, 1)
+        self.assertEqual(raised.exception.coverage.uncovered_symbols, ("MSFT",))
+        self.assertGreater(raised.exception.coverage.minimum_budget_usd, Decimal("1000"))
 
     def test_empty_target_cannot_liquidate(self) -> None:
         with self.assertRaisesRegex(ValueError, "explicit liquidation"):

--- a/trading_executor/tests/test_policy.py
+++ b/trading_executor/tests/test_policy.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import unittest
+from datetime import datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+from trading_executor.engine import in_execution_window, instrument_session_is_open
+from trading_executor.policy import (
+    Instrument,
+    Position,
+    Quote,
+    Target,
+    build_order_intents,
+    investable_budget,
+    validate_position_ownership,
+)
+
+
+class PolicyTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.instrument = Instrument("AAPL", 265598, "USD", "NASDAQ", Decimal("0.01"), Decimal("1"), False, True)
+        self.quote = Quote("AAPL", Decimal("99.90"), Decimal("100.00"), 1)
+
+    def test_budget_keeps_two_percent_reserve(self) -> None:
+        self.assertEqual(investable_budget(Decimal("1000")), Decimal("980.00"))
+
+    def test_integer_sizing_never_exceeds_investable_budget(self) -> None:
+        sells, buys = build_order_intents(
+            budget_usd=Decimal("1000"), targets=[Target("AAPL", Decimal("1"))],
+            owned_positions=[], quotes={"AAPL": self.quote}, instruments={"AAPL": self.instrument},
+        )
+        self.assertEqual(sells, [])
+        self.assertEqual(buys[0].quantity, Decimal("9"))
+        self.assertLessEqual(buys[0].quantity * buys[0].limit_price, Decimal("980"))
+
+    def test_fractional_sizing_includes_marketable_limit_cushion(self) -> None:
+        fractional = Instrument("AAPL", 265598, "USD", "NASDAQ", Decimal("0.01"), Decimal("0.001"), True, True)
+        _, buys = build_order_intents(
+            budget_usd=Decimal("1000"), targets=[Target("AAPL", Decimal("1"))],
+            owned_positions=[], quotes={"AAPL": self.quote}, instruments={"AAPL": fractional},
+        )
+        self.assertLessEqual(buys[0].quantity * buys[0].limit_price, Decimal("980"))
+
+    def test_empty_target_cannot_liquidate(self) -> None:
+        with self.assertRaisesRegex(ValueError, "explicit liquidation"):
+            build_order_intents(
+                budget_usd=Decimal("1000"), targets=[],
+                owned_positions=[Position("AAPL", Decimal("2"))],
+                quotes={"AAPL": self.quote}, instruments={"AAPL": self.instrument},
+            )
+
+    def test_manual_overlap_is_blocking(self) -> None:
+        conflicts = validate_position_ownership(
+            [Position("AAPL", Decimal("12"))], [Position("AAPL", Decimal("10"))], ["AAPL"],
+        )
+        self.assertEqual(conflicts, ["AAPL"])
+
+    def test_unrelated_manual_position_is_not_owned(self) -> None:
+        conflicts = validate_position_ownership(
+            [Position("MSFT", Decimal("4"))], [], ["AAPL"],
+        )
+        self.assertEqual(conflicts, [])
+
+    def test_execution_window_is_new_york_regular_hours_only(self) -> None:
+        zone = ZoneInfo("America/New_York")
+        self.assertTrue(in_execution_window(datetime(2026, 8, 24, 10, 0, tzinfo=zone)))
+        self.assertFalse(in_execution_window(datetime(2026, 8, 24, 9, 59, tzinfo=zone)))
+        self.assertFalse(in_execution_window(datetime(2026, 8, 23, 11, 0, tzinfo=zone)))
+
+    def test_contract_liquid_hours_block_a_closed_session(self) -> None:
+        zone = ZoneInfo("America/New_York")
+        open_instrument = Instrument(
+            "AAPL", 1, "USD", "NASDAQ", Decimal("0.01"), Decimal("1"), False, True,
+            liquid_hours="20260824:0930-20260824:1600", time_zone="US/Eastern",
+        )
+        self.assertTrue(instrument_session_is_open(open_instrument, datetime(2026, 8, 24, 10, 0, tzinfo=zone)))
+        self.assertFalse(instrument_session_is_open(open_instrument, datetime(2026, 8, 24, 17, 0, tzinfo=zone)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/trading_executor/tests/test_reporter.py
+++ b/trading_executor/tests/test_reporter.py
@@ -44,6 +44,25 @@ class ReporterRecoveryTests(unittest.TestCase):
         self.assertEqual([event["exec_id"] for event in client.events[1:]], ["exec-a", "exec-b"])
         self.assertTrue(client.events[0]["raw_status"]["recovered"])
 
+    def test_recovery_reports_only_latest_execution_correction(self) -> None:
+        plan_id = "00000000-0000-4000-8000-000000000001"
+        client_key = f"hib:{plan_id}:MSFT:BUY:r1:a1"
+        common = {
+            "client_order_key": client_key, "symbol": "MSFT", "side": "BUY",
+            "conid": 1, "ib_order_id": 42, "ib_perm_id": 84,
+        }
+        snapshot = BrokerSnapshot(
+            account_id="DU12345", positions=[], settled_cash_usd=Decimal("100"),
+            executions=(
+                BrokerExecution(fill=ExecutionFill("0001.01", Decimal("1"), Decimal("100")), **common),
+                BrokerExecution(fill=ExecutionFill("0001.02", Decimal("0.5"), Decimal("99")), **common),
+            ),
+        )
+        client = FakeClient()
+        ControlReporter(client).recover(snapshot)
+        self.assertEqual([event["exec_id"] for event in client.events if event["action"] == "fill"], ["0001.02"])
+        self.assertEqual(client.events[0]["filled_quantity"], "0.5")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/trading_executor/tests/test_reporter.py
+++ b/trading_executor/tests/test_reporter.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import unittest
+from decimal import Decimal
+
+from trading_executor.engine import BrokerExecution, BrokerSnapshot, ExecutionFill
+from trading_executor.reporter import ControlReporter
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.events: list[dict] = []
+
+    def event(self, payload: dict) -> dict:
+        self.events.append(payload)
+        if payload["action"] == "order":
+            return {"order_id": "00000000-0000-4000-8000-000000000099"}
+        return {"accepted": True}
+
+
+class ReporterRecoveryTests(unittest.TestCase):
+    def test_broker_first_recovery_reports_each_exec_id_before_retry(self) -> None:
+        plan_id = "00000000-0000-4000-8000-000000000001"
+        client_key = f"hib:{plan_id}:MSFT:BUY:r1:a1"
+        snapshot = BrokerSnapshot(
+            account_id="DU12345", positions=[], settled_cash_usd=Decimal("100"),
+            executions=(
+                BrokerExecution(
+                    client_order_key=client_key, symbol="MSFT", side="BUY", conid=1,
+                    ib_order_id=42, ib_perm_id=84,
+                    fill=ExecutionFill("exec-a", Decimal("0.4"), Decimal("100"), Decimal("0.10"), executed_at="2026-08-24T14:00:00+00:00"),
+                ),
+                BrokerExecution(
+                    client_order_key=client_key, symbol="MSFT", side="BUY", conid=1,
+                    ib_order_id=42, ib_perm_id=84,
+                    fill=ExecutionFill("exec-b", Decimal("0.6"), Decimal("101"), Decimal("0.15"), executed_at="2026-08-24T14:00:01+00:00"),
+                ),
+            ),
+        )
+        client = FakeClient()
+        recovered = ControlReporter(client).recover(snapshot)
+        self.assertEqual(recovered, 1)
+        self.assertEqual([event["action"] for event in client.events], ["order", "fill", "fill"])
+        self.assertEqual([event["exec_id"] for event in client.events[1:]], ["exec-a", "exec-b"])
+        self.assertTrue(client.events[0]["raw_status"]["recovered"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
﻿## Summary

- add an IBKR Paper-only control plane and Trading UI for frozen Portfolio Returns strategies, with one-time pairing, HMAC/replay protection, eligibility, previews, audit history, Telegram alerts, and a hard Paper/4002 boundary
- execute the natural snapshot target set (N may be below 20) with full N/N quantity coverage, sell-before-buy sequencing, fresh marketable limits, WhatIf, settled-USD-only buying, and no empty-target liquidation
- harden ownership and accounting so only correction-aware system fills create strategy-owned positions/cash; broker positions remain observations and unrelated account cash cannot refill strategy losses
- make the Windows executor durable and single-writer with a per-connection SQLite WAL outbox/order-intent journal, local lock, server lease, kill-switch polling, broker-first recovery, execution correction handling, and current TWS API error-callback compatibility

## Preview

URL: https://pr-134-hedge-in-a-box-site.fly.dev

The preview intentionally exposes only UI and branched portfolio data. AUTH_BYPASS_PREVIEW disables pairing and every trading mutation/executor endpoint.

## Test plan

- [x] python -m unittest discover -s trading_executor/tests -v (29 tests; 6 end-to-end integration scenarios)
- [x] integration: signed HTTP outage/replay preserves order-before-fill ordering
- [x] integration: current IBKR error callback, 7-day execution filter, restart recovery, and latest correction revision
- [x] integration: ambiguous order intent cannot resubmit; duplicate local executor is rejected; kill switch stops before submit; retry price cannot worsen
- [x] npm run test:portfolio (27 frontend/security/data-contract tests)
- [x] focused ESLint across all touched frontend/API files
- [x] python -m pytest tests/test_workspace_isolation.py -q (7 passed)
- [x] npm run build (production compile and TypeScript passed)
- [x] preview Neon migration 013 applied successfully against PostgreSQL
- [x] refreshed Fly preview at b016c14: both Trading pages return 200, deployed UI includes strategy cash/N/N, and pairing/sync/events mutations return disabled/503
- [ ] after merge: configure production secrets, generate a Nasdaq-100 Paper snapshot, pair the Windows VM, verify heartbeat, then complete the IBKR Paper validation gate

## Notes for reviewer

- Live remains disabled in Fly config and is refused by the executor; port 4001 is not accepted.
- IBKR credentials and 2FA never enter Fly or Neon. DPAPI protects the local account/device secret; the SQLite journal contains no IBKR login secret.
- Strategy ownership is rebuilt only from the latest correction revision in each IBKR execution family. The executor endpoint explicitly rejects attempts to replace ownership from raw broker positions.
- A stable executor instance acquires the server lease before touching IB Gateway. It renews/checks the lease before every real order and while an order is open. Re-pairing clears a stale lease.
- Control-plane events are persisted before transmission. A crash after order preparation cannot cause an automatic duplicate; ambiguous state requires broker evidence or manual reconciliation.
- Buys are capped by both IBKR SettledCash and the strategy-owned cash ledger. Same-day sale proceeds wait for settlement, margin buying power is ignored, and external account cash cannot top up the strategy.
- Actual authenticated IBKR validation remains an operational post-merge Paper gate because CI cannot log into the owner's Gateway. The checklist is in docs/ibkr-paper-trading.md and trading_executor/README.md.


### Navigation icon follow-up
- Replaced the Trading sidebar candlestick with BriefcaseBusiness; Technical Analysis keeps ChartCandlestick.
- 
pm run build and focused ESLint passed.
- Verified on the deployed preview: /analysis/trading renders lucide-briefcase-business, while /analysis/dashboard/AAPL/technical-analysis renders lucide-chart-candlestick; both returned HTTP 200.