### PR TITLE
Deduplicate Nasdaq universe runs by issuer

### DIFF
--- a/frontend/src/components/shell/nasdaq-run-modal.tsx
+++ b/frontend/src/components/shell/nasdaq-run-modal.tsx
@@ -322,7 +322,7 @@ export function NasdaqRunModal({
                     : " · enforcement disabled"}
                 </p>
                 <p className="mt-2 text-xs text-[color:var(--text-muted)]">
-                  Universe: {stocks.length} securities · {data.universe?.source || "Unknown source"} · as of {formatDate(data.universe?.asOf)}
+                  Universe: {stocks.length} companies · {data.universe?.source || "Unknown source"} · as of {formatDate(data.universe?.asOf)}
                 </p>
               </div>
 

--- a/frontend/src/lib/nasdaq-run-policy.test.ts
+++ b/frontend/src/lib/nasdaq-run-policy.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { selectNasdaqRunStocks } from "./nasdaq-run-policy";
+import { deduplicateNasdaqIssuerStocks, selectNasdaqRunStocks } from "./nasdaq-run-policy";
 
 const UNIVERSE = [
   { ticker: "AAPL", companyName: "Apple", rank: 1 },
@@ -31,5 +31,52 @@ test("selected mode cannot queue symbols outside the Nasdaq universe", () => {
     selectedTickers: ["NVDA", "TSLA"],
   });
   assert.deepEqual(stocks.map((stock) => stock.ticker), ["NVDA"]);
+});
+
+const ALPHABET_UNIVERSE = [
+  { ticker: "GOOGL", companyName: "Alphabet Inc. Class A Common Stock", rank: 5 },
+  { ticker: "GOOG", companyName: "Alphabet Inc. Class C Capital Stock", rank: 6 },
+  { ticker: "AAPL", companyName: "Apple Inc.", rank: 1 },
+];
+
+test("issuer deduplication keeps GOOGL and exposes GOOG only as an alias", () => {
+  const stocks = deduplicateNasdaqIssuerStocks(ALPHABET_UNIVERSE);
+  assert.deepEqual(stocks.map((stock) => stock.ticker), ["GOOGL", "AAPL"]);
+  assert.deepEqual(stocks[0].aliases, ["GOOGL", "GOOG"]);
+});
+
+test("all mode never queues both Alphabet share classes", () => {
+  const stocks = selectNasdaqRunStocks(ALPHABET_UNIVERSE, { mode: "all" });
+  assert.deepEqual(stocks.map((stock) => stock.ticker), ["GOOGL", "AAPL"]);
+});
+
+test("selected mode maps either or both Alphabet symbols to GOOGL", () => {
+  for (const selectedTickers of [["GOOG"], ["GOOGL"], ["GOOG", "GOOGL"]]) {
+    const stocks = selectNasdaqRunStocks(ALPHABET_UNIVERSE, { mode: "selected", selectedTickers });
+    assert.deepEqual(stocks.map((stock) => stock.ticker), ["GOOGL"]);
+  }
+});
+
+test("missing-week and resume modes treat a GOOG report as completed GOOGL coverage", () => {
+  const missingWeek = selectNasdaqRunStocks(ALPHABET_UNIVERSE, {
+    mode: "missing_week",
+    recentlyCompletedTickers: ["GOOG"],
+  });
+  assert.deepEqual(missingWeek.map((stock) => stock.ticker), ["AAPL"]);
+
+  const resumed = selectNasdaqRunStocks(ALPHABET_UNIVERSE, {
+    mode: "all",
+    resumedReleaseTickers: ["GOOG"],
+  });
+  assert.deepEqual(resumed.map((stock) => stock.ticker), ["AAPL"]);
+});
+
+test("future same-issuer share classes collapse to the best-ranked security", () => {
+  const stocks = deduplicateNasdaqIssuerStocks([
+    { ticker: "TESTB", companyName: "Test Holdings Class B Common Stock", rank: 40 },
+    { ticker: "TESTA", companyName: "Test Holdings Class A Common Stock", rank: 39 },
+  ]);
+  assert.deepEqual(stocks.map((stock) => stock.ticker), ["TESTA"]);
+  assert.deepEqual(stocks[0].aliases, ["TESTB", "TESTA"]);
 });
 

--- a/frontend/src/lib/nasdaq-run-policy.ts
+++ b/frontend/src/lib/nasdaq-run-policy.ts
@@ -2,6 +2,86 @@ import type { NasdaqUniverseStock } from "@/lib/nasdaq-universe";
 
 export type NasdaqRunSelectionMode = "all" | "selected" | "missing_week";
 
+const KNOWN_ISSUER_GROUPS = [
+  { canonicalTicker: "GOOGL", tickers: ["GOOGL", "GOOG"] },
+] as const;
+
+const knownIssuerKeyByTicker = new Map<string, string>();
+const knownIssuerTickersByKey = new Map<string, readonly string[]>();
+for (const group of KNOWN_ISSUER_GROUPS) {
+  const key = `ticker:${group.canonicalTicker}`;
+  knownIssuerTickersByKey.set(key, group.tickers);
+  for (const ticker of group.tickers) knownIssuerKeyByTicker.set(ticker, key);
+}
+
+function cleanTicker(value: unknown): string {
+  return String(value || "").trim().toUpperCase();
+}
+
+function issuerNameKey(value: string): string {
+  return value
+    .trim()
+    .toUpperCase()
+    .replace(/\b(?:CLASS|CL)\s+[A-Z0-9]+\b.*$/, "")
+    .replace(/[^A-Z0-9]+/g, " ")
+    .trim();
+}
+
+function issuerKey(stock: NasdaqUniverseStock): string {
+  const ticker = cleanTicker(stock.ticker);
+  const knownKey = knownIssuerKeyByTicker.get(ticker);
+  if (knownKey) return knownKey;
+  const nameKey = issuerNameKey(stock.companyName);
+  return nameKey ? `name:${nameKey}` : `ticker:${ticker}`;
+}
+
+function rankValue(stock: NasdaqUniverseStock): number {
+  return stock.rank == null || !Number.isFinite(stock.rank) ? Number.POSITIVE_INFINITY : stock.rank;
+}
+
+function preferCandidate(
+  key: string,
+  existing: NasdaqUniverseStock,
+  candidate: NasdaqUniverseStock,
+): boolean {
+  const canonicalTicker = key.startsWith("ticker:") ? key.slice("ticker:".length) : "";
+  const existingIsCanonical = cleanTicker(existing.ticker) === canonicalTicker;
+  const candidateIsCanonical = cleanTicker(candidate.ticker) === canonicalTicker;
+  if (existingIsCanonical !== candidateIsCanonical) return candidateIsCanonical;
+  if (rankValue(existing) !== rankValue(candidate)) return rankValue(candidate) < rankValue(existing);
+  return cleanTicker(candidate.ticker).localeCompare(cleanTicker(existing.ticker)) < 0;
+}
+
+/**
+ * Collapse multiple listed share classes into one executable company row.
+ * Known groups have an explicit canonical ticker; otherwise the best-ranked
+ * security from rows sharing the same issuer name is retained.
+ */
+export function deduplicateNasdaqIssuerStocks(stocks: NasdaqUniverseStock[]): NasdaqUniverseStock[] {
+  const groups = new Map<string, { stock: NasdaqUniverseStock; aliases: Set<string> }>();
+
+  for (const rawStock of stocks) {
+    const ticker = cleanTicker(rawStock.ticker);
+    if (!ticker) continue;
+    const stock = { ...rawStock, ticker };
+    const key = issuerKey(stock);
+    const aliases = [ticker, ...(rawStock.aliases || []).map(cleanTicker)].filter(Boolean);
+    const knownAliases = knownIssuerTickersByKey.get(key) || [];
+    const existing = groups.get(key);
+    if (!existing) {
+      groups.set(key, { stock, aliases: new Set([...knownAliases, ...aliases]) });
+      continue;
+    }
+    for (const alias of [...knownAliases, ...aliases]) existing.aliases.add(alias);
+    if (preferCandidate(key, existing.stock, stock)) existing.stock = stock;
+  }
+
+  return Array.from(groups.values(), ({ stock, aliases }) => ({
+    ...stock,
+    aliases: Array.from(aliases),
+  }));
+}
+
 export function selectNasdaqRunStocks(
   stocks: NasdaqUniverseStock[],
   opts: {
@@ -11,22 +91,30 @@ export function selectNasdaqRunStocks(
     resumedReleaseTickers?: Iterable<string>;
   },
 ): NasdaqUniverseStock[] {
+  const uniqueStocks = deduplicateNasdaqIssuerStocks(stocks);
+  const tickerByAlias = new Map<string, string>();
+  for (const stock of uniqueStocks) {
+    tickerByAlias.set(cleanTicker(stock.ticker), stock.ticker);
+    for (const alias of stock.aliases || []) tickerByAlias.set(cleanTicker(alias), stock.ticker);
+  }
   const normalized = (values: Iterable<string> | undefined) => new Set(
-    Array.from(values || [], (value) => String(value || "").trim().toUpperCase()).filter(Boolean),
+    Array.from(values || [], (value) => cleanTicker(value))
+      .filter(Boolean)
+      .map((ticker) => tickerByAlias.get(ticker) || ticker),
   );
 
   if (opts.resumedReleaseTickers) {
     const completed = normalized(opts.resumedReleaseTickers);
-    return stocks.filter((stock) => !completed.has(stock.ticker));
+    return uniqueStocks.filter((stock) => !completed.has(stock.ticker));
   }
   if (opts.mode === "selected") {
     const selected = normalized(opts.selectedTickers);
-    return stocks.filter((stock) => selected.has(stock.ticker));
+    return uniqueStocks.filter((stock) => selected.has(stock.ticker));
   }
   if (opts.mode === "missing_week") {
     const recent = normalized(opts.recentlyCompletedTickers);
-    return stocks.filter((stock) => !recent.has(stock.ticker));
+    return uniqueStocks.filter((stock) => !recent.has(stock.ticker));
   }
-  return [...stocks];
+  return uniqueStocks;
 }
 

--- a/frontend/src/lib/nasdaq-runs-db.ts
+++ b/frontend/src/lib/nasdaq-runs-db.ts
@@ -9,7 +9,7 @@ import {
   configuredNasdaqConcurrency,
   configuredNasdaqCostPerAttempt,
 } from "@/lib/nasdaq-execution-policy";
-import { selectNasdaqRunStocks } from "@/lib/nasdaq-run-policy";
+import { deduplicateNasdaqIssuerStocks, selectNasdaqRunStocks } from "@/lib/nasdaq-run-policy";
 import type { NasdaqUniverseSnapshot, NasdaqUniverseStock } from "@/lib/nasdaq-universe";
 
 export type NasdaqRunMode = "all" | "selected" | "missing_week";
@@ -279,17 +279,22 @@ async function recentResume(): Promise<ResumeRow | null> {
 
 function snapshotStocks(value: unknown): NasdaqUniverseStock[] {
   if (!Array.isArray(value)) return [];
-  return value.flatMap((entry) => {
+  const stocks = value.flatMap((entry) => {
     if (!entry || typeof entry !== "object") return [];
     const row = entry as Record<string, unknown>;
     const ticker = String(row.ticker || "").trim().toUpperCase();
     if (!ticker) return [];
+    const aliases = Array.isArray(row.aliases)
+      ? row.aliases.map((alias) => String(alias || "").trim().toUpperCase()).filter(Boolean)
+      : undefined;
     return [{
       ticker,
       companyName: String(row.companyName || row.company_name || ticker),
       rank: Number.isFinite(Number(row.rank)) ? Number(row.rank) : null,
+      aliases,
     }];
   });
+  return deduplicateNasdaqIssuerStocks(stocks);
 }
 
 async function completedTickersForRelease(releaseId: string): Promise<Set<string>> {

--- a/frontend/src/lib/nasdaq-universe.ts
+++ b/frontend/src/lib/nasdaq-universe.ts
@@ -3,10 +3,13 @@ import "server-only";
 import fs from "node:fs/promises";
 import path from "node:path";
 
+import { deduplicateNasdaqIssuerStocks } from "@/lib/nasdaq-run-policy";
+
 export type NasdaqUniverseStock = {
   ticker: string;
   companyName: string;
   rank: number | null;
+  aliases?: string[];
 };
 
 export type NasdaqUniverseSnapshot = {
@@ -44,12 +47,13 @@ export function normalizeNasdaqUniverse(raw: RawUniverse): NasdaqUniverseStock[]
       rank: Number.isFinite(rankValue) ? rankValue : null,
     });
   }
-  return Array.from(byTicker.values()).sort((a, b) => {
+  const sorted = Array.from(byTicker.values()).sort((a, b) => {
     if (a.rank != null && b.rank != null) return a.rank - b.rank;
     if (a.rank != null) return -1;
     if (b.rank != null) return 1;
     return a.ticker.localeCompare(b.ticker);
   });
+  return deduplicateNasdaqIssuerStocks(sorted);
 }
 
 async function readUniverseFile(filePath: string): Promise<{ raw: RawUniverse; modifiedAt: string } | null> {

--- a/scripts/nasdaq_universe_run.py
+++ b/scripts/nasdaq_universe_run.py
@@ -120,13 +120,31 @@ def _heartbeat(run_id: str, runner_prefix: str, stop: threading.Event) -> None:
             pass
 
 
-def _release_has_full_coverage(conn, release_id: str, snapshot: object) -> bool:
-    expected = {
-        str(row.get("ticker") or "").strip().upper()
-        for row in (snapshot if isinstance(snapshot, list) else [])
-        if isinstance(row, dict) and str(row.get("ticker") or "").strip()
+def _snapshot_has_full_coverage(snapshot: object, actual_tickers: object) -> bool:
+    actual = {
+        str(ticker or "").strip().upper()
+        for ticker in (actual_tickers if isinstance(actual_tickers, (list, set, tuple)) else [])
+        if str(ticker or "").strip()
     }
-    if not expected:
+    expected_groups: list[set[str]] = []
+    for row in snapshot if isinstance(snapshot, list) else []:
+        if not isinstance(row, dict):
+            continue
+        ticker = str(row.get("ticker") or "").strip().upper()
+        aliases = {
+            str(alias or "").strip().upper()
+            for alias in (row.get("aliases") if isinstance(row.get("aliases"), list) else [])
+            if str(alias or "").strip()
+        }
+        if ticker:
+            aliases.add(ticker)
+        if aliases:
+            expected_groups.append(aliases)
+    return bool(expected_groups) and all(group & actual for group in expected_groups)
+
+
+def _release_has_full_coverage(conn, release_id: str, snapshot: object) -> bool:
+    if not isinstance(snapshot, list) or not snapshot:
         return False
     with conn.cursor() as cur:
         cur.execute(
@@ -140,7 +158,7 @@ def _release_has_full_coverage(conn, release_id: str, snapshot: object) -> bool:
             (release_id,),
         )
         actual = {str(row[0] or "").strip().upper() for row in cur.fetchall()}
-    return expected.issubset(actual)
+    return _snapshot_has_full_coverage(snapshot, actual)
 
 
 def _load_and_start_run(conn, run_id: str) -> dict[str, Any]:

--- a/tests/test_nasdaq_execution.py
+++ b/tests/test_nasdaq_execution.py
@@ -9,6 +9,7 @@ from ai_hedge.nasdaq_execution import (
     is_preferred_off_peak_utc,
     retry_delay_seconds,
 )
+from scripts.nasdaq_universe_run import _snapshot_has_full_coverage
 
 
 def _utc(hour: int, minute: int = 0) -> datetime:
@@ -45,3 +46,18 @@ def test_ticker_timeout_is_bounded(monkeypatch) -> None:
     assert configured_ticker_timeout_seconds() == 30 * 60
     monkeypatch.setenv("NASDAQ_TICKER_TIMEOUT_SECONDS", "999999")
     assert configured_ticker_timeout_seconds() == 6 * 60 * 60
+
+
+def test_release_coverage_accepts_any_saved_alias_for_an_issuer() -> None:
+    snapshot = [
+        {
+            "ticker": "GOOGL",
+            "companyName": "Alphabet Inc. Class A Common Stock",
+            "aliases": ["GOOGL", "GOOG"],
+        },
+        {"ticker": "AAPL", "companyName": "Apple Inc.", "aliases": ["AAPL"]},
+    ]
+
+    assert _snapshot_has_full_coverage(snapshot, {"GOOG", "AAPL"})
+    assert _snapshot_has_full_coverage(snapshot, {"GOOGL", "AAPL"})
+    assert not _snapshot_has_full_coverage(snapshot, {"AAPL"})


### PR DESCRIPTION
## Summary

- collapse multiple Nasdaq-listed share classes into one executable issuer row
- use GOOGL as Alphabet's canonical run ticker while treating GOOG as an alias in selected, missing-week, and resume modes
- preserve alias-aware release coverage so historical GOOG reports satisfy Alphabet coverage

## Preview

URL: https://pr-135-hedge-in-a-box-site.fly.dev

Verified on the deployed preview:
- `/nasdaq100/reports` returns HTTP 200
- `/api/screeners/nasdaq100?workspace=nasdaq100` returns the current 102-security source universe
- the deployed client bundle contains the `Universe: ... companies` UI and the GOOGL/GOOG grouping code
- `/api/nasdaq100/runs` correctly enforces the run-password gate; no paid analysis was started during verification

## Test plan

- [x] `npm exec eslint -- src/lib/nasdaq-run-policy.ts src/lib/nasdaq-run-policy.test.ts src/lib/nasdaq-universe.ts src/lib/nasdaq-runs-db.ts src/components/shell/nasdaq-run-modal.tsx`
- [x] `npm run test:portfolio` (32 passed)
- [x] `PYTHONPATH=src python -m pytest tests/test_nasdaq_execution.py tests/test_nasdaq_worker_server.py tests/test_workspace_isolation.py -q` (16 passed)
- [x] `python -m compileall -q scripts/nasdaq_universe_run.py`
- [x] `npm run build`
- [x] verify the deployed Nasdaq reports page, source-universe API, client bundle, and authorization gate

## Notes for reviewer

- The Nasdaq screener can continue to show every index security. This change is scoped to the executable universe and prevents duplicate issuer analysis jobs.
- The current 102-security source becomes 101 executable companies because GOOG is retained only as an alias of GOOGL.