### PR TITLE
feat: compare equal and score-weighted portfolios

### DIFF
--- a/.github/workflows/preview-site.yml
+++ b/.github/workflows/preview-site.yml
@@ -266,7 +266,7 @@ jobs:
           flyctl ssh console --app "${{ env.PREVIEW_APP }}" --command \
             "sh -lc 'cd /app/frontend && npm run portfolio:refresh -- --workspace analysis --track backtest --start-cutoff 2026-04-30'"
           flyctl ssh console --app "${{ env.PREVIEW_APP }}" --command \
-            "sh -lc 'cd /app/frontend && npm run portfolio:refresh -- --workspace analysis --track paper --paper-cutoff 2026-08-17'"
+            "sh -lc 'cd /app/frontend && npm run portfolio:refresh -- --workspace analysis --track paper --methodology equal --paper-cutoff 2026-08-17'"
 
       - name: Diagnostics on deploy failure
         if: failure() && steps.deploy.conclusion == 'failure'

--- a/frontend/scripts/refresh-portfolio-performance.ts
+++ b/frontend/scripts/refresh-portfolio-performance.ts
@@ -27,11 +27,14 @@ import {
   computePortfolioNavSeries,
   firstExecutionDateForCandidates,
   latestPriceOnOrBefore,
-  PORTFOLIO_METHODOLOGY_VERSION,
+  PORTFOLIO_METHODOLOGIES,
   PORTFOLIO_PROVIDER,
   PORTFOLIO_RISK_FREE_SYMBOL,
   portfolioWorkspaceConfig,
+  resolvePortfolioMethodology,
   type MarketPricePoint,
+  type PortfolioMethodology,
+  type PortfolioMethodologyKey,
   type PortfolioSnapshotDefinition,
   type PortfolioTrack,
 } from "../src/lib/portfolio-performance-engine";
@@ -68,10 +71,12 @@ type CliArgs = {
   paperCutoff: string | null;
   throughDate: string;
   replaceBacktest: boolean;
+  methodology: PortfolioMethodologyKey | "all";
 };
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const NY_TIME_ZONE = "America/New_York";
+const priceProviderRequests = new Map<string, Promise<PriceBundle>>();
 
 function parseCliArgs(): CliArgs {
   const values = process.argv.slice(2);
@@ -91,6 +96,11 @@ function parseCliArgs(): CliArgs {
   const throughDate = valueFor("--through") || new Date().toISOString().slice(0, 10);
   const startCutoff = valueFor("--start-cutoff") || "2026-04-30";
   const paperCutoff = valueFor("--paper-cutoff");
+  const rawMethodology = valueFor("--methodology") || "all";
+  const methodology = rawMethodology === "all" ? "all" : resolvePortfolioMethodology(rawMethodology)?.key;
+  if (!methodology) {
+    throw new Error("--methodology must be all, equal, or score_blend.");
+  }
   for (const [name, value] of [
     ["--through", throughDate],
     ["--start-cutoff", startCutoff],
@@ -108,6 +118,7 @@ function parseCliArgs(): CliArgs {
     paperCutoff,
     throughDate,
     replaceBacktest: values.includes("--replace-backtest"),
+    methodology,
   };
 }
 
@@ -189,10 +200,16 @@ function monthlyCutoffDates(startDate: string, endDate: string): string[] {
 }
 
 function runPriceProvider(payload: object): Promise<PriceBundle> {
+  const cacheKey = JSON.stringify(payload);
+  const cached = priceProviderRequests.get(cacheKey);
+  if (cached) {
+    console.log("[portfolio] reusing market data fetched for the other methodology.");
+    return cached;
+  }
   const repoRoot = path.resolve(process.cwd(), "..");
   const script = path.resolve(repoRoot, "scripts", "portfolio_prices.py");
   const python = process.env.PYTHON_EXECUTABLE || "python";
-  return new Promise((resolve, reject) => {
+  const request = new Promise<PriceBundle>((resolve, reject) => {
     const child = spawn(python, [script], {
       cwd: repoRoot,
       env: { ...process.env, PYTHONPATH: path.resolve(repoRoot, "src"), PYTHONUNBUFFERED: "1" },
@@ -215,6 +232,8 @@ function runPriceProvider(payload: object): Promise<PriceBundle> {
     });
     child.stdin.end(JSON.stringify(payload));
   });
+  priceProviderRequests.set(cacheKey, request);
+  return request;
 }
 
 function flattenPriceBundle(bundle: PriceBundle): MarketPricePoint[] {
@@ -263,8 +282,7 @@ function lensMapKey(lens: DiscoveryLensSelection): string {
   return `${lens.type}:${lens.key || "overall"}`;
 }
 
-async function main() {
-  const args = parseCliArgs();
+async function refreshMethodology(args: CliArgs, methodology: PortfolioMethodology) {
   const workspaceConfig = portfolioWorkspaceConfig(args.workspace);
   if (args.replaceBacktest && args.track !== "backtest") {
     throw new Error("--replace-backtest is only valid with --track backtest.");
@@ -273,7 +291,7 @@ async function main() {
     throw new Error("--paper-cutoff is only valid with --track paper.");
   }
   const owner = `${process.env.HOSTNAME || "local"}:${process.pid}:${randomUUID()}`;
-  const lockKey = `portfolio-performance:${args.workspace}:${args.track}:${PORTFOLIO_METHODOLOGY_VERSION}`;
+  const lockKey = `portfolio-performance:${args.workspace}:${args.track}:${methodology.version}`;
   if (!(await acquirePortfolioRefreshLock(lockKey, owner))) {
     console.log(`[portfolio] ${lockKey} is already running; exiting cleanly.`);
     return;
@@ -284,13 +302,13 @@ async function main() {
     refreshRunId = await startPortfolioRefreshRun({
       workspace: args.workspace,
       track: args.track,
-      methodologyVersion: PORTFOLIO_METHODOLOGY_VERSION,
+      methodologyVersion: methodology.version,
     });
     const processedSnapshotIds: string[] = [];
     if (args.replaceBacktest) {
-      await deletePortfolioTrack(args.workspace, "backtest", PORTFOLIO_METHODOLOGY_VERSION);
+      await deletePortfolioTrack(args.workspace, "backtest", methodology.version);
     }
-    let existing = await loadPortfolioSnapshots(args.workspace, args.track, PORTFOLIO_METHODOLOGY_VERSION);
+    let existing = await loadPortfolioSnapshots(args.workspace, args.track, methodology.version);
     const now = new Date();
     let cutoffs: string[];
     if (args.track === "backtest") {
@@ -439,6 +457,7 @@ async function main() {
           executionDate,
           priceBySymbol,
           currencyByTicker,
+          methodologyVersion: methodology.version,
         });
         const storedSnapshot = await insertPortfolioSnapshot({
           workspace: args.workspace,
@@ -446,7 +465,7 @@ async function main() {
           lens,
           cutoffAt: cutoffAt.toISOString(),
           executionDate,
-          methodologyVersion: PORTFOLIO_METHODOLOGY_VERSION,
+          methodologyVersion: methodology.version,
           benchmarkSymbol: workspaceConfig.benchmarkSymbol,
           benchmarkName: workspaceConfig.benchmarkName,
           candidateCount: candidates.length,
@@ -459,7 +478,7 @@ async function main() {
       console.log(`[portfolio] ${args.track} cutoff ${cutoffDate}: ${createdForCutoff} snapshots (${visibleReports.length} reports).`);
     }
 
-    existing = await loadPortfolioSnapshots(args.workspace, args.track, PORTFOLIO_METHODOLOGY_VERSION);
+    existing = await loadPortfolioSnapshots(args.workspace, args.track, methodology.version);
     for (const lensSnapshots of groupSnapshotsByLens(existing)) {
       const first = lensSnapshots[0];
       const nav = computePortfolioNavSeries({
@@ -473,7 +492,7 @@ async function main() {
         track: args.track,
         lensType: first.lens.type,
         lensKey: first.lens.key || "overall",
-        methodologyVersion: PORTFOLIO_METHODOLOGY_VERSION,
+        methodologyVersion: methodology.version,
         points: nav,
       });
     }
@@ -488,6 +507,7 @@ async function main() {
       const snapshot = snapshotsById.get(snapshotId);
       const reasons = [...warningReasons];
       if (args.track !== "paper") reasons.push("backtest_not_tradeable");
+      if (!methodology.tradeExecutionReleased) reasons.push("methodology_execution_not_released");
       if (args.workspace !== "nasdaq100") reasons.push("analysis_execution_not_released");
       if (snapshot?.status !== "ready") reasons.push("empty_target_requires_confirmation");
       const eligible = reasons.length === 0;
@@ -508,7 +528,7 @@ async function main() {
     });
     refreshRunId = null;
     if (enqueued) console.log(`[portfolio] enqueued ${enqueued} IBKR Paper rebalance plan(s).`);
-    console.log(`[portfolio] refreshed ${args.workspace}/${args.track}: ${existing.length} snapshots, ${fetchedPoints.length} price rows.`);
+    console.log(`[portfolio] refreshed ${args.workspace}/${args.track}/${methodology.key}: ${existing.length} snapshots, ${fetchedPoints.length} price rows.`);
   } catch (error) {
     if (refreshRunId) {
       try {
@@ -524,6 +544,16 @@ async function main() {
     throw error;
   } finally {
     await releasePortfolioRefreshLock(lockKey, owner);
+  }
+}
+
+async function main() {
+  const args = parseCliArgs();
+  const methodologies = args.methodology === "all"
+    ? PORTFOLIO_METHODOLOGIES
+    : PORTFOLIO_METHODOLOGIES.filter((methodology) => methodology.key === args.methodology);
+  for (const methodology of methodologies) {
+    await refreshMethodology(args, methodology);
   }
 }
 

--- a/frontend/src/app/api/portfolio-performance/route.ts
+++ b/frontend/src/app/api/portfolio-performance/route.ts
@@ -33,6 +33,16 @@ function parsePeriod(value: string | null): PortfolioPeriod {
   return VALID_PERIODS.has(normalized) ? normalized : "all";
 }
 
+function parseStartDate(value: string | null): string | null {
+  if (!value) return null;
+  const parsed = Date.parse(`${value}T00:00:00Z`);
+  return /^\d{4}-\d{2}-\d{2}$/.test(value)
+    && Number.isFinite(parsed)
+    && new Date(parsed).toISOString().slice(0, 10) === value
+    ? value
+    : null;
+}
+
 function groupByLens(rows: StoredPortfolioNavPoint[]): StoredPortfolioNavPoint[][] {
   const grouped = new Map<string, StoredPortfolioNavPoint[]>();
   for (const row of rows) {
@@ -150,6 +160,9 @@ export async function GET(request: Request) {
   const url = new URL(request.url);
   const track = parseTrack(url.searchParams.get("track"));
   const period = parsePeriod(url.searchParams.get("period"));
+  const rawStartDate = url.searchParams.get("start");
+  const startDate = parseStartDate(rawStartDate);
+  if (rawStartDate && !startDate) return NextResponse.json({ error: "Invalid start date." }, { status: 400 });
   const workspace = parseApiWorkspace(url.searchParams.get("workspace"));
   if (!workspace) return NextResponse.json({ error: "Invalid workspace." }, { status: 400 });
   const methodology = resolvePortfolioMethodology(url.searchParams.get("methodology"));
@@ -166,7 +179,9 @@ export async function GET(request: Request) {
     });
     const riskFreePoints = riskFreePrices.get(PORTFOLIO_RISK_FREE_SYMBOL) || [];
     const summaries = groupByLens(rows)
-      .map((group) => summarizeLens(group, period, riskFreePoints, workspace, track))
+      .map((group) => startDate ? group.filter((row) => row.date >= startDate) : group)
+      .filter((group) => group.length > 0)
+      .map((group) => summarizeLens(group, startDate ? "all" : period, riskFreePoints, workspace, track))
       .sort((a, b) => {
         if (a.lens_type === "overall") return -1;
         if (b.lens_type === "overall") return 1;
@@ -176,7 +191,7 @@ export async function GET(request: Request) {
       ...emptyResponse(workspace, track, period, methodology),
       available: true,
       message: null,
-      range: { start: dates[0], end: dates[dates.length - 1] },
+      range: { start: startDate || dates[0], end: dates[dates.length - 1] },
       by_model: summaries.filter((row) => row.lens_type === "overall" || row.lens_type === "model"),
       by_valuator: summaries.filter((row) => row.lens_type === "valuator"),
     });

--- a/frontend/src/app/api/portfolio-performance/route.ts
+++ b/frontend/src/app/api/portfolio-performance/route.ts
@@ -2,17 +2,18 @@ import { NextResponse } from "next/server";
 
 import { loadMarketPrices, loadPortfolioNav, type StoredPortfolioNavPoint } from "@/lib/portfolio-db";
 import {
-  PORTFOLIO_METHODOLOGY_VERSION,
   PORTFOLIO_PROVIDER,
   PORTFOLIO_RISK_FREE_NAME,
   PORTFOLIO_RISK_FREE_SYMBOL,
   PORTFOLIO_RISK_MIN_OBSERVATIONS,
   PORTFOLIO_TRADING_DAYS_PER_YEAR,
   portfolioWorkspaceConfig,
+  resolvePortfolioMethodology,
   summarizePortfolioPeriod,
   type MarketPricePoint,
   type PortfolioPeriod,
   type PortfolioTrack,
+  type PortfolioMethodology,
 } from "@/lib/portfolio-performance-engine";
 import { parseApiWorkspace, type Workspace } from "@/lib/workspace";
 import { tradingPortfolioKey } from "@/lib/trading-types";
@@ -95,7 +96,13 @@ function summarizeLens(
   };
 }
 
-function emptyResponse(workspace: Workspace, track: PortfolioTrack, period: PortfolioPeriod, message?: string) {
+function emptyResponse(
+  workspace: Workspace,
+  track: PortfolioTrack,
+  period: PortfolioPeriod,
+  methodology: PortfolioMethodology,
+  message?: string,
+) {
   const config = portfolioWorkspaceConfig(workspace);
   return {
     generated_at: new Date().toISOString(),
@@ -107,9 +114,13 @@ function emptyResponse(workspace: Workspace, track: PortfolioTrack, period: Port
       ? "Nasdaq 100 forward portfolio history will appear after complete universe coverage and the first eligible market session."
       : "Portfolio performance history is not available yet."),
     methodology: {
-      version: PORTFOLIO_METHODOLOGY_VERSION,
+      key: methodology.key,
+      version: methodology.version,
+      label: methodology.label,
+      short_label: methodology.shortLabel,
+      trade_execution_released: methodology.tradeExecutionReleased,
       universe: config.universe,
-      construction: "Up to 20 positive-score stocks, equally weighted, rebalanced monthly",
+      construction: methodology.construction,
       score: "60% implied target return + 40% allocation, confidence-disagreement penalty applied",
       base_currency: "USD",
       return_type: "Gross simulated total return; no fees, slippage, tax, or cash interest",
@@ -141,9 +152,11 @@ export async function GET(request: Request) {
   const period = parsePeriod(url.searchParams.get("period"));
   const workspace = parseApiWorkspace(url.searchParams.get("workspace"));
   if (!workspace) return NextResponse.json({ error: "Invalid workspace." }, { status: 400 });
+  const methodology = resolvePortfolioMethodology(url.searchParams.get("methodology"));
+  if (!methodology) return NextResponse.json({ error: "Invalid portfolio methodology." }, { status: 400 });
   try {
-    const rows = await loadPortfolioNav(workspace, track, PORTFOLIO_METHODOLOGY_VERSION);
-    if (!rows.length) return NextResponse.json(emptyResponse(workspace, track, period));
+    const rows = await loadPortfolioNav(workspace, track, methodology.version);
+    if (!rows.length) return NextResponse.json(emptyResponse(workspace, track, period, methodology));
     const dates = rows.map((row) => row.date).sort();
     const riskFreePrices = await loadMarketPrices({
       symbols: [PORTFOLIO_RISK_FREE_SYMBOL],
@@ -160,7 +173,7 @@ export async function GET(request: Request) {
         return a.label.localeCompare(b.label);
       });
     return NextResponse.json({
-      ...emptyResponse(workspace, track, period),
+      ...emptyResponse(workspace, track, period, methodology),
       available: true,
       message: null,
       range: { start: dates[0], end: dates[dates.length - 1] },
@@ -169,6 +182,6 @@ export async function GET(request: Request) {
     });
   } catch (error) {
     console.warn("[portfolio-performance] DB read failed:", error);
-    return NextResponse.json(emptyResponse(workspace, track, period));
+    return NextResponse.json(emptyResponse(workspace, track, period, methodology));
   }
 }

--- a/frontend/src/components/portfolio-returns-section.tsx
+++ b/frontend/src/components/portfolio-returns-section.tsx
@@ -6,6 +6,8 @@ import { useWorkspace } from "@/components/shell/workspace-context";
 
 type PortfolioTrack = "paper" | "backtest";
 type PortfolioPeriod = "1m" | "3m" | "6m" | "1y" | "all";
+type PortfolioMethodologyKey = "equal" | "score_blend";
+type PortfolioMethodologyView = "compare" | PortfolioMethodologyKey;
 type PortfolioStatus = "ok" | "insufficient_history" | "no_positions" | "stale_market_data";
 type PortfolioRiskStatus = "ok" | "insufficient_history" | "risk_free_unavailable" | "stale_market_data";
 
@@ -41,7 +43,11 @@ type PortfolioPerformancePayload = {
   available: boolean;
   message: string | null;
   methodology: {
+    key: PortfolioMethodologyKey;
     version: string;
+    label: string;
+    short_label: string;
+    trade_execution_released: boolean;
     universe: string;
     construction: string;
     return_type: string;
@@ -65,6 +71,12 @@ const PERIODS: Array<{ value: PortfolioPeriod; label: string }> = [
   { value: "3m", label: "3M" },
   { value: "6m", label: "6M" },
   { value: "1y", label: "1Y" },
+];
+
+const METHODOLOGY_VIEWS: Array<{ value: PortfolioMethodologyView; label: string }> = [
+  { value: "compare", label: "Compare" },
+  { value: "equal", label: "Equal Weight" },
+  { value: "score_blend", label: "60/40 Score" },
 ];
 
 function formatPercent(value: number | null): string {
@@ -127,12 +139,14 @@ function ReturnsTable({
   benchmarkName,
   minimumObservations,
   track,
+  canConnect,
 }: {
   title: string;
   rows: PortfolioReturnRow[];
   benchmarkName: string;
   minimumObservations: number;
   track: PortfolioTrack;
+  canConnect: boolean;
 }) {
   const { href } = useWorkspace();
   const rowHref = (row: PortfolioReturnRow): string => row.lens_type === "overall"
@@ -154,7 +168,7 @@ function ReturnsTable({
                     {row.label}
                   </Link>
                   <p className="mt-1 text-xs text-[color:var(--text-muted)]">{statusLabel(row) || `${row.holdings_count} latest holdings`}</p>
-                  {track === "paper" ? (
+                  {track === "paper" && canConnect ? (
                     <Link href={tradingHref(row)} className="mt-2 inline-flex rounded-md border border-[color:var(--accent)] px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.12em] text-[color:var(--accent)] hover:bg-[color:var(--surface-elevated)]">
                       Connect
                     </Link>
@@ -218,7 +232,7 @@ function ReturnsTable({
                       {statusLabel(row) || `${row.holdings_count} holdings · since ${formatDate(row.period_start)}`}
                     </p>
                     {riskNotice ? <p className="mt-0.5 max-w-56 text-[11px] leading-snug text-[color:var(--warning)]">{riskNotice}</p> : null}
-                    {track === "paper" ? (
+                    {track === "paper" && canConnect ? (
                       <Link href={tradingHref(row)} className="mt-1.5 inline-flex rounded-md border border-[color:var(--accent)] px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.12em] text-[color:var(--accent)] hover:bg-[color:var(--surface)]">
                         Connect
                       </Link>
@@ -243,11 +257,143 @@ function ReturnsTable({
   );
 }
 
+type ComparedRow = {
+  key: string;
+  label: string;
+  reference: PortfolioReturnRow;
+  equal: PortfolioReturnRow | null;
+  scoreBlend: PortfolioReturnRow | null;
+};
+
+function pairRows(equalRows: PortfolioReturnRow[], scoreBlendRows: PortfolioReturnRow[]): ComparedRow[] {
+  const pairs = new Map<string, ComparedRow>();
+  for (const row of equalRows) {
+    const key = `${row.lens_type}:${row.lens_key || "overall"}`;
+    pairs.set(key, { key, label: row.label, reference: row, equal: row, scoreBlend: null });
+  }
+  for (const row of scoreBlendRows) {
+    const key = `${row.lens_type}:${row.lens_key || "overall"}`;
+    const existing = pairs.get(key);
+    pairs.set(key, existing
+      ? { ...existing, scoreBlend: row }
+      : { key, label: row.label, reference: row, equal: null, scoreBlend: row });
+  }
+  return Array.from(pairs.values()).sort((a, b) => {
+    const aReturn = a.equal?.return_pct ?? a.scoreBlend?.return_pct ?? Number.NEGATIVE_INFINITY;
+    const bReturn = b.equal?.return_pct ?? b.scoreBlend?.return_pct ?? Number.NEGATIVE_INFINITY;
+    return bReturn - aReturn || a.label.localeCompare(b.label);
+  });
+}
+
+function ComparisonMetrics({ row, label }: { row: PortfolioReturnRow | null; label: string }) {
+  return (
+    <dl className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-3 text-xs">
+      <dt className="font-semibold uppercase tracking-[0.12em] text-[color:var(--text-secondary)]">{label}</dt>
+      {row ? (
+        <>
+          <dd className={`mt-2 text-lg font-bold tabular-nums ${returnTone(row.return_pct)}`}>{formatPercent(row.return_pct)}</dd>
+          <div className="mt-2 flex items-center justify-between gap-2"><span className="text-[color:var(--text-muted)]">Volatility</span><span className="tabular-nums text-[color:var(--text-primary)]">{formatPercent(row.portfolio_volatility_pct)}</span></div>
+          <div className="mt-1 flex items-center justify-between gap-2"><span className="text-[color:var(--text-muted)]">Sharpe</span><span className="tabular-nums text-[color:var(--text-primary)]">{formatRatio(row.portfolio_sharpe)}</span></div>
+        </>
+      ) : <dd className="mt-2 leading-relaxed text-[color:var(--text-muted)]">Awaiting first snapshot</dd>}
+    </dl>
+  );
+}
+
+function ComparisonTable({
+  title,
+  equalRows,
+  scoreBlendRows,
+}: {
+  title: string;
+  equalRows: PortfolioReturnRow[];
+  scoreBlendRows: PortfolioReturnRow[];
+}) {
+  const { href } = useWorkspace();
+  const rows = pairRows(equalRows, scoreBlendRows);
+  const rowHref = (row: PortfolioReturnRow): string => row.lens_type === "overall"
+    ? href("/discovery?lens_type=overall")
+    : href(`/discovery?lens_type=${row.lens_type}&lens_key=${encodeURIComponent(row.lens_key || row.label)}`);
+  return (
+    <section className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
+      <h3 className="mb-3 text-sm font-semibold uppercase tracking-[0.16em] text-[color:var(--text-secondary)]">{title}</h3>
+      <div className="space-y-2 md:hidden">
+        {rows.map((pair) => {
+          const difference = pair.equal?.return_pct === null || pair.equal?.return_pct === undefined
+            || pair.scoreBlend?.return_pct === null || pair.scoreBlend?.return_pct === undefined
+            ? null
+            : pair.scoreBlend.return_pct - pair.equal.return_pct;
+          return (
+            <article key={`${pair.key}:comparison-mobile`} className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-3">
+              <div className="flex items-start justify-between gap-3">
+                <Link href={rowHref(pair.reference)} className="font-semibold text-[color:var(--accent)] underline-offset-2 hover:underline">{pair.label}</Link>
+                <div className="text-right">
+                  <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-[color:var(--text-muted)]">60/40 difference</p>
+                  <p className={`mt-1 font-bold tabular-nums ${returnTone(difference)}`}>{formatPercent(difference)}</p>
+                </div>
+              </div>
+              <div className="mt-3 grid grid-cols-2 gap-2">
+                <ComparisonMetrics row={pair.equal} label="Equal" />
+                <ComparisonMetrics row={pair.scoreBlend} label="60/40" />
+              </div>
+            </article>
+          );
+        })}
+      </div>
+      <div className="hidden overflow-x-auto rounded-lg border border-[color:var(--border-subtle)] md:block">
+        <table className="w-full min-w-[940px] text-sm">
+          <thead className="bg-[color:var(--surface)] text-[color:var(--text-muted)]">
+            <tr className="border-b border-[color:var(--border-subtle)]">
+              <th rowSpan={2} className="px-3 py-2 text-left font-medium">Portfolio</th>
+              <th colSpan={3} className="border-l border-[color:var(--border-subtle)] px-3 py-2 text-center font-semibold text-[color:var(--text-secondary)]">Equal Weight</th>
+              <th colSpan={3} className="border-l border-[color:var(--border-subtle)] px-3 py-2 text-center font-semibold text-[color:var(--text-secondary)]">60/40 Score Blend</th>
+              <th rowSpan={2} className="border-l border-[color:var(--border-subtle)] px-3 py-2 text-right font-medium">Return difference</th>
+            </tr>
+            <tr className="border-b border-[color:var(--border-subtle)] text-[11px] uppercase tracking-[0.08em]">
+              {(["Return", "Volatility", "Sharpe", "Return", "Volatility", "Sharpe"] as const).map((label, index) => (
+                <th key={`${label}:${index}`} className={`${index === 0 || index === 3 ? "border-l border-[color:var(--border-subtle)] " : ""}px-3 py-2 text-right font-medium`}>{label}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((pair) => {
+              const difference = pair.equal?.return_pct === null || pair.equal?.return_pct === undefined
+                || pair.scoreBlend?.return_pct === null || pair.scoreBlend?.return_pct === undefined
+                ? null
+                : pair.scoreBlend.return_pct - pair.equal.return_pct;
+              return (
+                <tr key={pair.key} className="border-b border-[color:var(--border-subtle)] last:border-b-0">
+                  <td className="px-3 py-2">
+                    <Link href={rowHref(pair.reference)} className="font-medium text-[color:var(--accent)] underline-offset-2 hover:underline">{pair.label}</Link>
+                    <p className="mt-0.5 text-[11px] text-[color:var(--text-muted)]">{pair.reference.holdings_count} latest holdings</p>
+                  </td>
+                  <td className={`border-l border-[color:var(--border-subtle)] px-3 py-2 text-right font-semibold tabular-nums ${returnTone(pair.equal?.return_pct ?? null)}`}>{formatPercent(pair.equal?.return_pct ?? null)}</td>
+                  <td className="px-3 py-2 text-right tabular-nums text-[color:var(--text-primary)]">{formatPercent(pair.equal?.portfolio_volatility_pct ?? null)}</td>
+                  <td className="px-3 py-2 text-right tabular-nums text-[color:var(--text-primary)]">{formatRatio(pair.equal?.portfolio_sharpe ?? null)}</td>
+                  <td className={`border-l border-[color:var(--border-subtle)] px-3 py-2 text-right font-semibold tabular-nums ${returnTone(pair.scoreBlend?.return_pct ?? null)}`}>{formatPercent(pair.scoreBlend?.return_pct ?? null)}</td>
+                  <td className="px-3 py-2 text-right tabular-nums text-[color:var(--text-primary)]">{formatPercent(pair.scoreBlend?.portfolio_volatility_pct ?? null)}</td>
+                  <td className="px-3 py-2 text-right tabular-nums text-[color:var(--text-primary)]">{formatRatio(pair.scoreBlend?.portfolio_sharpe ?? null)}</td>
+                  <td className={`border-l border-[color:var(--border-subtle)] px-3 py-2 text-right font-semibold tabular-nums ${returnTone(difference)}`}>{formatPercent(difference)}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+      {!rows.length ? <p className="text-sm text-[color:var(--text-muted)]">No portfolio history is available yet.</p> : null}
+    </section>
+  );
+}
+
 export function PortfolioReturnsSection() {
   const { workspace, api } = useWorkspace();
   const [track, setTrack] = useState<PortfolioTrack>("paper");
   const [period, setPeriod] = useState<PortfolioPeriod>("all");
-  const [data, setData] = useState<PortfolioPerformancePayload | null>(null);
+  const [methodologyView, setMethodologyView] = useState<PortfolioMethodologyView>("compare");
+  const [dataByMethodology, setDataByMethodology] = useState<Record<PortfolioMethodologyKey, PortfolioPerformancePayload | null>>({
+    equal: null,
+    score_blend: null,
+  });
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -255,11 +401,17 @@ export function PortfolioReturnsSection() {
     async function load() {
       setLoading(true);
       try {
-        const response = await fetch(api(`/api/portfolio-performance?track=${track}&period=${period}`), { cache: "no-store" });
-        const payload = (await response.json()) as PortfolioPerformancePayload;
-        if (!cancelled) setData(payload);
+        const entries = await Promise.all((["equal", "score_blend"] as const).map(async (methodology) => {
+          const response = await fetch(
+            api(`/api/portfolio-performance?track=${track}&period=${period}&methodology=${methodology}`),
+            { cache: "no-store" },
+          );
+          if (!response.ok) return [methodology, null] as const;
+          return [methodology, (await response.json()) as PortfolioPerformancePayload] as const;
+        }));
+        if (!cancelled) setDataByMethodology(Object.fromEntries(entries) as Record<PortfolioMethodologyKey, PortfolioPerformancePayload | null>);
       } catch {
-        if (!cancelled) setData(null);
+        if (!cancelled) setDataByMethodology({ equal: null, score_blend: null });
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -268,11 +420,20 @@ export function PortfolioReturnsSection() {
     return () => { cancelled = true; };
   }, [api, period, track, workspace]);
 
-  const benchmarkName = data?.methodology.benchmark_name || (workspace === "nasdaq100"
+  const equalData = dataByMethodology.equal;
+  const scoreBlendData = dataByMethodology.score_blend;
+  const selectedData = methodologyView === "compare" ? null : dataByMethodology[methodologyView];
+  const metadataSource = equalData || scoreBlendData;
+  const benchmarkName = metadataSource?.methodology.benchmark_name || (workspace === "nasdaq100"
     ? "Invesco QQQ - total-return proxy"
     : "S&P 500 Total Return");
-  const minimumRiskObservations = data?.methodology.minimum_risk_observations || 20;
-  const riskFreeName = data?.methodology.risk_free_name || "13-week U.S. Treasury Bill yield proxy";
+  const minimumRiskObservations = metadataSource?.methodology.minimum_risk_observations || 20;
+  const riskFreeName = metadataSource?.methodology.risk_free_name || "13-week U.S. Treasury Bill yield proxy";
+  const comparisonAvailable = Boolean(equalData?.available || scoreBlendData?.available);
+  const visibleAvailable = methodologyView === "compare" ? comparisonAvailable : Boolean(selectedData?.available);
+  const unavailableMessage = methodologyView === "compare"
+    ? equalData?.message || scoreBlendData?.message
+    : selectedData?.message;
 
   return (
     <section className="mb-6 rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-overlay)] p-4 sm:p-5">
@@ -282,7 +443,7 @@ export function PortfolioReturnsSection() {
             <h2 className="font-display text-xl text-[color:var(--text-primary)]">Portfolio Returns</h2>
             <span className="rounded-full border border-[color:var(--warning)] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--warning)]">Public Beta</span>
           </div>
-          <p className="mt-1 max-w-3xl text-sm text-[color:var(--text-muted)]">Monthly Top 20 positive-score portfolios, equal weighted and measured in USD against {benchmarkName}.</p>
+          <p className="mt-1 max-w-3xl text-sm text-[color:var(--text-muted)]">Compare monthly Top 20 positive-score portfolios using equal weight or a 60% equal / 40% score blend capped at 2x equal weight.</p>
           <div className="mt-3 flex flex-wrap gap-2 text-[11px] font-medium text-[color:var(--text-secondary)]">
             <span className="rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-2.5 py-1">Annualized daily risk</span>
             <span className="rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-2.5 py-1">Minimum {minimumRiskObservations} daily returns</span>
@@ -303,27 +464,47 @@ export function PortfolioReturnsSection() {
         </div>
       </div>
 
+      <div className="mt-4 flex flex-wrap items-center justify-between gap-3 border-t border-[color:var(--border-subtle)] pt-4">
+        <div className="inline-flex flex-wrap rounded-lg border border-[color:var(--border-strong)] bg-[color:var(--surface)] p-1" aria-label="Portfolio methodology view">
+          {METHODOLOGY_VIEWS.map((option) => (
+            <button key={option.value} type="button" onClick={() => setMethodologyView(option.value)} disabled={loading && methodologyView !== option.value} className={`rounded-md px-3 py-1.5 text-xs font-semibold transition disabled:cursor-not-allowed disabled:text-[color:var(--text-disabled)] ${methodologyView === option.value ? "bg-[color:var(--accent)] text-[color:var(--text-on-accent)]" : "text-[color:var(--text-secondary)] hover:text-[color:var(--text-primary)]"}`}>
+              {option.label}
+            </button>
+          ))}
+        </div>
+        <p className="max-w-2xl text-xs text-[color:var(--text-muted)]">
+          {methodologyView === "compare"
+            ? "Return difference is 60/40 minus Equal Weight; positive means the score blend led."
+            : selectedData?.methodology.construction}
+        </p>
+      </div>
+
       {loading ? (
         <div className="mt-4 grid gap-3 lg:grid-cols-2">
           <div className="h-40 animate-pulse rounded-xl bg-[color:var(--border-subtle)]" />
           <div className="h-40 animate-pulse rounded-xl bg-[color:var(--border-subtle)]" />
         </div>
-      ) : !data?.available ? (
+      ) : !visibleAvailable ? (
         <div className="mt-4 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4 text-sm text-[color:var(--text-muted)]">
-          {data?.message || "Portfolio performance history is not available yet."}
+          {unavailableMessage || "Portfolio performance history is not available yet."}
+        </div>
+      ) : methodologyView === "compare" ? (
+        <div className="mt-4 grid items-start gap-4 xl:grid-cols-2">
+          <ComparisonTable title="Models" equalRows={equalData?.by_model || []} scoreBlendRows={scoreBlendData?.by_model || []} />
+          <ComparisonTable title="Valuators" equalRows={equalData?.by_valuator || []} scoreBlendRows={scoreBlendData?.by_valuator || []} />
         </div>
       ) : (
         <div className="mt-4 grid items-start gap-4 xl:grid-cols-2">
-          <ReturnsTable title="Models" rows={data.by_model} benchmarkName={benchmarkName} minimumObservations={minimumRiskObservations} track={track} />
-          <ReturnsTable title="Valuators" rows={data.by_valuator} benchmarkName={benchmarkName} minimumObservations={minimumRiskObservations} track={track} />
+          <ReturnsTable title="Models" rows={selectedData?.by_model || []} benchmarkName={benchmarkName} minimumObservations={minimumRiskObservations} track={track} canConnect={Boolean(selectedData?.methodology.trade_execution_released)} />
+          <ReturnsTable title="Valuators" rows={selectedData?.by_valuator || []} benchmarkName={benchmarkName} minimumObservations={minimumRiskObservations} track={track} canConnect={Boolean(selectedData?.methodology.trade_execution_released)} />
         </div>
       )}
 
       <p className="mt-4 text-xs leading-relaxed text-[color:var(--text-muted)]">
         {track === "paper"
-          ? "Paper records each portfolio from the day it is created, and its holdings are never rewritten later. "
+          ? "Paper records each methodology separately from the day it is created, and its holdings are never rewritten later; the 60/40 series begins forward from its launch refresh. "
           : "Backtest reconstructs what each portfolio would have held at earlier month-ends, using only information available at the time. "}
-        Benchmark: every portfolio is compared with {benchmarkName}. {workspace === "nasdaq100" ? "QQQ adjusted close is used as an investable total-return proxy; it is not presented as the official XNDX index series. Only reports from a completed, fully covered Nasdaq 100 release can enter the ranking. " : "The Analysis benchmark is the full S&P 500 Total Return Index, including reinvested dividends. Only stocks analyzed during the previous 90 days can enter the ranking; that does not narrow the benchmark. "}Volatility is the annualized sample standard deviation of daily returns. Sharpe compares daily returns with the daily-matched {riskFreeName} yield and is annualized over 252 trading days; it appears after {minimumRiskObservations} daily returns. Latest holdings is the count at the most recent frozen rebalance, so it can differ from today&apos;s live Discovery ranking. Returns are simulated before fees, taxes, slippage, or cash interest. Prices, Treasury yield, and FX come from yfinance; missing data is shown explicitly.
+        Both methods use the same candidates, rebalance dates, prices, and {benchmarkName}; only position weights differ. {workspace === "nasdaq100" ? "QQQ adjusted close is used as an investable total-return proxy; it is not presented as the official XNDX index series. Only reports from a completed, fully covered Nasdaq 100 release can enter the ranking. " : "The Analysis benchmark is the full S&P 500 Total Return Index, including reinvested dividends. Only stocks analyzed during the previous 90 days can enter the ranking; that does not narrow the benchmark. "}Volatility is the annualized sample standard deviation of daily returns. Sharpe compares daily returns with the daily-matched {riskFreeName} yield and is annualized over 252 trading days; it appears after {minimumRiskObservations} daily returns. Latest holdings is the count at the most recent frozen rebalance, so it can differ from today&apos;s live Discovery ranking. Returns are simulated before fees, taxes, slippage, or cash interest. Prices, Treasury yield, and FX come from yfinance; missing data is shown explicitly. The new 60/40 methodology is visible in Paper but is not released to automated trading.
       </p>
     </section>
   );

--- a/frontend/src/components/portfolio-returns-section.tsx
+++ b/frontend/src/components/portfolio-returns-section.tsx
@@ -285,6 +285,18 @@ function pairRows(equalRows: PortfolioReturnRow[], scoreBlendRows: PortfolioRetu
   });
 }
 
+function comparisonReturnDifference(pair: ComparedRow): number | null {
+  if (
+    !pair.equal
+    || !pair.scoreBlend
+    || pair.equal.return_pct === null
+    || pair.scoreBlend.return_pct === null
+    || pair.equal.period_start !== pair.scoreBlend.period_start
+    || pair.equal.period_end !== pair.scoreBlend.period_end
+  ) return null;
+  return pair.scoreBlend.return_pct - pair.equal.return_pct;
+}
+
 function ComparisonMetrics({ row, label }: { row: PortfolioReturnRow | null; label: string }) {
   return (
     <dl className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-3 text-xs">
@@ -319,10 +331,7 @@ function ComparisonTable({
       <h3 className="mb-3 text-sm font-semibold uppercase tracking-[0.16em] text-[color:var(--text-secondary)]">{title}</h3>
       <div className="space-y-2 md:hidden">
         {rows.map((pair) => {
-          const difference = pair.equal?.return_pct === null || pair.equal?.return_pct === undefined
-            || pair.scoreBlend?.return_pct === null || pair.scoreBlend?.return_pct === undefined
-            ? null
-            : pair.scoreBlend.return_pct - pair.equal.return_pct;
+          const difference = comparisonReturnDifference(pair);
           return (
             <article key={`${pair.key}:comparison-mobile`} className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-3">
               <div className="flex items-start justify-between gap-3">
@@ -357,10 +366,7 @@ function ComparisonTable({
           </thead>
           <tbody>
             {rows.map((pair) => {
-              const difference = pair.equal?.return_pct === null || pair.equal?.return_pct === undefined
-                || pair.scoreBlend?.return_pct === null || pair.scoreBlend?.return_pct === undefined
-                ? null
-                : pair.scoreBlend.return_pct - pair.equal.return_pct;
+              const difference = comparisonReturnDifference(pair);
               return (
                 <tr key={pair.key} className="border-b border-[color:var(--border-subtle)] last:border-b-0">
                   <td className="px-3 py-2">
@@ -394,6 +400,10 @@ export function PortfolioReturnsSection() {
     equal: null,
     score_blend: null,
   });
+  const [comparisonByMethodology, setComparisonByMethodology] = useState<Record<PortfolioMethodologyKey, PortfolioPerformancePayload | null>>({
+    equal: null,
+    score_blend: null,
+  });
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -409,9 +419,33 @@ export function PortfolioReturnsSection() {
           if (!response.ok) return [methodology, null] as const;
           return [methodology, (await response.json()) as PortfolioPerformancePayload] as const;
         }));
-        if (!cancelled) setDataByMethodology(Object.fromEntries(entries) as Record<PortfolioMethodologyKey, PortfolioPerformancePayload | null>);
+        const loaded = Object.fromEntries(entries) as Record<PortfolioMethodologyKey, PortfolioPerformancePayload | null>;
+        let comparison = loaded;
+        const availableStarts = Object.values(loaded)
+          .filter((payload): payload is PortfolioPerformancePayload => Boolean(payload?.available && payload.range.start))
+          .map((payload) => payload.range.start as string);
+        if (period === "all" && availableStarts.length === 2 && availableStarts[0] !== availableStarts[1]) {
+          const commonStart = availableStarts.sort().at(-1) as string;
+          const alignedEntries = await Promise.all((["equal", "score_blend"] as const).map(async (methodology) => {
+            const payload = loaded[methodology];
+            if (!payload?.available || payload.range.start === commonStart) return [methodology, payload] as const;
+            const response = await fetch(
+              api(`/api/portfolio-performance?track=${track}&period=all&methodology=${methodology}&start=${commonStart}`),
+              { cache: "no-store" },
+            );
+            return [methodology, response.ok ? (await response.json()) as PortfolioPerformancePayload : null] as const;
+          }));
+          comparison = Object.fromEntries(alignedEntries) as Record<PortfolioMethodologyKey, PortfolioPerformancePayload | null>;
+        }
+        if (!cancelled) {
+          setDataByMethodology(loaded);
+          setComparisonByMethodology(comparison);
+        }
       } catch {
-        if (!cancelled) setDataByMethodology({ equal: null, score_blend: null });
+        if (!cancelled) {
+          setDataByMethodology({ equal: null, score_blend: null });
+          setComparisonByMethodology({ equal: null, score_blend: null });
+        }
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -422,6 +456,8 @@ export function PortfolioReturnsSection() {
 
   const equalData = dataByMethodology.equal;
   const scoreBlendData = dataByMethodology.score_blend;
+  const equalComparisonData = comparisonByMethodology.equal;
+  const scoreBlendComparisonData = comparisonByMethodology.score_blend;
   const selectedData = methodologyView === "compare" ? null : dataByMethodology[methodologyView];
   const metadataSource = equalData || scoreBlendData;
   const benchmarkName = metadataSource?.methodology.benchmark_name || (workspace === "nasdaq100"
@@ -474,7 +510,7 @@ export function PortfolioReturnsSection() {
         </div>
         <p className="max-w-2xl text-xs text-[color:var(--text-muted)]">
           {methodologyView === "compare"
-            ? "Return difference is 60/40 minus Equal Weight; positive means the score blend led."
+            ? "Return difference is 60/40 minus Equal Weight over the same dates; positive means the score blend led."
             : selectedData?.methodology.construction}
         </p>
       </div>
@@ -490,8 +526,8 @@ export function PortfolioReturnsSection() {
         </div>
       ) : methodologyView === "compare" ? (
         <div className="mt-4 grid items-start gap-4 xl:grid-cols-2">
-          <ComparisonTable title="Models" equalRows={equalData?.by_model || []} scoreBlendRows={scoreBlendData?.by_model || []} />
-          <ComparisonTable title="Valuators" equalRows={equalData?.by_valuator || []} scoreBlendRows={scoreBlendData?.by_valuator || []} />
+          <ComparisonTable title="Models" equalRows={equalComparisonData?.by_model || []} scoreBlendRows={scoreBlendComparisonData?.by_model || []} />
+          <ComparisonTable title="Valuators" equalRows={equalComparisonData?.by_valuator || []} scoreBlendRows={scoreBlendComparisonData?.by_valuator || []} />
         </div>
       ) : (
         <div className="mt-4 grid items-start gap-4 xl:grid-cols-2">

--- a/frontend/src/lib/portfolio-performance-engine.test.ts
+++ b/frontend/src/lib/portfolio-performance-engine.test.ts
@@ -4,11 +4,14 @@ import test from "node:test";
 import type { ScoredDiscoveryCandidate } from "./discovery-engine";
 import {
   buildHoldingsForSnapshot,
+  calculatePortfolioWeights,
   computePortfolioNavSeries,
   firstBenchmarkDateAfter,
   firstExecutionDateForCandidates,
   PORTFOLIO_RISK_MIN_OBSERVATIONS,
+  PORTFOLIO_SCORE_BLEND_METHODOLOGY_VERSION,
   PORTFOLIO_TRADING_DAYS_PER_YEAR,
+  resolvePortfolioMethodology,
   portfolioWorkspaceConfig,
   summarizePortfolioPeriod,
   type MarketPricePoint,
@@ -68,6 +71,52 @@ test("snapshot construction selects at most 20 positive names with equal 1/N wei
     currencyByTicker,
   });
   assert.deepEqual(cash, []);
+});
+
+test("60/40 score blend sums to one and follows score proportions below the cap", () => {
+  const methodology = resolvePortfolioMethodology(PORTFOLIO_SCORE_BLEND_METHODOLOGY_VERSION);
+  assert.ok(methodology);
+  const weights = calculatePortfolioWeights([5, 4, 3, 2, 1], methodology);
+  const expected = [
+    0.6 / 5 + 0.4 * 5 / 15,
+    0.6 / 5 + 0.4 * 4 / 15,
+    0.6 / 5 + 0.4 * 3 / 15,
+    0.6 / 5 + 0.4 * 2 / 15,
+    0.6 / 5 + 0.4 * 1 / 15,
+  ];
+  assert.ok(Math.abs(weights.reduce((sum, weight) => sum + weight, 0) - 1) < 1e-12);
+  weights.forEach((weight, index) => assert.ok(Math.abs(weight - expected[index]) < 1e-12));
+});
+
+test("60/40 score blend caps concentrated names at 2x equal weight and redistributes excess", () => {
+  const methodology = resolvePortfolioMethodology("score_blend");
+  assert.ok(methodology);
+  const weights = calculatePortfolioWeights([1000, 100, 10, 1], methodology);
+  assert.ok(Math.abs(weights.reduce((sum, weight) => sum + weight, 0) - 1) < 1e-12);
+  assert.ok(weights.every((weight) => weight <= 0.5 + 1e-12));
+  assert.ok(Math.abs(weights[0] - 0.5) < 1e-12);
+  assert.ok(weights[1] > weights[2]);
+  assert.ok(weights[2] > weights[3]);
+});
+
+test("snapshot construction applies the selected methodology without issuer deduplication", () => {
+  const candidates = [candidate("NICE", 10), candidate("NICE.TA", 5), candidate("OTHER", 1)];
+  const priceBySymbol = new Map<string, MarketPricePoint[]>();
+  const currencyByTicker = new Map<string, string>();
+  for (const item of candidates) {
+    priceBySymbol.set(item.row.ticker, [price(item.row.ticker, "2026-05-04", 100)]);
+    currencyByTicker.set(item.row.ticker, "USD");
+  }
+  const holdings = buildHoldingsForSnapshot({
+    candidates,
+    executionDate: "2026-05-04",
+    priceBySymbol,
+    currencyByTicker,
+    methodologyVersion: PORTFOLIO_SCORE_BLEND_METHODOLOGY_VERSION,
+  });
+  assert.deepEqual(holdings.map((holding) => holding.ticker), ["NICE", "NICE.TA", "OTHER"]);
+  assert.ok(Math.abs(holdings.reduce((sum, holding) => sum + holding.weight, 0) - 1) < 1e-12);
+  assert.ok(holdings[0].weight > holdings[1].weight);
 });
 
 function snapshot(args: { id: string; executionDate: string; ticker: string; entryPrice: number }): PortfolioSnapshotDefinition {

--- a/frontend/src/lib/portfolio-performance-engine.ts
+++ b/frontend/src/lib/portfolio-performance-engine.ts
@@ -5,7 +5,10 @@ import {
 } from "@/lib/discovery-engine";
 import type { Workspace } from "@/lib/workspace";
 
-export const PORTFOLIO_METHODOLOGY_VERSION = "top20-positive-equal-v1";
+export const PORTFOLIO_EQUAL_WEIGHT_METHODOLOGY_VERSION = "top20-positive-equal-v1";
+export const PORTFOLIO_SCORE_BLEND_METHODOLOGY_VERSION = "top20-positive-blend60-score40-cap2x-v2";
+// Trading automation deliberately remains pinned to the original released methodology.
+export const PORTFOLIO_METHODOLOGY_VERSION = PORTFOLIO_EQUAL_WEIGHT_METHODOLOGY_VERSION;
 export const PORTFOLIO_BENCHMARK_SYMBOL = "^SP500TR";
 export const PORTFOLIO_RISK_FREE_SYMBOL = "^IRX";
 export const PORTFOLIO_RISK_FREE_NAME = "13-week U.S. Treasury Bill yield proxy";
@@ -17,6 +20,51 @@ export const PORTFOLIO_TRADING_DAYS_PER_YEAR = 252;
 
 export type PortfolioTrack = "backtest" | "paper";
 export type PortfolioPeriod = "1m" | "3m" | "6m" | "1y" | "all";
+export type PortfolioMethodologyKey = "equal" | "score_blend";
+export type PortfolioMethodology = {
+  key: PortfolioMethodologyKey;
+  version: string;
+  label: string;
+  shortLabel: string;
+  construction: string;
+  equalWeightFraction: number;
+  scoreWeightFraction: number;
+  maxEqualWeightMultiple: number | null;
+  tradeExecutionReleased: boolean;
+};
+
+export const PORTFOLIO_METHODOLOGIES: readonly PortfolioMethodology[] = [
+  {
+    key: "equal",
+    version: PORTFOLIO_EQUAL_WEIGHT_METHODOLOGY_VERSION,
+    label: "Equal Weight",
+    shortLabel: "Equal",
+    construction: "Top 20 positive scores, equally weighted at each monthly rebalance.",
+    equalWeightFraction: 1,
+    scoreWeightFraction: 0,
+    maxEqualWeightMultiple: null,
+    tradeExecutionReleased: true,
+  },
+  {
+    key: "score_blend",
+    version: PORTFOLIO_SCORE_BLEND_METHODOLOGY_VERSION,
+    label: "60/40 Score Blend",
+    shortLabel: "60/40",
+    construction: "60% equal weight and 40% proportional to positive score, capped at 2x equal weight.",
+    equalWeightFraction: 0.6,
+    scoreWeightFraction: 0.4,
+    maxEqualWeightMultiple: 2,
+    tradeExecutionReleased: false,
+  },
+] as const;
+
+export function resolvePortfolioMethodology(value?: string | null): PortfolioMethodology | null {
+  const normalized = String(value || "").trim().toLowerCase();
+  if (!normalized) return PORTFOLIO_METHODOLOGIES[0];
+  return PORTFOLIO_METHODOLOGIES.find((methodology) => (
+    methodology.key === normalized || methodology.version.toLowerCase() === normalized
+  )) || null;
+}
 export type PortfolioDataStatus = "ok" | "no_positions" | "stale_market_data";
 export type PortfolioRiskStatus =
   | "ok"
@@ -154,6 +202,7 @@ export function buildHoldingsForSnapshot(args: {
   executionDate: string;
   priceBySymbol: Map<string, MarketPricePoint[]>;
   currencyByTicker: Map<string, string>;
+  methodologyVersion?: string;
   limit?: number;
 }): PortfolioHoldingDefinition[] {
   const ranked = selectPositiveTopN(args.candidates, args.limit || 20);
@@ -174,8 +223,56 @@ export function buildHoldingsForSnapshot(args: {
       entryPriceUsd: price.adjustedCloseUsd,
     });
   }
-  const weight = selected.length ? 1 / selected.length : 0;
-  return selected.map((holding, index) => ({ ...holding, rank: index + 1, weight }));
+  const methodology = resolvePortfolioMethodology(args.methodologyVersion);
+  if (!methodology) {
+    throw new Error(`Unknown portfolio methodology: ${args.methodologyVersion}`);
+  }
+  const weights = calculatePortfolioWeights(selected.map((holding) => holding.score), methodology);
+  return selected.map((holding, index) => ({ ...holding, rank: index + 1, weight: weights[index] }));
+}
+
+export function calculatePortfolioWeights(
+  scores: number[],
+  methodology: PortfolioMethodology = PORTFOLIO_METHODOLOGIES[0],
+): number[] {
+  const count = scores.length;
+  if (!count) return [];
+  if (scores.some((score) => !Number.isFinite(score) || score <= 0)) {
+    throw new Error("Portfolio scores must be finite positive numbers.");
+  }
+
+  const equalWeight = 1 / count;
+  const scoreTotal = scores.reduce((sum, score) => sum + score, 0);
+  const rawWeights = scores.map((score) => (
+    (methodology.equalWeightFraction * equalWeight)
+    + (methodology.scoreWeightFraction * (score / scoreTotal))
+  ));
+  if (methodology.maxEqualWeightMultiple === null) return rawWeights;
+
+  const cap = Math.min(1, methodology.maxEqualWeightMultiple * equalWeight);
+  const weights = Array(count).fill(0) as number[];
+  let remainingIndices = rawWeights.map((_, index) => index);
+  let remainingWeight = 1;
+
+  // Redistribute any capped excess proportionally across the still-uncapped raw weights.
+  while (remainingIndices.length) {
+    const remainingRawTotal = remainingIndices.reduce((sum, index) => sum + rawWeights[index], 0);
+    const cappedIndices = remainingIndices.filter((index) => (
+      (rawWeights[index] / remainingRawTotal) * remainingWeight > cap + Number.EPSILON
+    ));
+    if (!cappedIndices.length) {
+      for (const index of remainingIndices) {
+        weights[index] = (rawWeights[index] / remainingRawTotal) * remainingWeight;
+      }
+      break;
+    }
+    for (const index of cappedIndices) weights[index] = cap;
+    remainingWeight -= cap * cappedIndices.length;
+    const cappedSet = new Set(cappedIndices);
+    remainingIndices = remainingIndices.filter((index) => !cappedSet.has(index));
+  }
+
+  return weights;
 }
 
 export function computePortfolioNavSeries(args: {


### PR DESCRIPTION
## Summary

- Add a versioned 60% equal-weight / 40% score-proportional methodology with iterative redistribution above a 2x equal-weight position cap.
- Refresh and persist Equal Weight plus 60/40 Backtest and Paper series independently, while keeping existing Paper immutable and automated trading pinned to equal-weight v1.
- Add Compare / Equal Weight / 60/40 Score views with side-by-side return, volatility, Sharpe, and same-period return-difference tables.

## Preview

URL: https://pr-145-hedge-in-a-box-site.fly.dev/analysis/hit-rate

## Test plan

- [x] `npm run test:portfolio` (41 tests)
- [x] Targeted ESLint on all changed TypeScript/TSX files
- [x] `npm run build`
- [x] Preview `/analysis/hit-rate` returned 200 and its deployed HTML/bundle contains Compare and 60/40 Score controls
- [x] Preview Neon backfill created 71 Analysis Backtest snapshots for each methodology; both APIs expose 8 model and 10 valuator rows over 2026-05-01..2026-08-25
- [x] Preview API aligned a requested comparison start exactly and rejected an invalid start with 400
- [x] Nasdaq-100 v2 refresh/API verified independently; historical snapshots honestly remain `no_positions` because no point-in-time reports existed at those cutoffs

## Notes for reviewer

- Methodology versions are `top20-positive-equal-v1` and `top20-positive-blend60-score40-cap2x-v2`; existing equal-weight records are not rewritten.
- The new Paper series starts forward at its first refresh. The fixed historical preview Paper seed is explicitly restricted to Equal Weight so it cannot backdate v2.
- Since-Inception comparison aligns both methodologies to their first common date; a return difference is emitted only for matching start/end dates.
- Market prices remain shared/upserted; only methodology-specific snapshots, holdings, and NAV rows grow. Identical provider requests are reused within a refresh process.
- NICE and NICE.TA remain distinct tickers by design for now.
- `PORTFOLIO_METHODOLOGY_VERSION` remains the equal-weight v1 alias, and v2 receives `methodology_execution_not_released`, so the new comparison cannot enqueue IBKR plans.
- In-app visual inspection was unavailable because the browser runtime lacks its sandbox policy. Verification used the live preview HTTP/API, deployed bundle markers, production build, and responsive code review; no screenshot claim is made.