### PR TITLE
Add lowest conviction Discovery ranking

### DIFF
--- a/frontend/src/app/(app)/discovery/page.tsx
+++ b/frontend/src/app/(app)/discovery/page.tsx
@@ -250,10 +250,7 @@ export default function DiscoveryPage() {
       <div>
         <header className="mb-6 rounded-2xl border border-white/10 bg-black/35 p-4 backdrop-blur-xl">
           <h1 className="font-display text-2xl">Market Discovery</h1>
-          <p className="text-xs tracking-[0.2em] text-zinc-500">
-            <span className="block">Based On Reports From the</span>
-            <span className="block">Last 3 Months</span>
-          </p>
+          <p className="text-xs tracking-[0.2em] text-zinc-500">Based On Reports From the Last 3 Months</p>
         </header>
 
         {loading || !data ? (

--- a/frontend/src/app/(app)/discovery/page.tsx
+++ b/frontend/src/app/(app)/discovery/page.tsx
@@ -26,6 +26,7 @@ type DiscoveryPayload = {
   top_undervalued: DiscoveryRow[];
   top_overvalued: DiscoveryRow[];
   top_conviction: DiscoveryRow[];
+  lowest_conviction: DiscoveryRow[];
   top_highest_allocation: DiscoveryRow[];
   top_lowest_allocation: DiscoveryRow[];
   top_scores: DiscoveryRow[];
@@ -230,7 +231,7 @@ export default function DiscoveryPage() {
       <div>
         <header className="mb-6 rounded-2xl border border-white/10 bg-black/35 p-4 backdrop-blur-xl">
           <h1 className="font-display text-2xl">Market Discovery</h1>
-          <p className="text-xs uppercase tracking-[0.2em] text-zinc-500">All Reports (Latest Per Ticker)</p>
+          <p className="text-xs uppercase tracking-[0.2em] text-zinc-500">Reports From the Last 3 Months</p>
         </header>
 
         {loading || !data ? (
@@ -347,13 +348,22 @@ export default function DiscoveryPage() {
                 metricLabel="allocation"
               />
               {lensType === "overall" ? (
-                <SectionCard
-                  title="Top Conviction"
-                  icon={<Radar size={16} className="hib-conviction-accent" />}
-                  rows={data.top_conviction}
-                  accent="hib-conviction-accent"
-                  metricLabel="disagreement"
-                />
+                <>
+                  <SectionCard
+                    title="Top Conviction"
+                    icon={<Radar size={16} className="hib-conviction-accent" />}
+                    rows={data.top_conviction}
+                    accent="hib-conviction-accent"
+                    metricLabel="disagreement"
+                  />
+                  <SectionCard
+                    title="Lowest Conviction"
+                    icon={<Radar size={16} className="text-[color:var(--danger)]" />}
+                    rows={data.lowest_conviction}
+                    accent="text-[color:var(--danger)]"
+                    metricLabel="disagreement"
+                  />
+                </>
               ) : null}
             </div>
           </>

--- a/frontend/src/app/(app)/discovery/page.tsx
+++ b/frontend/src/app/(app)/discovery/page.tsx
@@ -146,16 +146,16 @@ function SectionCard({
                   </div>
                 ) : (
                   <div className={showSummaryScore ? "rounded-lg border border-white/10 bg-white/5 px-2.5 py-2" : undefined}>
-                    <p className="text-zinc-500">Disagreement Score</p>
-                    <p className={`${accent} mt-0.5 font-semibold tabular-nums`}>
+                    <p className={showSummaryScore ? "min-h-8 text-zinc-500 leading-4" : "text-zinc-500"}>Disagreement Score</p>
+                    <p className={`${accent} ${showSummaryScore ? "mt-2" : "mt-0.5"} font-semibold tabular-nums`}>
                       {Number.isFinite(row.confidence_cv) ? row.confidence_cv.toFixed(3) : "N/A"}
                     </p>
                   </div>
                 )}
                 {showSummaryScore ? (
                   <div className="rounded-lg border border-white/10 bg-white/5 px-2.5 py-2">
-                    <p className="text-zinc-500">Summary Score</p>
-                    <p className={`${summaryScoreTone(row.points_score)} mt-0.5 font-semibold tabular-nums`}>
+                    <p className="min-h-8 text-zinc-500 leading-4">Summary Score</p>
+                    <p className={`${summaryScoreTone(row.points_score)} mt-2 font-semibold tabular-nums`}>
                       {fmtScore(row.points_score)}
                     </p>
                   </div>
@@ -250,7 +250,10 @@ export default function DiscoveryPage() {
       <div>
         <header className="mb-6 rounded-2xl border border-white/10 bg-black/35 p-4 backdrop-blur-xl">
           <h1 className="font-display text-2xl">Market Discovery</h1>
-          <p className="text-xs uppercase tracking-[0.2em] text-zinc-500">Reports From the Last 3 Months</p>
+          <p className="text-xs uppercase tracking-[0.2em] text-zinc-500">
+            <span className="block">Based On Reports From the</span>
+            <span className="block">Last 3 Months</span>
+          </p>
         </header>
 
         {loading || !data ? (
@@ -378,9 +381,9 @@ export default function DiscoveryPage() {
                   />
                   <SectionCard
                     title="Lowest Conviction"
-                    icon={<Radar size={16} className="text-[color:var(--danger)]" />}
+                    icon={<Radar size={16} className="text-[color:var(--info)]" />}
                     rows={data.lowest_conviction}
-                    accent="text-[color:var(--danger)]"
+                    accent="text-[color:var(--info)]"
                     metricLabel="disagreement"
                     showSummaryScore
                   />

--- a/frontend/src/app/(app)/discovery/page.tsx
+++ b/frontend/src/app/(app)/discovery/page.tsx
@@ -250,7 +250,7 @@ export default function DiscoveryPage() {
       <div>
         <header className="mb-6 rounded-2xl border border-white/10 bg-black/35 p-4 backdrop-blur-xl">
           <h1 className="font-display text-2xl">Market Discovery</h1>
-          <p className="text-xs uppercase tracking-[0.2em] text-zinc-500">
+          <p className="text-xs tracking-[0.2em] text-zinc-500">
             <span className="block">Based On Reports From the</span>
             <span className="block">Last 3 Months</span>
           </p>

--- a/frontend/src/app/(app)/discovery/page.tsx
+++ b/frontend/src/app/(app)/discovery/page.tsx
@@ -55,18 +55,27 @@ function fmtScore(value: number | null | undefined): string {
   return `${value >= 0 ? "+" : ""}${value.toFixed(2)}`;
 }
 
+function summaryScoreTone(value: number | null | undefined): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) return "text-[color:var(--text-muted)]";
+  if (value > 0) return "text-[color:var(--success)]";
+  if (value < 0) return "text-[color:var(--danger)]";
+  return "text-[color:var(--text-secondary)]";
+}
+
 function SectionCard({
   title,
   icon,
   rows,
   accent,
   metricLabel,
+  showSummaryScore = false,
 }: {
   title: string;
   icon: ReactNode;
   rows: DiscoveryRow[];
   accent: string;
   metricLabel: "return" | "disagreement" | "allocation" | "score";
+  showSummaryScore?: boolean;
 }) {
   const { href } = useWorkspace();
   const [topN, setTopN] = useState<10 | 20>(10);
@@ -136,14 +145,24 @@ function SectionCard({
                     <p className={accent}>{fmtScore(row.points_score)}</p>
                   </div>
                 ) : (
-                  <div>
+                  <div className={showSummaryScore ? "rounded-lg border border-white/10 bg-white/5 px-2.5 py-2" : undefined}>
                     <p className="text-zinc-500">Disagreement Score</p>
-                    <p className={accent}>{Number.isFinite(row.confidence_cv) ? row.confidence_cv.toFixed(3) : "N/A"}</p>
+                    <p className={`${accent} mt-0.5 font-semibold tabular-nums`}>
+                      {Number.isFinite(row.confidence_cv) ? row.confidence_cv.toFixed(3) : "N/A"}
+                    </p>
                   </div>
                 )}
-                <div>
+                {showSummaryScore ? (
+                  <div className="rounded-lg border border-white/10 bg-white/5 px-2.5 py-2">
+                    <p className="text-zinc-500">Summary Score</p>
+                    <p className={`${summaryScoreTone(row.points_score)} mt-0.5 font-semibold tabular-nums`}>
+                      {fmtScore(row.points_score)}
+                    </p>
+                  </div>
+                ) : null}
+                <div className={showSummaryScore ? "col-span-2 flex flex-wrap items-center justify-between gap-1 border-t border-white/10 pt-2" : undefined}>
                   <p className="text-zinc-500">Updated</p>
-                  <p className="text-zinc-200">{fmtDateTimeNoSeconds(String(row.updated_at || ""))}</p>
+                  <p className="text-zinc-200 tabular-nums">{fmtDateTimeNoSeconds(String(row.updated_at || ""))}</p>
                 </div>
               </div>
             </div>
@@ -355,6 +374,7 @@ export default function DiscoveryPage() {
                     rows={data.top_conviction}
                     accent="hib-conviction-accent"
                     metricLabel="disagreement"
+                    showSummaryScore
                   />
                   <SectionCard
                     title="Lowest Conviction"
@@ -362,6 +382,7 @@ export default function DiscoveryPage() {
                     rows={data.lowest_conviction}
                     accent="text-[color:var(--danger)]"
                     metricLabel="disagreement"
+                    showSummaryScore
                   />
                 </>
               ) : null}

--- a/frontend/src/app/api/discovery/route.ts
+++ b/frontend/src/app/api/discovery/route.ts
@@ -109,6 +109,7 @@ export async function GET(request: Request) {
     top_undervalued: ranked.topUndervalued,
     top_overvalued: ranked.topOvervalued,
     top_conviction: ranked.topConviction,
+    lowest_conviction: ranked.lowestConviction,
     top_highest_allocation: ranked.topHighestAllocation,
     top_lowest_allocation: ranked.topLowestAllocation,
     top_scores: ranked.topScores,

--- a/frontend/src/lib/discovery-engine.test.ts
+++ b/frontend/src/lib/discovery-engine.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import type { DashboardPayload } from "./dashboard-types";
 import {
   prepareDiscoveryUniverse,
+  rankDiscoveryRows,
   scoreDiscoveryCandidates,
   selectPositiveTopN,
   type DiscoverySourceReport,
@@ -87,7 +88,7 @@ test("historical discovery excludes future reports and anchors the 90-day window
   assert.ok(Math.abs(Number(persona[0].row.points_score) - 18.2) < 1e-9);
 });
 
-function candidate(ticker: string, score: number): ScoredDiscoveryCandidate {
+function candidate(ticker: string, score: number, disagreement: number = 0): ScoredDiscoveryCandidate {
   return {
     sourceReportIds: [],
     row: {
@@ -95,10 +96,10 @@ function candidate(ticker: string, score: number): ScoredDiscoveryCandidate {
       company_name: ticker,
       margin_safety_pct: 0,
       overvaluation_pct: 0,
-      dispersion: 0,
+      dispersion: disagreement,
       return_pct: 0,
       investment_allocation_pct: 0,
-      confidence_cv: 0,
+      confidence_cv: disagreement,
       points_score: score,
       updated_at: "2026-08-01T00:00:00Z",
     },
@@ -113,4 +114,16 @@ test("Top N keeps only positive scores and uses ticker as a deterministic tie-br
     candidate("ZERO", 0),
   ], 20);
   assert.deepEqual(selected.map((item) => item.row.ticker), ["AAA", "ZZZ"]);
+});
+
+test("conviction rankings order ticker-level disagreement in both directions", () => {
+  const ranked = rankDiscoveryRows([
+    candidate("HIGH", 1, 0.8),
+    candidate("LOW", 1, 0.1),
+    candidate("MID", 1, 0.4),
+    candidate("MISSING", 1, Number.POSITIVE_INFINITY),
+  ]);
+
+  assert.deepEqual(ranked.topConviction.map((row) => row.ticker), ["LOW", "MID", "HIGH"]);
+  assert.deepEqual(ranked.lowestConviction.map((row) => row.ticker), ["HIGH", "MID", "LOW"]);
 });

--- a/frontend/src/lib/discovery-engine.ts
+++ b/frontend/src/lib/discovery-engine.ts
@@ -44,6 +44,7 @@ export type RankedDiscoveryRows = {
   topUndervalued: DiscoveryRow[];
   topOvervalued: DiscoveryRow[];
   topConviction: DiscoveryRow[];
+  lowestConviction: DiscoveryRow[];
   topHighestAllocation: DiscoveryRow[];
   topLowestAllocation: DiscoveryRow[];
   topScores: DiscoveryRow[];
@@ -56,6 +57,7 @@ function safeNum(value: unknown): number {
 }
 
 function safeNumOrNull(value: unknown): number | null {
+  if (value === null || value === undefined || value === "") return null;
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : null;
 }
@@ -259,11 +261,23 @@ export function selectPositiveTopN(
 
 export function rankDiscoveryRows(candidates: ScoredDiscoveryCandidate[]): RankedDiscoveryRows {
   const rows = candidates.map((candidate) => candidate.row);
+  const convictionRows = rows.filter((row) => Number.isFinite(row.confidence_cv));
   return {
     all: rows,
     topUndervalued: rows.filter((row) => row.return_pct > 0).sort((a, b) => b.return_pct - a.return_pct).slice(0, 20),
     topOvervalued: rows.filter((row) => row.return_pct < 0).sort((a, b) => a.return_pct - b.return_pct).slice(0, 20),
-    topConviction: [...rows].sort((a, b) => a.confidence_cv - b.confidence_cv).slice(0, 20),
+    topConviction: [...convictionRows]
+      .sort((a, b) => {
+        const disagreementDiff = a.confidence_cv - b.confidence_cv;
+        return Math.abs(disagreementDiff) > 1e-12 ? disagreementDiff : a.ticker.localeCompare(b.ticker);
+      })
+      .slice(0, 20),
+    lowestConviction: [...convictionRows]
+      .sort((a, b) => {
+        const disagreementDiff = b.confidence_cv - a.confidence_cv;
+        return Math.abs(disagreementDiff) > 1e-12 ? disagreementDiff : a.ticker.localeCompare(b.ticker);
+      })
+      .slice(0, 20),
     topHighestAllocation: rows
       .filter((row) => typeof row.investment_allocation_pct === "number" && Number(row.investment_allocation_pct) > 0)
       .sort((a, b) => Number(b.investment_allocation_pct) - Number(a.investment_allocation_pct))


### PR DESCRIPTION
﻿## Summary

- add a ticker-level Lowest Conviction list ranked by the highest 3-month disagreement scores
- keep Top Conviction and Lowest Conviction limited to rows with numeric disagreement data and add deterministic ticker tie-breakers
- show the directional Summary Score only inside conviction cards, with semantic positive/negative colors and a compact mobile layout
- present the three-month report subtitle as one contiguous line of text with natural wrapping only when space requires it
- use the semantic info-blue tone for Lowest Conviction disagreement and align both metric values with equal label height and spacing

## Preview

URL: https://pr-144-hedge-in-a-box-site.fly.dev

## Test plan

- [x] `npm.cmd run test:portfolio` (38 tests passed)
- [x] focused ESLint for the Discovery page with the known baseline effect rule disabled, plus engine/API lint from the initial commit
- [x] `npm.cmd run build`
- [x] verify the final deployed bundle contains one contiguous subtitle with no forced block or uppercase transform
- [x] verify the refreshed deployed bundle contains the info-blue Lowest Conviction tone, equal label height, and equal score spacing
- [x] verify the deployed CSS defines the info tone separately for dark and light themes
- [x] verify `/api/discovery` on the refreshed preview still returns the 3-month Top/Lowest Conviction lists

## Notes for reviewer

- `Lowest Conviction` is the inverse ticker-level ranking of `Top Conviction`: highest mean Disagreement Score first across the same trailing 3-month report aggregation.
- Conviction cards pair Disagreement Score with Summary Score; positive summary scores use the semantic success token, negative scores use the danger token, and zero/missing values remain neutral.
- Lowest Conviction disagreement now uses `--info`, which is distinct from both the Top Conviction cyan and the short/negative red in dark and light themes.
- Both metric labels reserve the same two-line height and use the same gap before their values, keeping the scores aligned on narrow cards.
- In-app visual inspection was unavailable because the browser connection lacked required session metadata; preview HTTP/API/deployed-bundle/CSS checks passed instead.
- Page-only ESLint still reports the existing `react-hooks/set-state-in-effect` finding at `discovery/page.tsx:193`, outside this diff, when the baseline rule is enabled.
- Standalone `tsc --noEmit` still reports four existing optional `decision_card` findings in `hit-rate-aggregate.test.ts` and `ticker-summary-aggregate.test.ts`; the production build TypeScript phase passes.
