### PR TITLE
fix: release complete Nasdaq portfolio cohort

### DIFF
--- a/.github/workflows/preview-site.yml
+++ b/.github/workflows/preview-site.yml
@@ -252,6 +252,17 @@ jobs:
             echo "Portfolio performance code is not part of this PR; skipping preview backfill."
             exit 0
           fi
+          read -r PREVIEW_MACHINE_ID PREVIEW_MACHINE_STATE < <(
+            flyctl machine list --app "${{ env.PREVIEW_APP }}" --json \
+              | jq -r '.[0] | [.id, .state] | @tsv'
+          )
+          if [ -z "${PREVIEW_MACHINE_ID:-}" ]; then
+            echo "::error::Preview app has no machine to bootstrap."
+            exit 1
+          fi
+          if [ "$PREVIEW_MACHINE_STATE" != "started" ]; then
+            flyctl machine start "$PREVIEW_MACHINE_ID" --app "${{ env.PREVIEW_APP }}"
+          fi
           flyctl ssh console --app "${{ env.PREVIEW_APP }}" --command \
             "sh -lc 'cd /app/frontend && npm run portfolio:refresh -- --workspace analysis --track backtest --start-cutoff 2026-04-30'"
           flyctl ssh console --app "${{ env.PREVIEW_APP }}" --command \

--- a/docs/nasdaq100-workspace.md
+++ b/docs/nasdaq100-workspace.md
@@ -1,9 +1,11 @@
 # Nasdaq 100 workspace operations
 
-The Nasdaq 100 workspace is release-based. Report publication remains gated by
-explicit release activation, while portfolio tracking starts automatically
-after an active release exists. Existing reports remain in the Analysis
-workspace.
+The Nasdaq 100 workspace is release-based. Portfolio tracking starts only after
+the active release cohort covers the complete issuer-deduplicated universe.
+`Missing this week` runs may satisfy that cohort with reports saved by an older
+active release during the same seven-day window; this avoids rerunning a fresh
+analysis merely to move it into a newer release. Existing reports remain in the
+Analysis workspace.
 
 Create a staged release:
 
@@ -17,17 +19,27 @@ Generate each report into that release with the regular single-ticker CLI:
 python -m ai_hedge.cli --ticker AAPL --workspace nasdaq100 --release-id <release-uuid>
 ```
 
-Staged reports are not visible through the site or public APIs. After the
-operator has performed the external coverage checks, activate the complete
-release atomically:
+For a manually staged release, activate it after the operator has performed the
+external coverage checks:
 
 ```powershell
 python scripts/report_release.py activate --release <release-uuid-or-key>
 ```
 
+Universe runs activate themselves. If a completed `Missing this week` run
+spans several active releases, reconcile the release-cohort coverage gate:
+
+```powershell
+python scripts/report_release.py reconcile --release <release-uuid-or-key>
+```
+
+The command refuses to mark coverage complete unless every constituent group
+in the run's frozen universe snapshot has a saved report in the current release
+or another active release from the preceding seven days.
+
 The scheduled Portfolio Performance workflow refreshes both Analysis and
 Nasdaq 100. Nasdaq refreshes exit cleanly while there is no active release;
-after the first activation they begin collecting Paper and Backtest NAV,
+after the first complete cohort they begin collecting Paper and Backtest NAV,
 QQQ benchmark history, and the `^IRX` 13-week Treasury yield used by Sharpe.
 The same tracks can also be refreshed manually:
 

--- a/frontend/src/app/api/portfolio-performance/route.ts
+++ b/frontend/src/app/api/portfolio-performance/route.ts
@@ -104,7 +104,7 @@ function emptyResponse(workspace: Workspace, track: PortfolioTrack, period: Port
     available: false,
     workspace,
     message: message || (workspace === "nasdaq100"
-      ? "Nasdaq 100 portfolio history will appear after the first release is activated and portfolios are refreshed."
+      ? "Nasdaq 100 forward portfolio history will appear after complete universe coverage and the first eligible market session."
       : "Portfolio performance history is not available yet."),
     methodology: {
       version: PORTFOLIO_METHODOLOGY_VERSION,

--- a/frontend/src/lib/nasdaq-runs-db.ts
+++ b/frontend/src/lib/nasdaq-runs-db.ts
@@ -164,19 +164,47 @@ export async function reconcileStaleNasdaqRuns(): Promise<number> {
         RETURNING attempt.run_id
       ), counts AS (
         SELECT stale.id, run.release_id, run.requested_count, run.universe_count,
+               run.universe_snapshot,
                count(*) FILTER (WHERE item.status = 'completed')::int AS completed_count,
                count(*) FILTER (WHERE item.status = 'failed')::int AS failed_count,
                count(*) FILTER (WHERE item.status IN ('stopped', 'pending', 'running'))::int AS stopped_count
           FROM stale_ids stale
           JOIN nasdaq_universe_runs run ON run.id = stale.id
           LEFT JOIN nasdaq_universe_run_items item ON item.run_id = stale.id
-         GROUP BY stale.id, run.release_id, run.requested_count, run.universe_count
-      ), report_counts AS (
-        SELECT counts.id, count(DISTINCT reports.ticker)::int AS release_report_count
+         GROUP BY stale.id, run.release_id, run.requested_count, run.universe_count, run.universe_snapshot
+      ), coverage_checks AS (
+        SELECT counts.id,
+               jsonb_typeof(counts.universe_snapshot) = 'array'
+               AND jsonb_array_length(counts.universe_snapshot) > 0
+               AND NOT EXISTS (
+                 SELECT 1
+                   FROM jsonb_array_elements(counts.universe_snapshot) expected(stock)
+                  WHERE NOT EXISTS (
+                    SELECT 1
+                      FROM reports report
+                      JOIN report_releases source_release ON source_release.id = report.release_id
+                     WHERE report.workspace = 'nasdaq100'
+                       AND report.deleted_at IS NULL
+                       AND source_release.status IN ('running', 'active')
+                       AND (
+                            report.release_id = counts.release_id
+                            OR report.available_at >= now() - interval '7 days'
+                       )
+                       AND upper(report.ticker) IN (
+                         SELECT upper(expected.stock->>'ticker')
+                         UNION
+                         SELECT upper(alias.value)
+                           FROM jsonb_array_elements_text(
+                             CASE
+                               WHEN jsonb_typeof(expected.stock->'aliases') = 'array'
+                               THEN expected.stock->'aliases'
+                               ELSE '[]'::jsonb
+                             END
+                           ) alias(value)
+                       )
+                  )
+               ) AS coverage_complete
           FROM counts
-          LEFT JOIN reports ON reports.release_id = counts.release_id
-            AND reports.workspace = 'nasdaq100' AND reports.deleted_at IS NULL
-         GROUP BY counts.id
       ), updated_runs AS (
         UPDATE nasdaq_universe_runs run
          SET status = CASE
@@ -197,11 +225,12 @@ export async function reconcileStaleNasdaqRuns(): Promise<number> {
       ), activated_releases AS (
         UPDATE report_releases release
            SET status = 'active',
-               coverage_complete = report_counts.release_report_count >= counts.universe_count
-          FROM updated_runs, counts, report_counts
+               activated_at = coalesce(release.activated_at, now()),
+               coverage_complete = coverage_checks.coverage_complete
+          FROM updated_runs, counts, coverage_checks
          WHERE release.id = updated_runs.release_id
            AND counts.id = updated_runs.id
-           AND report_counts.id = updated_runs.id
+           AND coverage_checks.id = updated_runs.id
            AND updated_runs.status = 'completed'
       )
       SELECT id::text AS id FROM updated_runs;

--- a/frontend/src/lib/portfolio-db.ts
+++ b/frontend/src/lib/portfolio-db.ts
@@ -125,7 +125,19 @@ export async function listPortfolioReportInputs(args: {
        WHERE r.generated_at >= ${args.earliestGeneratedAt}::timestamptz
          AND r.generated_at <= ${args.latestGeneratedAt}::timestamptz
          AND r.workspace = ${args.workspace}
-         AND (r.workspace = 'analysis' OR (rr.status = 'active' AND rr.coverage_complete))
+         AND (
+              r.workspace = 'analysis'
+              OR (
+                   rr.status = 'active'
+                   AND EXISTS (
+                     SELECT 1
+                       FROM report_releases coverage_release
+                      WHERE coverage_release.workspace = 'nasdaq100'
+                        AND coverage_release.status = 'active'
+                        AND coverage_release.coverage_complete
+                   )
+              )
+         )
        ORDER BY r.generated_at, r.id
        LIMIT ${pageSize}
       OFFSET ${offset};

--- a/frontend/src/lib/portfolio-performance-engine.ts
+++ b/frontend/src/lib/portfolio-performance-engine.ts
@@ -29,7 +29,7 @@ export function portfolioWorkspaceConfig(workspace: Workspace) {
     ? {
         benchmarkSymbol: "QQQ",
         benchmarkName: "Invesco QQQ — total-return proxy",
-        universe: "Nasdaq 100 reports from fully covered active releases in the trailing 90 days",
+        universe: "Nasdaq 100 reports from active releases in the trailing 90 days, unlocked after complete universe coverage",
       }
     : {
         benchmarkSymbol: PORTFOLIO_BENCHMARK_SYMBOL,

--- a/scripts/nasdaq_universe_run.py
+++ b/scripts/nasdaq_universe_run.py
@@ -168,11 +168,16 @@ def _release_has_full_coverage(conn, release_id: str, snapshot: object) -> bool:
     with conn.cursor() as cur:
         cur.execute(
             """
-            SELECT DISTINCT ticker
-              FROM reports
-             WHERE workspace = 'nasdaq100'
-               AND release_id = %s::uuid
-               AND deleted_at IS NULL;
+            SELECT DISTINCT report.ticker
+              FROM reports report
+              JOIN report_releases release ON release.id = report.release_id
+             WHERE report.workspace = 'nasdaq100'
+               AND report.deleted_at IS NULL
+               AND release.status IN ('running', 'active')
+               AND (
+                    report.release_id = %s::uuid
+                    OR report.available_at >= now() - interval '7 days'
+               );
             """,
             (release_id,),
         )

--- a/scripts/report_release.py
+++ b/scripts/report_release.py
@@ -11,6 +11,7 @@ import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
 sys.path.insert(0, str(ROOT / "src"))
 
 try:
@@ -21,12 +22,14 @@ except ImportError:
     pass
 
 from ai_hedge.db.connection import get_conn  # noqa: E402
+from scripts.nasdaq_universe_run import _snapshot_has_full_coverage  # noqa: E402
 
 
 def _find_release(cur, identifier: str):
     cur.execute(
         """
-        SELECT id::text, workspace, release_key, status, created_at, activated_at
+        SELECT id::text, workspace, release_key, status, coverage_complete,
+               created_at, activated_at
           FROM report_releases
          WHERE id::text = %s OR (workspace = 'nasdaq100' AND release_key = %s)
          LIMIT 1
@@ -44,6 +47,12 @@ def main() -> int:
     create.add_argument("--key", required=True)
     activate = sub.add_parser("activate")
     activate.add_argument("--release", required=True, help="Release UUID or release key")
+    reconcile = sub.add_parser("reconcile")
+    reconcile.add_argument(
+        "--release",
+        required=True,
+        help="Completed universe-run release UUID or release key",
+    )
     sub.add_parser("list")
     args = parser.parse_args()
 
@@ -56,7 +65,8 @@ def main() -> int:
                     VALUES ('nasdaq100', %s)
                     ON CONFLICT (workspace, release_key) DO UPDATE
                        SET release_key = EXCLUDED.release_key
-                    RETURNING id::text, workspace, release_key, status, created_at, activated_at;
+                    RETURNING id::text, workspace, release_key, status, coverage_complete,
+                              created_at, activated_at;
                     """,
                     (args.key.strip(),),
                 )
@@ -73,7 +83,8 @@ def main() -> int:
                     UPDATE report_releases
                        SET status = 'active', activated_at = now()
                      WHERE id = %s::uuid AND workspace = 'nasdaq100' AND status = 'staged'
-                    RETURNING id::text, workspace, release_key, status, created_at, activated_at;
+                    RETURNING id::text, workspace, release_key, status, coverage_complete,
+                              created_at, activated_at;
                     """,
                     (release[0],),
                 )
@@ -82,13 +93,63 @@ def main() -> int:
                     raise ValueError("Release is already active.")
                 cur.execute(
                     "UPDATE reports SET available_at = %s WHERE release_id = %s::uuid;",
-                    (updated[5], release[0]),
+                    (updated[6], release[0]),
                 )
                 rows = [updated]
+            elif args.command == "reconcile":
+                release = _find_release(cur, args.release.strip())
+                if not release:
+                    raise ValueError("Release was not found.")
+                cur.execute(
+                    """
+                    SELECT universe_snapshot
+                      FROM nasdaq_universe_runs
+                     WHERE release_id = %s::uuid
+                       AND status = 'completed'
+                     ORDER BY finished_at DESC NULLS LAST, created_at DESC
+                     LIMIT 1;
+                    """,
+                    (release[0],),
+                )
+                run = cur.fetchone()
+                if not run:
+                    raise ValueError("Release has no completed universe run.")
+                cur.execute(
+                    """
+                    SELECT DISTINCT report.ticker
+                      FROM reports report
+                      JOIN report_releases source_release ON source_release.id = report.release_id
+                     WHERE report.workspace = 'nasdaq100'
+                       AND report.deleted_at IS NULL
+                       AND source_release.status IN ('running', 'active')
+                       AND (
+                            report.release_id = %s::uuid
+                            OR report.available_at >= now() - interval '7 days'
+                       );
+                    """,
+                    (release[0],),
+                )
+                actual = {str(row[0] or "").strip().upper() for row in cur.fetchall()}
+                if not _snapshot_has_full_coverage(run[0], actual):
+                    raise ValueError("Release cohort does not cover the complete Nasdaq 100 universe.")
+                cur.execute(
+                    """
+                    UPDATE report_releases
+                       SET status = 'active',
+                           activated_at = coalesce(activated_at, now()),
+                           coverage_complete = true
+                     WHERE id = %s::uuid AND workspace = 'nasdaq100'
+                    RETURNING id::text, workspace, release_key, status, coverage_complete,
+                              created_at, activated_at;
+                    """,
+                    (release[0],),
+                )
+                rows = [cur.fetchone()]
             else:
                 cur.execute(
                     """
-                    SELECT id::text, workspace, release_key, status, created_at, activated_at
+                    SELECT id::text, workspace, release_key, status, coverage_complete,
+                           created_at, activated_at
                       FROM report_releases
                      ORDER BY created_at DESC;
                     """
@@ -102,8 +163,9 @@ def main() -> int:
             "workspace": str(row[1]),
             "release_key": str(row[2]),
             "status": str(row[3]),
-            "created_at": row[4].isoformat(),
-            "activated_at": row[5].isoformat() if row[5] else None,
+            "coverage_complete": bool(row[4]),
+            "created_at": row[5].isoformat(),
+            "activated_at": row[6].isoformat() if row[6] else None,
         }
         for row in rows
         if row

--- a/tests/test_nasdaq_execution.py
+++ b/tests/test_nasdaq_execution.py
@@ -10,7 +10,11 @@ from ai_hedge.nasdaq_execution import (
     is_preferred_off_peak_utc,
     retry_delay_seconds,
 )
-from scripts.nasdaq_universe_run import _snapshot_has_full_coverage, _terminal_run_status
+from scripts.nasdaq_universe_run import (
+    _release_has_full_coverage,
+    _snapshot_has_full_coverage,
+    _terminal_run_status,
+)
 
 
 def _utc(hour: int, minute: int = 0) -> datetime:
@@ -70,6 +74,43 @@ def test_release_coverage_accepts_any_saved_alias_for_an_issuer() -> None:
     assert _snapshot_has_full_coverage(snapshot, {"GOOG", "AAPL"})
     assert _snapshot_has_full_coverage(snapshot, {"GOOGL", "AAPL"})
     assert not _snapshot_has_full_coverage(snapshot, {"AAPL"})
+
+
+def test_release_coverage_reads_the_current_release_and_recent_active_cohort() -> None:
+    class Cursor:
+        query = ""
+        params = ()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def execute(self, query, params) -> None:
+            self.query = query
+            self.params = params
+
+        def fetchall(self):
+            return [("AAPL",), ("MSFT",)]
+
+    class Connection:
+        cursor_instance = Cursor()
+
+        def cursor(self):
+            return self.cursor_instance
+
+    snapshot = [
+        {"ticker": "AAPL", "aliases": ["AAPL"]},
+        {"ticker": "MSFT", "aliases": ["MSFT"]},
+    ]
+    conn = Connection()
+
+    assert _release_has_full_coverage(conn, "5c4ea3b9-3817-4d8b-a291-598019958d85", snapshot)
+    assert "report.release_id = %s::uuid" in conn.cursor_instance.query
+    assert "report.available_at >= now() - interval '7 days'" in conn.cursor_instance.query
+    assert "release.status IN ('running', 'active')" in conn.cursor_instance.query
+    assert conn.cursor_instance.params == ("5c4ea3b9-3817-4d8b-a291-598019958d85",)
 
 
 def test_terminal_run_status_distinguishes_stop_from_technical_failure() -> None:

--- a/tests/test_workspace_isolation.py
+++ b/tests/test_workspace_isolation.py
@@ -85,6 +85,20 @@ def test_universe_run_migration_supports_incremental_visibility_and_resume() -> 
     assert "coverage_complete" in migration
 
 
+def test_portfolio_unlocks_the_active_nasdaq_cohort_after_full_coverage() -> None:
+    portfolio_db = (
+        Path(__file__).resolve().parents[1]
+        / "frontend"
+        / "src"
+        / "lib"
+        / "portfolio-db.ts"
+    ).read_text(encoding="utf-8")
+
+    assert "rr.status = 'active'" in portfolio_db
+    assert "coverage_release.workspace = 'nasdaq100'" in portfolio_db
+    assert "coverage_release.coverage_complete" in portfolio_db
+
+
 def test_worker_pool_migration_has_leases_budget_and_concurrency_guards() -> None:
     migration = (
         Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Summary

- treat a completed seven-day Nasdaq release cohort as the full-universe coverage unit
- unlock isolated Nasdaq portfolio inputs only after that complete coverage gate is set
- add a safe operator reconciliation command for the completed 101-company cohort
- wake reused Fly preview machines before portfolio bootstrap and clarify the first-session Forward state

## Preview

URL: https://pr-141-hedge-in-a-box-site.fly.dev

## Test plan

- [x] `python -m pytest tests/test_nasdaq_execution.py tests/test_workspace_isolation.py --basetemp=.codex-pytest-nasdaq-release-2 -q` (18 passed)
- [x] `npm run test:portfolio` (36 passed)
- [x] targeted ESLint on the changed frontend TypeScript files
- [x] `npm run build`
- [x] live read-only coverage audit: 102 active reports / 101 issuer groups / 0 missing dashboards / 0 missing currencies
- [x] preview reconciliation returned `coverage_complete=true` for release `2ecd8250-7ee1-445b-9a36-b81079bee71f`
- [x] preview Paper refresh stored 721 market-price rows and correctly deferred snapshots because the first eligible session (2026-08-25) had not occurred
- [x] preview API returned isolated `nasdaq100` Paper metadata, QQQ benchmark, and the first-eligible-session message
- [x] preview `/nasdaq100/hit-rate` returned HTTP 200 with Portfolio Returns and Nasdaq navigation
- [x] preview workflow redeploy passed after explicitly waking the reused Fly machine

## Notes for reviewer

The latest run completed 68/68 but its release contained 97 reports because NVDA, MSFT, AMZN, and GOOGL had already completed in earlier active releases during the same seven-day `Missing this week` window. Across active releases the frozen universe is fully covered: 101 issuer groups. Portfolio storage was still empty because the old gate required one release to contain every issuer. This keeps Analysis isolated, does not rewrite Paper history, and does not fabricate returns before the first post-release market session.
