### PR TITLE
fix: align initial Nasdaq Paper cutoff

### DIFF
--- a/frontend/scripts/refresh-portfolio-performance.ts
+++ b/frontend/scripts/refresh-portfolio-performance.ts
@@ -310,9 +310,9 @@ async function main() {
       });
     }
 
-    const allCutoffDates = [...cutoffs, ...existing.map((snapshot) => nyDateString(new Date(snapshot.cutoffAt)))];
-    const earliestCutoff = allCutoffDates.sort()[0] || previousNyCalendarDay(now);
-    const earliestReport = addDays(earliestCutoff, -90);
+    const reportQueryCutoffs = [...cutoffs, ...existing.map((snapshot) => nyDateString(new Date(snapshot.cutoffAt)))];
+    const reportQueryCutoff = reportQueryCutoffs.sort()[0] || previousNyCalendarDay(now);
+    const earliestReport = addDays(reportQueryCutoff, -90);
     const reports = await listPortfolioReportInputs({
       workspace: args.workspace,
       earliestGeneratedAt: `${earliestReport}T00:00:00Z`,
@@ -328,6 +328,27 @@ async function main() {
       refreshRunId = null;
       return;
     }
+    if (
+      args.workspace === "nasdaq100"
+      && args.track === "paper"
+      && !args.paperCutoff
+      && existing.length === 0
+    ) {
+      const completedUniverseCutoff = reports
+        .map((report) => nyDateString(new Date(report.generatedAt)))
+        .sort()
+        .at(-1) || null;
+      cutoffs = planPaperCutoffs({
+        explicitCutoff: null,
+        existingCutoffDates: [],
+        defaultInitialCutoff: previousNyCalendarDay(now),
+        completedUniverseCutoff,
+        newMonthlyCutoffs: [],
+      });
+      console.log(`[portfolio] Nasdaq 100 initial Paper cutoff aligned to ${cutoffs[0]}, after full-cohort reporting.`);
+    }
+    const allCutoffDates = [...cutoffs, ...existing.map((snapshot) => nyDateString(new Date(snapshot.cutoffAt)))];
+    const earliestCutoff = allCutoffDates.sort()[0] || previousNyCalendarDay(now);
     const currencyByTicker = new Map<string, string>();
     for (const report of reports) currencyByTicker.set(report.ticker, report.currency);
     for (const snapshot of existing) {

--- a/frontend/src/lib/portfolio-refresh-policy.test.ts
+++ b/frontend/src/lib/portfolio-refresh-policy.test.ts
@@ -21,6 +21,16 @@ test("a new Paper track uses the safe initial cutoff", () => {
   }), ["2026-08-18"]);
 });
 
+test("a new full-universe Paper track starts after its final report date", () => {
+  assert.deepEqual(planPaperCutoffs({
+    explicitCutoff: null,
+    existingCutoffDates: [],
+    defaultInitialCutoff: "2026-08-23",
+    completedUniverseCutoff: "2026-08-24",
+    newMonthlyCutoffs: [],
+  }), ["2026-08-24"]);
+});
+
 test("ongoing Paper refreshes retry existing cutoffs and add new month ends", () => {
   assert.deepEqual(planPaperCutoffs({
     explicitCutoff: null,

--- a/frontend/src/lib/portfolio-refresh-policy.ts
+++ b/frontend/src/lib/portfolio-refresh-policy.ts
@@ -2,10 +2,13 @@ export function planPaperCutoffs(args: {
   explicitCutoff: string | null;
   existingCutoffDates: string[];
   defaultInitialCutoff: string;
+  completedUniverseCutoff?: string | null;
   newMonthlyCutoffs: string[];
 }): string[] {
   if (args.explicitCutoff) return [args.explicitCutoff];
-  if (!args.existingCutoffDates.length) return [args.defaultInitialCutoff];
+  if (!args.existingCutoffDates.length) {
+    return [args.completedUniverseCutoff || args.defaultInitialCutoff];
+  }
   return Array.from(new Set([
     ...args.existingCutoffDates,
     ...args.newMonthlyCutoffs,


### PR DESCRIPTION
## Summary

- align a brand-new Nasdaq Paper track to the latest report date in the completed universe cohort
- defer the first snapshot until the following eligible market session instead of starting from a partial prior-day report set
- leave existing Paper history, explicit repair cutoffs, Analysis, and ongoing monthly rebalances unchanged

## Preview

URL: https://pr-142-hedge-in-a-box-site.fly.dev

## Test plan

- [x] targeted ESLint on the refresh script and policy files
- [x] `npm run test:portfolio` (37 passed)
- [x] `npm run build`
- [x] preview refresh without an explicit cutoff logged `Nasdaq 100 initial Paper cutoff aligned to 2026-08-24`
- [x] preview stored 721 market-price rows and created zero snapshots because no benchmark session exists after 2026-08-24 yet
- [x] preview API stayed isolated to `nasdaq100`, reported QQQ, and showed the first-eligible-session Forward message
- [x] Site Preview workflow passed

## Notes for reviewer

The completed Nasdaq cohort finished on 2026-08-24. The generic initial Paper policy would otherwise choose the previous New York calendar day (2026-08-23) during tonight's scheduled refresh and freeze a portfolio from only the reports available before the full cohort completed. Paper snapshots are immutable, so the first cutoff must be correct.
