### PR TITLE
Fix Nasdaq missing-week resume filtering

### DIFF
--- a/frontend/src/lib/nasdaq-run-policy.test.ts
+++ b/frontend/src/lib/nasdaq-run-policy.test.ts
@@ -17,6 +17,24 @@ test("a seven-day resume queues only tickers missing from the interrupted releas
   assert.deepEqual(stocks.map((stock) => stock.ticker), ["MSFT"]);
 });
 
+test("missing-week resume skips both release completions and other recent reports", () => {
+  const stocks = selectNasdaqRunStocks(UNIVERSE, {
+    mode: "missing_week",
+    resumedReleaseTickers: ["MSFT"],
+    recentlyCompletedTickers: ["aapl"],
+  });
+  assert.deepEqual(stocks.map((stock) => stock.ticker), ["NVDA"]);
+});
+
+test("all-mode resume does not inherit recent reports from other releases", () => {
+  const stocks = selectNasdaqRunStocks(UNIVERSE, {
+    mode: "all",
+    resumedReleaseTickers: ["MSFT"],
+    recentlyCompletedTickers: ["aapl"],
+  });
+  assert.deepEqual(stocks.map((stock) => stock.ticker), ["AAPL", "NVDA"]);
+});
+
 test("missing-week mode skips reports completed anywhere in the last seven days", () => {
   const stocks = selectNasdaqRunStocks(UNIVERSE, {
     mode: "missing_week",

--- a/frontend/src/lib/nasdaq-run-policy.ts
+++ b/frontend/src/lib/nasdaq-run-policy.ts
@@ -105,6 +105,9 @@ export function selectNasdaqRunStocks(
 
   if (opts.resumedReleaseTickers) {
     const completed = normalized(opts.resumedReleaseTickers);
+    if (opts.mode === "missing_week") {
+      for (const ticker of normalized(opts.recentlyCompletedTickers)) completed.add(ticker);
+    }
     return uniqueStocks.filter((stock) => !completed.has(stock.ticker));
   }
   if (opts.mode === "selected") {

--- a/frontend/src/lib/nasdaq-runs-db.ts
+++ b/frontend/src/lib/nasdaq-runs-db.ts
@@ -389,7 +389,12 @@ export async function createNasdaqRun(opts: {
       source = resume.universe_source;
       asOf = resume.universe_as_of;
       const completed = await completedTickersForRelease(releaseId);
-      stocks = selectNasdaqRunStocks(stocks, { mode: opts.mode, resumedReleaseTickers: completed });
+      const recent = opts.mode === "missing_week" ? await tickersRunInLastWeek() : undefined;
+      stocks = selectNasdaqRunStocks(stocks, {
+        mode: opts.mode,
+        recentlyCompletedTickers: recent,
+        resumedReleaseTickers: completed,
+      });
       effectiveMode = "resume_week";
       resumed = true;
     } else if (opts.mode === "missing_week") {


### PR DESCRIPTION
## Summary

- merge completed tickers from the interrupted release with all Nasdaq reports completed in the last seven days when resuming `missing_week`
- preserve `all` resume semantics so a full-universe release still completes its own snapshot
- add regression coverage for both modes, including the cross-release AAPL case

## Preview

URL: https://pr-139-hedge-in-a-box-site.fly.dev (unavailable due to Fly VM provisioning failure)

The preview image built successfully, including Next.js compilation and TypeScript. Fly created the preview VM but never transitioned it from `created` to `started`, then timed out. A workflow retry failed the same way; the stuck VM was replaced and a fresh VM reproduced the same infrastructure failure before the application process started.

## Test plan

- [x] `npm exec tsx -- --test src/lib/nasdaq-run-policy.test.ts` (10/10)
- [x] `npm run test:portfolio` (34/34)
- [x] targeted ESLint on the three changed files
- [x] `npm run build`
- [ ] preview HTTP verification (blocked before application startup by Fly VM provisioning)

## Notes for reviewer

No schema or worker changes. `all` resume behavior is intentionally unchanged. The existing Turbopack NFT tracing warning from `next.config.ts` remains unchanged.