### PR TITLE
Reduce GitHub preview notification noise

### DIFF
--- a/.github/workflows/preview-obs.yml
+++ b/.github/workflows/preview-obs.yml
@@ -11,7 +11,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 concurrency:
   group: preview-obs-pr-${{ github.event.pull_request.number }}
@@ -153,22 +152,22 @@ jobs:
           timeout 30 flyctl logs --app "${{ env.PREVIEW_APP }}" || true
           echo '::endgroup::'
 
-      - name: Sticky comment with preview URL
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: obs-preview
-          message: |
-            ### Obs preview deployed
+      - name: Publish preview summary
+        run: |
+          echo "::notice title=Obs preview::https://${PREVIEW_APP}.fly.dev"
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ### Obs preview deployed
 
-            **URL:** https://${{ env.PREVIEW_APP }}.fly.dev
+          **URL:** https://${PREVIEW_APP}.fly.dev
 
-            ⚠️ **Auth is bypassed on previews** — Google OAuth doesn't allow wildcard
-            redirect URIs for `pr-*` hostnames, so the preview hands out admin access
-            to anyone with the URL. Don't share it externally.
+          ⚠️ **Auth is bypassed on previews** — Google OAuth doesn't allow wildcard
+          redirect URIs for \`pr-*\` hostnames, so the preview hands out admin access
+          to anyone with the URL. Don't share it externally.
 
-            - DB is a Neon branch (`${{ env.NEON_BRANCH_NAME }}`) off prod's `${{ env.NEON_PARENT_BRANCH }}` — safe to mutate.
-            - Machine auto-stops when idle, auto-starts on request.
-            - Tear-down (Fly app + Neon branch) runs automatically when this PR is closed.
+          - DB is a Neon branch (\`${NEON_BRANCH_NAME}\`) off prod's \`${NEON_PARENT_BRANCH}\` — safe to mutate.
+          - Machine auto-stops when idle, auto-starts on request.
+          - Tear-down (Fly app + Neon branch) runs automatically when this PR is closed.
+          EOF
 
   teardown:
     if: github.event.action == 'closed'
@@ -219,11 +218,10 @@ jobs:
             echo "Neon branch $NEON_BRANCH_NAME already gone — nothing to delete."
           fi
 
-      - name: Update sticky comment
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: obs-preview
-          message: |
-            ### Obs preview torn down
+      - name: Publish teardown summary
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ### Obs preview torn down
 
-            The preview environment for this PR has been destroyed.
+          The preview environment for this PR has been destroyed.
+          EOF

--- a/.github/workflows/preview-site.yml
+++ b/.github/workflows/preview-site.yml
@@ -13,7 +13,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 concurrency:
   group: preview-site-pr-${{ github.event.pull_request.number }}
@@ -284,24 +283,24 @@ jobs:
           timeout 30 flyctl logs --app "${{ env.PREVIEW_APP }}" || true
           echo '::endgroup::'
 
-      - name: Sticky comment with preview URL
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: site-preview
-          message: |
-            ### Site preview deployed
+      - name: Publish preview summary
+        run: |
+          echo "::notice title=Site preview::https://${PREVIEW_APP}.fly.dev"
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ### Site preview deployed
 
-            **URL:** https://${{ env.PREVIEW_APP }}.fly.dev
+          **URL:** https://${PREVIEW_APP}.fly.dev
 
-            ⚠️ **Auth is bypassed on previews** — Google OAuth doesn't allow wildcard
-            redirect URIs for `pr-*` hostnames, so the preview hands out signed-in
-            access to anyone with the URL. Don't share it externally.
+          ⚠️ **Auth is bypassed on previews** — Google OAuth doesn't allow wildcard
+          redirect URIs for \`pr-*\` hostnames, so the preview hands out signed-in
+          access to anyone with the URL. Don't share it externally.
 
-            - Volume forked from prod on PR open; staleness accepted until close.
-            - Site DB is a Neon branch (`${{ env.NEON_BRANCH_NAME }}`) off prod's `${{ env.NEON_PARENT_BRANCH }}` — safe to mutate.
-            - **Obs DB is the prod obs DB** (no branching). Pipeline runs from this preview write `obs_runs` / `obs_calls` rows tagged with `source = "preview-pr-${{ github.event.pull_request.number }}"` so they're easy to filter or clean up later.
-            - Machine auto-stops when idle, auto-starts on request. It stays up for the duration of an active analysis run (self-ping keep-alive), then auto-stops — so mid-run analyses survive a closed tab.
-            - Tear-down (Fly app + volume + Neon branch) runs automatically when this PR is closed.
+          - Volume forked from prod on PR open; staleness accepted until close.
+          - Site DB is a Neon branch (\`${NEON_BRANCH_NAME}\`) off prod's \`${NEON_PARENT_BRANCH}\` — safe to mutate.
+          - **Obs DB is the prod obs DB** (no branching). Pipeline runs from this preview write \`obs_runs\` / \`obs_calls\` rows tagged with \`source = "preview-pr-${{ github.event.pull_request.number }}"\` so they're easy to filter or clean up later.
+          - Machine auto-stops when idle, auto-starts on request. It stays up for the duration of an active analysis run (self-ping keep-alive), then auto-stops — so mid-run analyses survive a closed tab.
+          - Tear-down (Fly app + volume + Neon branch) runs automatically when this PR is closed.
+          EOF
 
   teardown:
     if: github.event.action == 'closed'
@@ -352,11 +351,10 @@ jobs:
             echo "Neon branch $NEON_BRANCH_NAME already gone — nothing to delete."
           fi
 
-      - name: Update sticky comment
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: site-preview
-          message: |
-            ### Site preview torn down
+      - name: Publish teardown summary
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ### Site preview torn down
 
-            The preview environment for this PR has been destroyed.
+          The preview environment for this PR has been destroyed.
+          EOF


### PR DESCRIPTION
## Summary
- replace the site and observability preview bot comments with GitHub Actions job summaries and notices
- remove `pull-requests: write` from both preview workflows
- keep the preview URLs and security/teardown guidance available inside each workflow run

The failing **Trading Executor Monitor** workflow was also disabled manually in GitHub because the required `TRADING_MONITOR_TOKEN` repository secret is not configured. It should only be re-enabled after the same token is configured for GitHub Actions and the production Fly app, followed by a successful manual run.

## Preview verification
- Site: https://pr-137-hedge-in-a-box-site.fly.dev — HTTP 200, redirected to `/analysis/reports`, title `Hedge in a Box`
- Obs: https://pr-137-hedge-in-a-box-obs.fly.dev — HTTP 200, redirected to `/runs`, title `Hedge Observability`
- Both deploy checks succeeded and the PR has no bot comments after completion

## Test plan
- [x] Parse both workflow files as YAML
- [x] Assert read-only permissions, no sticky-comment action, and deploy/teardown summaries
- [x] Run `git diff --check`
- [x] Confirm Site Preview succeeds
- [x] Confirm Obs Preview succeeds
- [x] Verify both preview URLs respond
- [x] Verify this PR receives no preview bot comment