### PR TITLE
Fix dotted ticker dashboard routes

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "test:middleware": "tsx --test src/middleware.test.ts",
     "portfolio:refresh": "tsx scripts/refresh-portfolio-performance.ts",
     "test:portfolio": "tsx --test src/lib/discovery-engine.test.ts src/lib/nasdaq-execution-policy.test.ts src/lib/nasdaq-run-policy.test.ts src/lib/portfolio-performance-engine.test.ts src/lib/portfolio-refresh-policy.test.ts src/lib/trading-access-policy.test.ts src/lib/trading-db.test.ts src/lib/trading-signature.test.ts src/lib/workspace.test.ts"
   },

--- a/frontend/src/middleware.test.ts
+++ b/frontend/src/middleware.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { unstable_doesMiddlewareMatch } from "next/experimental/testing/server";
+
+import { config } from "./middleware";
+
+function matches(pathname: string): boolean {
+  return unstable_doesMiddlewareMatch({
+    config,
+    url: `https://hedge-in-a-box.com${pathname}`,
+  });
+}
+
+test("middleware runs for workspace dashboard routes with dotted tickers", () => {
+  assert.equal(matches("/analysis/dashboard/BSEN.TA/summary"), true);
+  assert.equal(matches("/nasdaq100/dashboard/BRK.B/summary"), true);
+  assert.equal(matches("/dashboard/BSEN.TA/summary"), true);
+});
+
+test("middleware protects API routes with dotted tickers", () => {
+  assert.equal(matches("/api/dashboard/BSEN.TA"), true);
+  assert.equal(matches("/api/dashboard/BRK.B/summary?window=all"), true);
+});
+
+test("middleware continues to skip static files", () => {
+  assert.equal(matches("/_next/static/chunks/app.js"), false);
+  assert.equal(matches("/_next/image/logo.png"), false);
+  assert.equal(matches("/images/logo.svg"), false);
+  assert.equal(matches("/favicon.ico"), false);
+});

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -70,5 +70,13 @@ export default auth((req) => {
 });
 
 export const config = {
-  matcher: ["/((?!_next/static|_next/image|favicon.ico|.*\\..*).*)"],
+  // Application and API paths may contain dotted ticker symbols (for example,
+  // BSEN.TA). Match them explicitly before the generic static-file exclusion.
+  matcher: [
+    "/api/:path*",
+    "/analysis/:path*",
+    "/nasdaq100/:path*",
+    "/dashboard/:path*",
+    "/((?!_next/static|_next/image|favicon.ico|.*\\..*).*)",
+  ],
 };


### PR DESCRIPTION
﻿## Summary

- run authentication and workspace routing for dashboard URLs containing dotted ticker symbols such as BSEN.TA and BRK.B
- protect dotted-ticker API routes with the same middleware instead of allowing them to bypass authentication
- add regression coverage for dotted application/API paths and static-file exclusions

## Preview

URL: https://pr-143-hedge-in-a-box-site.fly.dev

## Test plan

- [x] npm run test:middleware
- [x] targeted ESLint on middleware.ts and middleware.test.ts
- [x] npm run build
- [x] local production smoke: BSEN.TA and AAPL dashboard routes both redirect to sign-in; both API routes return 401; icon.svg remains 200
- [x] preview: BSEN.TA, BRK.B, and AAPL dashboard summary routes return 200; BSEN.TA renders Overall Summary and its dashboard API resolves a real report ID

## Notes for reviewer

The existing generic matcher intentionally skips paths containing dots so static assets are not authenticated. Explicit application and API matchers preserve that behavior for static files while allowing dotted ticker symbols through the middleware.
