### PR TITLE
Harden Nasdaq universe retries and stop diagnostics

### DIFF
--- a/.github/workflows/deploy-fly.yml
+++ b/.github/workflows/deploy-fly.yml
@@ -146,7 +146,10 @@ jobs:
 
   deploy-nasdaq-worker:
     needs: deploy-site
-    if: always() && (github.event_name == 'push' || inputs.target == 'all' || inputs.target == 'nasdaq-worker')
+    if: >-
+      always()
+      && (github.event_name == 'push' || inputs.target == 'all' || inputs.target == 'nasdaq-worker')
+      && (inputs.target == 'nasdaq-worker' || needs.deploy-site.result == 'success')
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:

--- a/frontend/src/components/shell/nasdaq-run-modal.tsx
+++ b/frontend/src/components/shell/nasdaq-run-modal.tsx
@@ -16,10 +16,14 @@ export type NasdaqRunSummary = {
   releaseId: string;
   requestedMode: "all" | "selected" | "missing_week";
   effectiveMode: "all" | "selected" | "missing_week" | "resume_week";
-  status: "queued" | "running" | "completed" | "partial" | "failed";
+  status: "queued" | "running" | "completed" | "partial" | "failed" | "stopped";
   requestedCount: number;
   completedCount: number;
   failedCount: number;
+  stoppedCount: number;
+  stoppedBeforeStartCount: number;
+  stoppedAfterAttemptCount: number;
+  retryPendingCount: number;
   activeCount: number;
   leadingTicker: string;
   leadingProgressPct: number;
@@ -314,7 +318,7 @@ export function NasdaqRunModal({
               ) : null}
 
               <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4 text-sm text-[color:var(--text-secondary)]">
-                <p>Each ticker is retried up to 3 times. A completed report is published immediately, even if the wider run later stops.</p>
+                <p>Each ticker is attempted up to 3 times. A completed report is published immediately, even if the wider run later stops.</p>
                 <p className="mt-2 text-xs text-[color:var(--text-muted)]">
                   Execution window: {data.executionWindow?.label || "10:00-01:00 UTC"}
                   {data.executionWindow?.enforced
@@ -343,10 +347,23 @@ export function NasdaqRunModal({
                     {latestRun.observedCostUsd > 0 ? ` · $${latestRun.observedCostUsd.toFixed(2)} observed` : ""}
                     {` · $${latestRun.budgetLimitUsd.toFixed(0)} limit`}
                   </p>
-                  {latestRun.stopRequestedAt ? (
+                  {latestRun.retryPendingCount || latestRun.stoppedCount ? (
+                    <p className="mt-2 text-xs text-[color:var(--text-muted)]">
+                      {latestRun.retryPendingCount ? `${latestRun.retryPendingCount} waiting to retry` : ""}
+                      {latestRun.retryPendingCount && latestRun.stoppedBeforeStartCount ? " / " : ""}
+                      {latestRun.stoppedBeforeStartCount ? `${latestRun.stoppedBeforeStartCount} not started` : ""}
+                      {(latestRun.retryPendingCount || latestRun.stoppedBeforeStartCount) && latestRun.stoppedAfterAttemptCount ? " / " : ""}
+                      {latestRun.stoppedAfterAttemptCount ? `${latestRun.stoppedAfterAttemptCount} stopped before retry` : ""}
+                    </p>
+                  ) : null}
+                  {latestRun.stopRequestedAt && (latestRun.status === "queued" || latestRun.status === "running") ? (
                     <p className="mt-2 text-xs text-[color:var(--warning)]">Stop requested. Active stocks are finishing.</p>
                   ) : null}
-                  {latestRun.error ? <p className="mt-2 text-xs text-[color:var(--danger)]">{latestRun.error}</p> : null}
+                  {latestRun.error ? (
+                    <p className={`mt-2 text-xs ${latestRun.status === "stopped" ? "text-[color:var(--warning)]" : "text-[color:var(--danger)]"}`}>
+                      {latestRun.error}
+                    </p>
+                  ) : null}
                 </div>
               ) : null}
 

--- a/frontend/src/lib/nasdaq-runs-db.ts
+++ b/frontend/src/lib/nasdaq-runs-db.ts
@@ -13,7 +13,7 @@ import { deduplicateNasdaqIssuerStocks, selectNasdaqRunStocks } from "@/lib/nasd
 import type { NasdaqUniverseSnapshot, NasdaqUniverseStock } from "@/lib/nasdaq-universe";
 
 export type NasdaqRunMode = "all" | "selected" | "missing_week";
-export type NasdaqRunStatus = "queued" | "running" | "completed" | "partial" | "failed";
+export type NasdaqRunStatus = "queued" | "running" | "completed" | "partial" | "failed" | "stopped";
 
 export type NasdaqRunSummary = {
   id: string;
@@ -24,6 +24,10 @@ export type NasdaqRunSummary = {
   requestedCount: number;
   completedCount: number;
   failedCount: number;
+  stoppedCount: number;
+  stoppedBeforeStartCount: number;
+  stoppedAfterAttemptCount: number;
+  retryPendingCount: number;
   activeCount: number;
   leadingTicker: string;
   leadingProgressPct: number;
@@ -57,6 +61,10 @@ type RunRow = {
   requested_count: number;
   completed_count: number;
   failed_count: number;
+  stopped_count: number;
+  stopped_before_start_count: number;
+  stopped_after_attempt_count: number;
+  retry_pending_count: number;
   active_count: number;
   leading_ticker?: string | null;
   leading_progress_pct?: number | null;
@@ -101,6 +109,10 @@ function toSummary(row: RunRow): NasdaqRunSummary {
     requestedCount: Number(row.requested_count || 0),
     completedCount: Number(row.completed_count || 0),
     failedCount: Number(row.failed_count || 0),
+    stoppedCount: Number(row.stopped_count || 0),
+    stoppedBeforeStartCount: Number(row.stopped_before_start_count || 0),
+    stoppedAfterAttemptCount: Number(row.stopped_after_attempt_count || 0),
+    retryPendingCount: Number(row.retry_pending_count || 0),
     activeCount: Number(row.active_count || 0),
     leadingTicker: String(row.leading_ticker || ""),
     leadingProgressPct: Math.max(0, Math.min(100, Number(row.leading_progress_pct || 0))),
@@ -128,23 +140,33 @@ export async function reconcileStaleNasdaqRuns(): Promise<number> {
          WHERE status IN ('queued', 'running')
            AND coalesce(heartbeat_at, started_at, created_at) < now() - interval '15 minutes'
          FOR UPDATE
-      ), failed_items AS (
+      ), stopped_items AS (
         UPDATE nasdaq_universe_run_items item
-           SET status = 'failed',
+           SET status = 'stopped',
                finished_at = coalesce(item.finished_at, now()),
                worker_id = NULL,
                lease_expires_at = NULL,
-               last_error = CASE WHEN item.last_error = ''
-                 THEN 'Interrupted before completion; eligible for a seven-day resume.'
-                 ELSE item.last_error END
+               final_status_reason = 'Interrupted before completion; eligible for a seven-day resume.'
           FROM stale_ids stale
          WHERE item.run_id = stale.id
            AND item.status IN ('pending', 'running')
         RETURNING item.run_id
+      ), stopped_attempts AS (
+        UPDATE nasdaq_universe_run_attempts attempt
+           SET status = 'stopped',
+               finished_at = coalesce(attempt.finished_at, now()),
+               error = CASE WHEN attempt.error = ''
+                 THEN 'Interrupted before the attempt was finalized.'
+                 ELSE attempt.error END
+          FROM stale_ids stale
+         WHERE attempt.run_id = stale.id
+           AND attempt.status = 'running'
+        RETURNING attempt.run_id
       ), counts AS (
         SELECT stale.id, run.release_id, run.requested_count, run.universe_count,
                count(*) FILTER (WHERE item.status = 'completed')::int AS completed_count,
-               count(*) FILTER (WHERE item.status IN ('failed', 'pending', 'running'))::int AS failed_count
+               count(*) FILTER (WHERE item.status = 'failed')::int AS failed_count,
+               count(*) FILTER (WHERE item.status IN ('stopped', 'pending', 'running'))::int AS stopped_count
           FROM stale_ids stale
           JOIN nasdaq_universe_runs run ON run.id = stale.id
           LEFT JOIN nasdaq_universe_run_items item ON item.run_id = stale.id
@@ -158,12 +180,12 @@ export async function reconcileStaleNasdaqRuns(): Promise<number> {
       ), updated_runs AS (
         UPDATE nasdaq_universe_runs run
          SET status = CASE
-               WHEN counts.requested_count > 0 AND counts.completed_count = counts.requested_count THEN 'completed'
-               WHEN counts.completed_count > 0 THEN 'partial'
-               ELSE 'failed'
+             WHEN counts.requested_count > 0 AND counts.completed_count = counts.requested_count THEN 'completed'
+               ELSE 'stopped'
              END,
              completed_count = counts.completed_count,
              failed_count = counts.failed_count,
+             stopped_count = counts.stopped_count,
              finished_at = coalesce(run.finished_at, now()),
              error = CASE
                WHEN counts.requested_count > 0 AND counts.completed_count = counts.requested_count THEN ''
@@ -197,7 +219,16 @@ export async function listNasdaqRuns(limit = 5): Promise<NasdaqRunSummary[]> {
   const rows = (await sql`
     SELECT id::text AS id, release_id::text AS release_id,
            requested_mode, effective_mode, status,
-           requested_count, completed_count, failed_count,
+           requested_count, completed_count, failed_count, stopped_count,
+           (SELECT count(*)::int FROM nasdaq_universe_run_items item
+             WHERE item.run_id = nasdaq_universe_runs.id
+               AND item.status = 'stopped' AND item.attempts = 0) AS stopped_before_start_count,
+           (SELECT count(*)::int FROM nasdaq_universe_run_items item
+             WHERE item.run_id = nasdaq_universe_runs.id
+               AND item.status = 'stopped' AND item.attempts > 0) AS stopped_after_attempt_count,
+           (SELECT count(*)::int FROM nasdaq_universe_run_items item
+             WHERE item.run_id = nasdaq_universe_runs.id
+               AND item.status = 'pending' AND item.attempts > 0) AS retry_pending_count,
            (SELECT count(*)::int FROM nasdaq_universe_run_items item
              WHERE item.run_id = nasdaq_universe_runs.id AND item.status = 'running') AS active_count,
            progress.leading_ticker,
@@ -267,7 +298,7 @@ async function recentResume(): Promise<ResumeRow | null> {
            run.universe_snapshot
       FROM nasdaq_universe_runs run
       JOIN report_releases release ON release.id = run.release_id
-     WHERE run.status IN ('partial', 'failed')
+     WHERE run.status IN ('partial', 'failed', 'stopped')
        AND run.created_at >= now() - interval '7 days'
        AND (run.requested_mode IN ('all', 'missing_week') OR run.effective_mode = 'resume_week')
        AND release.status = 'running'
@@ -415,7 +446,10 @@ export async function createNasdaqRun(opts: {
         )
         SELECT id::text AS id, release_id::text AS release_id,
                requested_mode, effective_mode, status,
-               requested_count, completed_count, failed_count,
+               requested_count, completed_count, failed_count, stopped_count,
+               0::int AS stopped_before_start_count,
+               0::int AS stopped_after_attempt_count,
+               0::int AS retry_pending_count,
                0::int AS active_count, concurrency,
                estimated_cost_per_attempt_usd::float8,
                estimated_cost_usd::float8, observed_cost_usd::float8,
@@ -454,7 +488,10 @@ export async function createNasdaqRun(opts: {
         )
         SELECT id::text AS id, release_id::text AS release_id,
                requested_mode, effective_mode, status,
-               requested_count, completed_count, failed_count,
+               requested_count, completed_count, failed_count, stopped_count,
+               0::int AS stopped_before_start_count,
+               0::int AS stopped_after_attempt_count,
+               0::int AS retry_pending_count,
                0::int AS active_count, concurrency,
                estimated_cost_per_attempt_usd::float8,
                estimated_cost_usd::float8, observed_cost_usd::float8,

--- a/scripts/nasdaq_universe_run.py
+++ b/scripts/nasdaq_universe_run.py
@@ -49,43 +49,62 @@ class ClaimedItem:
     worker_id: str
 
 
-def _counts(conn, run_id: str) -> tuple[int, int, int, int]:
+def _attempt_job_id(run_id: str, ticker: str, attempt: int) -> str:
+    return f"N100_{ticker}_{run_id[:8]}_{attempt}"
+
+
+def _terminal_run_status(*, completed: int, failed: int, stopped: int, reason: str) -> str:
+    if reason:
+        return "stopped"
+    if failed == 0 and stopped == 0:
+        return "completed"
+    if completed:
+        return "partial"
+    if stopped:
+        return "stopped"
+    return "failed"
+
+
+def _counts(conn, run_id: str) -> tuple[int, int, int, int, int]:
     with conn.cursor() as cur:
         cur.execute(
             """
             SELECT count(*) FILTER (WHERE status = 'completed')::int,
                    count(*) FILTER (WHERE status = 'failed')::int,
                    count(*) FILTER (WHERE status = 'running')::int,
-                   count(*) FILTER (WHERE status = 'pending')::int
+                   count(*) FILTER (WHERE status = 'pending')::int,
+                   count(*) FILTER (WHERE status = 'stopped')::int
               FROM nasdaq_universe_run_items
              WHERE run_id = %s::uuid;
             """,
             (run_id,),
         )
-        row = cur.fetchone() or (0, 0, 0, 0)
+        row = cur.fetchone() or (0, 0, 0, 0, 0)
     return (
         int(row[0] or 0),
         int(row[1] or 0),
         int(row[2] or 0),
         int(row[3] or 0),
+        int(row[4] or 0),
     )
 
 
-def _update_counts(conn, run_id: str) -> tuple[int, int, int, int]:
-    completed, failed, running, pending = _counts(conn, run_id)
+def _update_counts(conn, run_id: str) -> tuple[int, int, int, int, int]:
+    completed, failed, running, pending, stopped = _counts(conn, run_id)
     with conn.cursor() as cur:
         cur.execute(
             """
             UPDATE nasdaq_universe_runs
-               SET completed_count = %s,
+                   SET completed_count = %s,
                    failed_count = %s,
+                   stopped_count = %s,
                    heartbeat_at = now()
              WHERE id = %s::uuid;
             """,
-            (completed, failed, run_id),
+            (completed, failed, stopped, run_id),
         )
     conn.commit()
-    return completed, failed, running, pending
+    return completed, failed, running, pending, stopped
 
 
 def _heartbeat(run_id: str, runner_prefix: str, stop: threading.Event) -> None:
@@ -272,6 +291,7 @@ def _claim_next_item(
                 UPDATE nasdaq_universe_run_items
                    SET status = 'failed', finished_at = now(),
                        worker_id = NULL, lease_expires_at = NULL,
+                       final_status_reason = 'Maximum ticker attempts exhausted.',
                        last_error = CASE WHEN last_error = ''
                            THEN 'Maximum ticker attempts exhausted.'
                            ELSE last_error END
@@ -328,16 +348,41 @@ def _claim_next_item(
             attempts = int(item[2] or 0) + 1
             cur.execute(
                 """
+                UPDATE nasdaq_universe_run_attempts
+                   SET status = 'failed', finished_at = coalesce(finished_at, now()),
+                       error = CASE WHEN error = ''
+                           THEN 'Worker lease expired before the attempt was finalized.'
+                           ELSE error END
+                 WHERE run_id = %s::uuid AND ticker = %s AND status = 'running';
+                """,
+                (run_id, ticker),
+            )
+            cur.execute(
+                """
                 UPDATE nasdaq_universe_run_items
                    SET status = 'running', attempts = %s,
                        worker_id = %s, heartbeat_at = now(),
                        lease_expires_at = now() + (%s * interval '1 second'),
                        started_at = coalesce(started_at, now()),
-                       finished_at = NULL, last_error = '',
+                       finished_at = NULL, final_status_reason = '',
                        estimated_cost_usd = estimated_cost_usd + %s
                  WHERE run_id = %s::uuid AND ticker = %s;
                 """,
                 (attempts, worker_id, LEASE_SECONDS, per_attempt, run_id, ticker),
+            )
+            cur.execute(
+                """
+                INSERT INTO nasdaq_universe_run_attempts (
+                    run_id, ticker, attempt, worker_id, job_id, status
+                ) VALUES (%s::uuid, %s, %s, %s, %s, 'running');
+                """,
+                (
+                    run_id,
+                    ticker,
+                    attempts,
+                    worker_id,
+                    _attempt_job_id(run_id, ticker, attempts),
+                ),
             )
             cur.execute(
                 """
@@ -371,7 +416,7 @@ def _finish_attempt(
                     """
                     UPDATE nasdaq_universe_run_items
                        SET status = 'completed', report_id = %s::uuid,
-                           finished_at = now(), last_error = '',
+                           finished_at = now(), last_error = '', final_status_reason = '',
                            worker_id = NULL, lease_expires_at = NULL,
                            heartbeat_at = now(), observed_cost_usd = observed_cost_usd + %s
                      WHERE run_id = %s::uuid AND ticker = %s AND worker_id = %s;
@@ -383,6 +428,7 @@ def _finish_attempt(
                     """
                     UPDATE nasdaq_universe_run_items
                        SET status = 'failed', finished_at = now(), last_error = %s,
+                           final_status_reason = 'Maximum ticker attempts exhausted.',
                            worker_id = NULL, lease_expires_at = NULL,
                            heartbeat_at = now(), observed_cost_usd = observed_cost_usd + %s
                      WHERE run_id = %s::uuid AND ticker = %s AND worker_id = %s;
@@ -395,6 +441,7 @@ def _finish_attempt(
                     """
                     UPDATE nasdaq_universe_run_items
                        SET status = 'pending', finished_at = NULL, last_error = %s,
+                           final_status_reason = '',
                            worker_id = NULL, lease_expires_at = NULL,
                            heartbeat_at = now(),
                            next_attempt_at = now() + (%s * interval '1 second'),
@@ -408,6 +455,23 @@ def _finish_attempt(
             # observed cost must not overwrite or double-count the new owner.
             finalized = cur.rowcount > 0
             if finalized:
+                attempt_status = "completed" if report_id else "failed"
+                cur.execute(
+                    """
+                    UPDATE nasdaq_universe_run_attempts
+                       SET status = %s, finished_at = now(), error = %s
+                     WHERE run_id = %s::uuid AND ticker = %s AND attempt = %s
+                       AND worker_id = %s AND status = 'running';
+                    """,
+                    (
+                        attempt_status,
+                        "" if report_id else last_error[:4000],
+                        run_id,
+                        item.ticker,
+                        item.attempts,
+                        item.worker_id,
+                    ),
+                )
                 cur.execute(
                     """
                     UPDATE nasdaq_universe_runs
@@ -435,7 +499,7 @@ def _execute_attempt(
     site_script = root / "scripts" / "site_run.py"
     src = root / "src"
     runs_root = root / "outputs" / "_site_runs"
-    job_id = f"N100_{item.ticker}_{run_id[:8]}_{item.attempts}"
+    job_id = _attempt_job_id(run_id, item.ticker, item.attempts)
     job_dir = runs_root / job_id
     status_file = job_dir / "_status.json"
     started_at = _utc_now()
@@ -576,13 +640,28 @@ def _fail_remaining_dispatchable(run_id: str, reason: str) -> None:
             cur.execute(
                 """
                 UPDATE nasdaq_universe_run_items
-                   SET status = 'failed', finished_at = now(), last_error = %s,
+                   SET status = 'stopped', finished_at = now(),
+                       final_status_reason = %s,
                        worker_id = NULL, lease_expires_at = NULL, heartbeat_at = now()
                  WHERE run_id = %s::uuid
                    AND (
                        status = 'pending'
                        OR (status = 'running' AND coalesce(lease_expires_at, '-infinity'::timestamptz) < now())
                    );
+                """,
+                (message, run_id),
+            )
+            cur.execute(
+                """
+                UPDATE nasdaq_universe_run_attempts attempt
+                   SET status = 'stopped', finished_at = coalesce(attempt.finished_at, now()),
+                       error = CASE WHEN attempt.error = '' THEN %s ELSE attempt.error END
+                  FROM nasdaq_universe_run_items item
+                 WHERE item.run_id = %s::uuid
+                   AND item.run_id = attempt.run_id
+                   AND item.ticker = attempt.ticker
+                   AND item.status = 'stopped'
+                   AND attempt.status = 'running';
                 """,
                 (message, run_id),
             )
@@ -595,10 +674,15 @@ def _finalize(run_id: str, run: dict[str, Any], reason: str = "") -> tuple[str, 
 
     release_id = _uuid(run.get("release_id"))
     with get_conn() as conn:
-        completed, failed, running, pending = _counts(conn, run_id)
+        completed, failed, running, pending, stopped = _counts(conn, run_id)
         if running or pending:
             return "running", completed, failed
-        final_status = "completed" if failed == 0 else ("partial" if completed else "failed")
+        final_status = _terminal_run_status(
+            completed=completed,
+            failed=failed,
+            stopped=stopped,
+            reason=reason,
+        )
         coverage_complete = final_status == "completed" and _release_has_full_coverage(
             conn,
             release_id,
@@ -620,10 +704,11 @@ def _finalize(run_id: str, run: dict[str, Any], reason: str = "") -> tuple[str, 
                 """
                 UPDATE nasdaq_universe_runs
                    SET status = %s, completed_count = %s, failed_count = %s,
+                       stopped_count = %s,
                        finished_at = now(), heartbeat_at = now(), error = %s
                  WHERE id = %s::uuid;
                 """,
-                (final_status, completed, failed, error[:4000], run_id),
+                (final_status, completed, failed, stopped, error[:4000], run_id),
             )
             if final_status == "completed":
                 cur.execute(
@@ -713,7 +798,7 @@ def main() -> int:
         if reason:
             _fail_remaining_dispatchable(run_id, reason)
         final_status, _completed, failed = _finalize(run_id, run, reason)
-        return 0 if final_status == "completed" and failed == 0 else 1
+        return 0 if final_status in {"completed", "stopped"} and failed == 0 else 1
     except KeyboardInterrupt:
         halt.set()
         _fail_remaining_dispatchable(run_id, "interrupted")

--- a/scripts/site_run.py
+++ b/scripts/site_run.py
@@ -94,6 +94,27 @@ def _looks_like_material_success_result(result: Any) -> bool:
     return status in {"success", "partial_success"}
 
 
+def _terminal_progress(completed: int, total: int, *, successful: bool) -> tuple[int, float]:
+    clean_total = max(1, int(total))
+    clean_completed = max(0, int(completed))
+    if successful:
+        return max(clean_total, clean_completed), 100.0
+    pct = min(99.0, (clean_completed / float(clean_total)) * 100.0)
+    return clean_completed, round(pct, 2)
+
+
+def _material_failure_error(result: Any) -> str:
+    if isinstance(result, dict):
+        for key in ("error", "message", "detail"):
+            message = str(result.get(key) or "").strip()
+            if message:
+                return message
+        status = str(result.get("status") or "").strip()
+        if status:
+            return f"Analysis service returned terminal status '{status}' without a report."
+    return "Analysis service returned without usable report artifacts."
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Run a site-triggered valuation job.")
     parser.add_argument("--ticker", required=True, help="Ticker symbol")
@@ -214,6 +235,32 @@ def main() -> int:
         except Exception:
             observed_cost_usd = 0.0
 
+        if not _looks_like_material_success_result(result):
+            failed_completed, failed_pct = _terminal_progress(
+                llm_completed,
+                llm_total_estimated,
+                successful=False,
+            )
+            failed_payload = {
+                **running_payload,
+                "status": "failed",
+                "finished_at": _utc_now(),
+                "llm_completed": failed_completed,
+                "llm_progress_pct": failed_pct,
+                "observed_cost_usd": observed_cost_usd,
+                "result": result,
+                "report_id": None,
+                "persistence_error": "",
+                "error": _material_failure_error(result),
+            }
+            if isinstance(result, dict) and result.get("traceback"):
+                failed_payload["traceback"] = result.get("traceback")
+            sink.update_status(failed_payload)
+            _append_progress_line(progress_file, "Site Run Finalized: failed")
+            legacy_port._deepseek_simple_full = original_full
+            legacy_port.deepseek_simple_text = original_deepseek
+            return 1
+
         # Ensure DB persistence before marking run as completed.
         report_id = None
         persistence_error = ""
@@ -273,43 +320,41 @@ def main() -> int:
             # The run can still be materially successful for the user even if
             # DB persistence is temporarily unavailable. Keep this as completed
             # and surface the persistence issue for diagnostics.
+            completed_calls, completed_pct = _terminal_progress(
+                llm_completed,
+                llm_total_estimated,
+                successful=True,
+            )
             completed_with_warning = {
                 **running_payload,
                 "status": "completed",
                 "finished_at": _utc_now(),
-                "llm_completed": llm_total_estimated if llm_total_estimated > llm_completed else llm_completed,
-                "llm_progress_pct": 100.0,
+                "llm_completed": completed_calls,
+                "llm_progress_pct": completed_pct,
                 "observed_cost_usd": observed_cost_usd,
                 "result": result,
                 "report_id": None,
                 "persistence_error": persistence_error or "DB persistence failed.",
                 "error": "",
             }
-            if not _looks_like_material_success_result(result):
-                failed_payload = {
-                    **completed_with_warning,
-                    "status": "failed",
-                    "error": persistence_error or "DB persistence failed.",
-                }
-                sink.update_status(failed_payload)
-                _append_progress_line(progress_file, "Site Run Finalized: failed")
-                legacy_port._deepseek_simple_full = original_full
-                legacy_port.deepseek_simple_text = original_deepseek
-                return 1
-
             sink.update_status(completed_with_warning)
             _append_progress_line(progress_file, "Site Run Finalized: completed")
             legacy_port._deepseek_simple_full = original_full
             legacy_port.deepseek_simple_text = original_deepseek
             return 0
 
+        completed_calls, completed_pct = _terminal_progress(
+            llm_completed,
+            llm_total_estimated,
+            successful=True,
+        )
         completed_payload = {
             **running_payload,
             "status": "completed",
             "finished_at": _utc_now(),
             "result": result,
-            "llm_completed": llm_total_estimated if llm_total_estimated > llm_completed else llm_completed,
-            "llm_progress_pct": 100.0,
+            "llm_completed": completed_calls,
+            "llm_progress_pct": completed_pct,
             "observed_cost_usd": observed_cost_usd,
             "report_id": report_id,
         }
@@ -325,12 +370,17 @@ def main() -> int:
             observed_cost_usd = total_cost_for_source_run_id(job_id)
         except Exception:
             pass
+        failed_completed, failed_pct = _terminal_progress(
+            llm_completed,
+            llm_total_estimated,
+            successful=False,
+        )
         failed_payload = {
             **running_payload,
             "status": "failed",
             "finished_at": _utc_now(),
-            "llm_completed": llm_completed,
-            "llm_progress_pct": round(min(99.0, (llm_completed / float(llm_total_estimated)) * 100.0), 2),
+            "llm_completed": failed_completed,
+            "llm_progress_pct": failed_pct,
             "observed_cost_usd": observed_cost_usd,
             "error": str(exc),
             "traceback": traceback.format_exc(limit=6),

--- a/src/ai_hedge/db/migrations/014_nasdaq_run_diagnostics.sql
+++ b/src/ai_hedge/db/migrations/014_nasdaq_run_diagnostics.sql
@@ -1,0 +1,37 @@
+-- Preserve technical attempt errors and distinguish stopped work from failures.
+
+ALTER TABLE nasdaq_universe_runs
+    DROP CONSTRAINT IF EXISTS nasdaq_universe_runs_status_check;
+
+ALTER TABLE nasdaq_universe_runs
+    ADD CONSTRAINT nasdaq_universe_runs_status_check
+        CHECK (status IN ('queued', 'running', 'completed', 'partial', 'failed', 'stopped')),
+    ADD COLUMN IF NOT EXISTS stopped_count int NOT NULL DEFAULT 0
+        CHECK (stopped_count >= 0);
+
+ALTER TABLE nasdaq_universe_run_items
+    DROP CONSTRAINT IF EXISTS nasdaq_universe_run_items_status_check;
+
+ALTER TABLE nasdaq_universe_run_items
+    ADD CONSTRAINT nasdaq_universe_run_items_status_check
+        CHECK (status IN ('pending', 'running', 'completed', 'failed', 'stopped')),
+    ADD COLUMN IF NOT EXISTS final_status_reason text NOT NULL DEFAULT '';
+
+CREATE TABLE IF NOT EXISTS nasdaq_universe_run_attempts (
+    run_id       uuid NOT NULL,
+    ticker       text NOT NULL,
+    attempt      int NOT NULL CHECK (attempt > 0),
+    worker_id    text NOT NULL,
+    job_id       text NOT NULL,
+    status       text NOT NULL DEFAULT 'running'
+                 CHECK (status IN ('running', 'completed', 'failed', 'stopped')),
+    error        text NOT NULL DEFAULT '',
+    started_at   timestamptz NOT NULL DEFAULT now(),
+    finished_at  timestamptz,
+    PRIMARY KEY (run_id, ticker, attempt),
+    FOREIGN KEY (run_id, ticker)
+        REFERENCES nasdaq_universe_run_items(run_id, ticker) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS nasdaq_universe_run_attempts_recent_idx
+    ON nasdaq_universe_run_attempts (run_id, started_at DESC);

--- a/src/ai_hedge/legacy_port.py
+++ b/src/ai_hedge/legacy_port.py
@@ -1,4 +1,6 @@
 import os
+import random
+import time
 from contextlib import contextmanager
 from functools import lru_cache
 from importlib import resources
@@ -459,15 +461,63 @@ def _fetch_yahooquery_snapshot_safe(ticker: str) -> Dict[str, Any]:
         }
 
 
+class YahooInfoUnavailableError(RuntimeError):
+    """Raised when Yahoo cannot provide a usable company-info mapping."""
+
+
+def _fetch_yfinance_info_with_retry(
+    ticker: str,
+    *,
+    max_attempts: int = 3,
+    base_delay_seconds: float = 2.0,
+) -> tuple[Any, Dict[str, Any]]:
+    """Fetch ``Ticker.info`` with bounded backoff and a fresh client each time.
+
+    A short Yahoo outage used to be converted to the string ``"Not available"``
+    and later crash on ``.get``. Keep the value typed and let the universe
+    runner retry the whole ticker only after these inexpensive provider retries
+    have been exhausted.
+    """
+
+    clean_ticker = str(ticker or "").strip().upper()
+    attempts = max(1, int(max_attempts))
+    last_error = "Yahoo returned no data."
+
+    for attempt in range(1, attempts + 1):
+        ticker_obj = yf.Ticker(clean_ticker)
+        try:
+            raw_info = ticker_obj.info
+            if not isinstance(raw_info, dict) or not raw_info:
+                raise TypeError(
+                    f"Yahoo returned {type(raw_info).__name__}, expected a non-empty dict"
+                )
+            return ticker_obj, dict(raw_info)
+        except Exception as exc:
+            last_error = f"{type(exc).__name__}: {str(exc)[:500]}"
+            if attempt >= attempts:
+                break
+            base_delay = max(0.0, float(base_delay_seconds)) * (2 ** (attempt - 1))
+            jitter = random.uniform(0.0, min(1.0, max(0.0, base_delay * 0.25)))
+            delay = base_delay + jitter
+            print(
+                f"Yahoo info fetch failed for {clean_ticker} "
+                f"(attempt {attempt}/{attempts}: {last_error}); retrying in {delay:.2f}s"
+            )
+            time.sleep(delay)
+
+    raise YahooInfoUnavailableError(
+        f"Yahoo info unavailable for {clean_ticker} after {attempts} attempts. "
+        f"Last error: {last_error}"
+    )
+
+
 def get_info_data(ticker: str) -> dict:
     info_dict = {}
-    ticker_obj = yf.Ticker(ticker)
+    ticker_obj, raw_info = _fetch_yfinance_info_with_retry(ticker)
     fin_rate = 1.0
     price_rate = 1.0
 
     try:
-        raw_info = ticker_obj.info
-
         # --- 1. Identify Currencies ---
         fin_curr_name = raw_info.get("financialCurrency", 'USD')
         price_curr_name = raw_info.get("currency", 'USD')
@@ -505,11 +555,11 @@ def get_info_data(ticker: str) -> dict:
 
         info_dict["change"] = raw_info.get("52WeekChange", 0)
 
-    except Exception as e:
-        print(f"Error processing {ticker}: {e}")
-        info_dict["info"] = "Not available"
-        info_dict["financials"] = "Not available"
-        info_dict["change"] = 0
+    except Exception as exc:
+        raise YahooInfoUnavailableError(
+            f"Yahoo info processing failed for {str(ticker or '').strip().upper()}: "
+            f"{type(exc).__name__}: {str(exc)[:500]}"
+        ) from exc
 
     try:
         info_dict["short_name"] = info_dict["info"].get("shortName")
@@ -1405,11 +1455,19 @@ DEEPSEEK_API_KEY = os.getenv("DEEPSEEK_API_KEY", "")
 def get_dicts(ticker):
     info_dict = get_info_data(ticker)
     info_payload = info_dict.get("info") if isinstance(info_dict, dict) else {}
-    files_dict = latest_filing_full_text(ticker, company_info=info_payload if isinstance(info_payload, dict) else {})
-    financial_dict = get_financial_data(ticker, info_dict["info"], info_dict["financials"])
+    if not isinstance(info_payload, dict):
+        raise YahooInfoUnavailableError(
+            f"Yahoo info unavailable for {str(ticker or '').strip().upper()}: "
+            f"expected dict, got {type(info_payload).__name__}."
+        )
+    info_financials = info_dict.get("financials")
+    if not isinstance(info_financials, dict):
+        info_financials = {}
+    files_dict = latest_filing_full_text(ticker, company_info=info_payload)
+    financial_dict = get_financial_data(ticker, info_payload, info_financials)
     variables_dict = get_variables(
         ticker,
-        info_dict["info"],
+        info_payload,
         financial_dict.get("statement_metrics", {}),
     )
     return info_dict, files_dict, financial_dict, variables_dict

--- a/src/ai_hedge/nasdaq_execution.py
+++ b/src/ai_hedge/nasdaq_execution.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import random
 from datetime import datetime, timezone
 
 
@@ -73,10 +74,16 @@ def is_preferred_off_peak_utc(value: datetime | None = None) -> bool:
 
 
 def retry_delay_seconds(attempts: int) -> int:
-    """Bounded exponential backoff between whole-ticker attempts."""
+    """Bounded exponential backoff with jitter between ticker attempts.
+
+    Jitter prevents several provider failures from returning to Yahoo and the
+    LLM APIs at the same instant after a concurrent burst.
+    """
 
     clean_attempts = max(1, int(attempts))
-    return min(15 * 60, 60 * (2 ** (clean_attempts - 1)))
+    base_delay = min(15 * 60, 60 * (2 ** (clean_attempts - 1)))
+    jitter_limit = min(30, max(5, base_delay // 4))
+    return min(15 * 60, base_delay + random.randint(0, jitter_limit))
 
 
 def budget_allows_attempt(current_usd: float, per_attempt_usd: float, limit_usd: float) -> bool:

--- a/src/ai_hedge/trading_agents_adapter.py
+++ b/src/ai_hedge/trading_agents_adapter.py
@@ -53,6 +53,47 @@ CONTEXT_INTRO = (
 )
 
 
+def _llm_model_name(llm: Any) -> str:
+    for attr in ("model_name", "model"):
+        value = str(getattr(llm, attr, "") or "").strip().lower()
+        if value:
+            return value
+    return ""
+
+
+def _supports_structured_output(llm: Any) -> bool:
+    """DeepSeek reasoner rejects the tool choice used by structured output."""
+
+    return "deepseek-reasoner" not in _llm_model_name(llm)
+
+
+def _bind_structured_if_supported(
+    llm: Any,
+    schema: Any,
+    agent_name: str,
+    bind_structured: Any,
+) -> Any:
+    if not _supports_structured_output(llm):
+        return None
+    return bind_structured(llm, schema, agent_name)
+
+
+def _create_deepseek_compatible_research_manager(llm: Any):
+    """Build the package Research Manager without a doomed reasoner tool call."""
+
+    from tradingagents.agents.managers import research_manager as research_manager_module
+
+    if _supports_structured_output(llm):
+        return research_manager_module.create_research_manager(llm)
+
+    original_bind = research_manager_module.bind_structured
+    try:
+        research_manager_module.bind_structured = lambda *_args, **_kwargs: None
+        return research_manager_module.create_research_manager(llm)
+    finally:
+        research_manager_module.bind_structured = original_bind
+
+
 def _create_required_target_portfolio_manager(llm: Any):
     """Build TradingAgents' portfolio manager with a required tactical target.
 
@@ -86,7 +127,12 @@ def _create_required_target_portfolio_manager(llm: Any):
             description="Required time horizon for the tactical price target, e.g. '6-12 months'.",
         )
 
-    structured_llm = bind_structured(llm, RequiredTargetPortfolioDecision, "Portfolio Manager")
+    structured_llm = _bind_structured_if_supported(
+        llm,
+        RequiredTargetPortfolioDecision,
+        "Portfolio Manager",
+        bind_structured,
+    )
 
     def portfolio_manager_node(state: Dict[str, Any]) -> Dict[str, Any]:
         instrument_context = build_instrument_context(state["company_of_interest"])
@@ -333,7 +379,12 @@ Trader plan:
 Risk debate:
 {_trim_chars(_text(risk_debate), 12_000)}
 """.strip()
-    structured_llm = bind_structured(llm, RequiredTacticalMetadata, "Portfolio Manager metadata repair")
+    structured_llm = _bind_structured_if_supported(
+        llm,
+        RequiredTacticalMetadata,
+        "Portfolio Manager metadata repair",
+        bind_structured,
+    )
     repaired = invoke_structured_or_freetext(
         structured_llm,
         llm,
@@ -798,11 +849,14 @@ def run_trading_agents_lens(
         # not change unrelated graph construction in this process.
         with _GRAPH_SETUP_LOCK:
             original_create_portfolio_manager = graph_setup.create_portfolio_manager
+            original_create_research_manager = graph_setup.create_research_manager
             try:
                 graph_setup.create_portfolio_manager = _create_required_target_portfolio_manager
+                graph_setup.create_research_manager = _create_deepseek_compatible_research_manager
                 graph = TradingAgentsGraph(selected_analysts=list(SELECTED_ANALYSTS), debug=False, config=config)
             finally:
                 graph_setup.create_portfolio_manager = original_create_portfolio_manager
+                graph_setup.create_research_manager = original_create_research_manager
         state, decision = _propagate_trading_agents_graph(graph, ticker_u, run_date)
         state_dict = state if isinstance(state, dict) else {}
         payload = normalize_trading_agents_state(ticker_u, state_dict, decision, now=now)

--- a/tests/test_legacy_port_provider_retry.py
+++ b/tests/test_legacy_port_provider_retry.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import pytest
+
+from ai_hedge import legacy_port as legacy
+
+
+class _FakeTicker:
+    def __init__(self, outcome):
+        self._outcome = outcome
+
+    @property
+    def info(self):
+        if isinstance(self._outcome, Exception):
+            raise self._outcome
+        return self._outcome
+
+
+def test_yfinance_info_retries_with_a_fresh_client_and_backoff(monkeypatch) -> None:
+    outcomes = [RuntimeError("HTTP 429"), TimeoutError("timed out"), {"shortName": "Apple"}]
+    clients = []
+    sleeps = []
+
+    def fake_ticker(_ticker):
+        client = _FakeTicker(outcomes[len(clients)])
+        clients.append(client)
+        return client
+
+    monkeypatch.setattr(legacy.yf, "Ticker", fake_ticker)
+    monkeypatch.setattr(legacy.random, "uniform", lambda _low, high: high)
+    monkeypatch.setattr(legacy.time, "sleep", sleeps.append)
+
+    client, info = legacy._fetch_yfinance_info_with_retry("aapl")
+
+    assert client is clients[-1]
+    assert info == {"shortName": "Apple"}
+    assert len(clients) == 3
+    assert sleeps == [2.5, 5.0]
+
+
+def test_yfinance_info_failure_is_explicit_and_never_returns_a_string(monkeypatch) -> None:
+    monkeypatch.setattr(legacy.yf, "Ticker", lambda _ticker: _FakeTicker("Not available"))
+    monkeypatch.setattr(legacy.time, "sleep", lambda _delay: None)
+
+    with pytest.raises(legacy.YahooInfoUnavailableError) as raised:
+        legacy._fetch_yfinance_info_with_retry("ABNB", base_delay_seconds=0)
+
+    message = str(raised.value)
+    assert "Yahoo info unavailable for ABNB after 3 attempts" in message
+    assert "expected a non-empty dict" in message

--- a/tests/test_nasdaq_execution.py
+++ b/tests/test_nasdaq_execution.py
@@ -9,7 +9,7 @@ from ai_hedge.nasdaq_execution import (
     is_preferred_off_peak_utc,
     retry_delay_seconds,
 )
-from scripts.nasdaq_universe_run import _snapshot_has_full_coverage
+from scripts.nasdaq_universe_run import _snapshot_has_full_coverage, _terminal_run_status
 
 
 def _utc(hour: int, minute: int = 0) -> datetime:
@@ -24,9 +24,10 @@ def test_preferred_window_uses_utc_and_crosses_midnight() -> None:
     assert not is_preferred_off_peak_utc(_utc(9, 59))
 
 
-def test_retry_backoff_is_bounded() -> None:
-    assert retry_delay_seconds(1) == 60
-    assert retry_delay_seconds(2) == 120
+def test_retry_backoff_is_bounded_and_jittered(monkeypatch) -> None:
+    monkeypatch.setattr("ai_hedge.nasdaq_execution.random.randint", lambda _low, high: high)
+    assert retry_delay_seconds(1) == 75
+    assert retry_delay_seconds(2) == 150
     assert retry_delay_seconds(5) == 900
     assert retry_delay_seconds(20) == 900
 
@@ -61,3 +62,9 @@ def test_release_coverage_accepts_any_saved_alias_for_an_issuer() -> None:
     assert _snapshot_has_full_coverage(snapshot, {"GOOG", "AAPL"})
     assert _snapshot_has_full_coverage(snapshot, {"GOOGL", "AAPL"})
     assert not _snapshot_has_full_coverage(snapshot, {"AAPL"})
+
+
+def test_terminal_run_status_distinguishes_stop_from_technical_failure() -> None:
+    assert _terminal_run_status(completed=3, failed=0, stopped=93, reason="stop_requested") == "stopped"
+    assert _terminal_run_status(completed=3, failed=3, stopped=0, reason="") == "partial"
+    assert _terminal_run_status(completed=0, failed=3, stopped=0, reason="") == "failed"

--- a/tests/test_site_run_status.py
+++ b/tests/test_site_run_status.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from scripts.site_run import _material_failure_error, _terminal_progress
+
+
+def test_failed_site_run_keeps_real_progress_below_complete() -> None:
+    assert _terminal_progress(0, 45, successful=False) == (0, 0.0)
+    assert _terminal_progress(3, 45, successful=False) == (3, 6.67)
+
+
+def test_successful_site_run_can_close_an_estimated_progress_total() -> None:
+    assert _terminal_progress(3, 45, successful=True) == (45, 100.0)
+
+
+def test_material_failure_prefers_the_service_error_over_persistence_wording() -> None:
+    assert _material_failure_error(
+        {"status": "error", "error": "Yahoo info unavailable after 3 attempts"}
+    ) == "Yahoo info unavailable after 3 attempts"

--- a/tests/test_trading_agents_adapter.py
+++ b/tests/test_trading_agents_adapter.py
@@ -248,6 +248,62 @@ def test_required_target_portfolio_manager_contract():
     assert "**Time Horizon**: 6 months" in result["final_trade_decision"]
 
 
+def test_deepseek_reasoner_skips_structured_tool_choice_for_managers():
+    class Response:
+        content = "**Rating**: Hold\n\n**Price Target**: 210\n\n**Time Horizon**: 6 months"
+
+    class FakeReasoner:
+        model_name = "deepseek-reasoner"
+
+        def __init__(self):
+            self.invocations = 0
+
+        def with_structured_output(self, _schema):
+            raise AssertionError("reasoner must not bind structured tool output")
+
+        def invoke(self, _prompt):
+            self.invocations += 1
+            return Response()
+
+    llm = FakeReasoner()
+    assert ta._supports_structured_output(llm) is False
+
+    portfolio_node = ta._create_required_target_portfolio_manager(llm)
+    portfolio_result = portfolio_node(
+        {
+            "company_of_interest": "IBM",
+            "investment_plan": "Balanced plan.",
+            "trader_investment_plan": "Wait.",
+            "risk_debate_state": {
+                "history": "Balanced risks.",
+                "aggressive_history": "",
+                "conservative_history": "",
+                "neutral_history": "",
+                "current_aggressive_response": "",
+                "current_conservative_response": "",
+                "current_neutral_response": "",
+                "count": 3,
+            },
+        }
+    )
+    assert "**Price Target**: 210" in portfolio_result["final_trade_decision"]
+
+    research_node = ta._create_deepseek_compatible_research_manager(llm)
+    research_result = research_node(
+        {
+            "company_of_interest": "IBM",
+            "investment_debate_state": {
+                "history": "Bull and bear evidence.",
+                "bear_history": "Bear evidence.",
+                "bull_history": "Bull evidence.",
+                "count": 2,
+            },
+        }
+    )
+    assert "**Rating**: Hold" in research_result["investment_plan"]
+    assert llm.invocations == 2
+
+
 def test_summarize_uses_observed_legacy_deepseek_wrapper(monkeypatch):
     calls = []
 

--- a/tests/test_workspace_isolation.py
+++ b/tests/test_workspace_isolation.py
@@ -122,3 +122,20 @@ def test_nasdaq_budget_migration_raises_the_default_to_600() -> None:
     ).read_text(encoding="utf-8")
 
     assert "ALTER COLUMN budget_limit_usd SET DEFAULT 600" in migration
+
+
+def test_nasdaq_diagnostics_migration_preserves_attempts_and_stopped_status() -> None:
+    migration = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "ai_hedge"
+        / "db"
+        / "migrations"
+        / "014_nasdaq_run_diagnostics.sql"
+    ).read_text(encoding="utf-8")
+
+    assert "'stopped'" in migration
+    assert "stopped_count" in migration
+    assert "final_status_reason" in migration
+    assert "nasdaq_universe_run_attempts" in migration
+    assert "PRIMARY KEY (run_id, ticker, attempt)" in migration


### PR DESCRIPTION
## Summary

- retry Yahoo/yfinance company-info fetches with bounded backoff and typed failures, then jitter whole-ticker retries
- preserve every Nasdaq attempt error and distinguish failed, retry-pending, not-started, and stopped work in storage and the admin UI
- report real LLM progress on early failures and bypass unsupported structured `tool_choice` calls for DeepSeek reasoner managers
- gate the Nasdaq worker deploy on the site migration deploy; observed-cost telemetry is intentionally unchanged

## Preview

URL: https://pr-138-hedge-in-a-box-site.fly.dev

## Test plan

- [x] `python -m pytest -q --basetemp=.codex-pytest-nasdaq-full` (140 passed)
- [x] focused Nasdaq/provider/status/TradingAgents tests (35 passed)
- [x] `frontend/node_modules/.bin/eslint.cmd src/lib/nasdaq-runs-db.ts src/components/shell/nasdaq-run-modal.tsx`
- [x] `npm run build` in `frontend/`
- [x] `python scripts/migrate.py --dry-run` discovers only `014_nasdaq_run_diagnostics.sql`
- [x] verify preview health, page render, and migration-backed Nasdaq runs API (read-only; no run started)

## Notes for reviewer

- Migration 014 adds `stopped` statuses, `stopped_count`, `final_status_reason`, and an immutable per-attempt history table.
- A user-requested stop no longer overwrites the last technical error or inflates `failed_count` with stocks that never started.
- Cost telemetry remains out of scope by request.
