### PR TITLE
fix: isolate and monitor portfolio refreshes

### DIFF
--- a/.github/workflows/portfolio-performance.yml
+++ b/.github/workflows/portfolio-performance.yml
@@ -120,6 +120,7 @@ jobs:
               exit 1
             fi
           fi
+          FAILURES=()
           for TARGET_WORKSPACE in $WORKSPACES; do
             COMMAND="cd /app/frontend && npm run portfolio:refresh -- --workspace $TARGET_WORKSPACE --track $TRACK"
             if [ -n "${INPUT_THROUGH:-}" ]; then
@@ -134,14 +135,29 @@ jobs:
                 COMMAND="$COMMAND --replace-backtest"
               fi
             fi
-            flyctl ssh console --app "$FLY_APP" --command "sh -lc '$COMMAND'"
+            if ! flyctl ssh console --app "$FLY_APP" --command "sh -lc '$COMMAND'"; then
+              echo "::error::$TARGET_WORKSPACE/$TRACK refresh failed; remaining workspaces will still run."
+              FAILURES+=("$TARGET_WORKSPACE/$TRACK")
+            fi
           done
+          if [ "${#FAILURES[@]}" -gt 0 ]; then
+            echo "::error::Portfolio refresh failures: ${FAILURES[*]}"
+            exit 1
+          fi
 
       - name: Refresh backtest alongside scheduled paper tracking
-        if: github.event_name == 'schedule'
+        if: github.event_name == 'schedule' && always()
         run: |
           set -euo pipefail
+          FAILURES=()
           for TARGET_WORKSPACE in analysis nasdaq100; do
-            flyctl ssh console --app "$FLY_APP" --command \
-              "sh -lc 'cd /app/frontend && npm run portfolio:refresh -- --workspace $TARGET_WORKSPACE --track backtest --start-cutoff 2026-04-30'"
+            if ! flyctl ssh console --app "$FLY_APP" --command \
+              "sh -lc 'cd /app/frontend && npm run portfolio:refresh -- --workspace $TARGET_WORKSPACE --track backtest --start-cutoff 2026-04-30'"; then
+              echo "::error::$TARGET_WORKSPACE/backtest refresh failed; remaining workspaces will still run."
+              FAILURES+=("$TARGET_WORKSPACE/backtest")
+            fi
           done
+          if [ "${#FAILURES[@]}" -gt 0 ]; then
+            echo "::error::Portfolio backtest refresh failures: ${FAILURES[*]}"
+            exit 1
+          fi

--- a/frontend/scripts/refresh-portfolio-performance.ts
+++ b/frontend/scripts/refresh-portfolio-performance.ts
@@ -38,7 +38,10 @@ import {
   type PortfolioSnapshotDefinition,
   type PortfolioTrack,
 } from "../src/lib/portfolio-performance-engine";
-import { planPaperCutoffs } from "../src/lib/portfolio-refresh-policy";
+import {
+  planPaperCutoffs,
+  runPortfolioRefreshTasksIndependently,
+} from "../src/lib/portfolio-refresh-policy";
 import {
   enqueueArmedStrategiesForSnapshots,
   finishPortfolioRefreshRun,
@@ -552,8 +555,17 @@ async function main() {
   const methodologies = args.methodology === "all"
     ? PORTFOLIO_METHODOLOGIES
     : PORTFOLIO_METHODOLOGIES.filter((methodology) => methodology.key === args.methodology);
-  for (const methodology of methodologies) {
-    await refreshMethodology(args, methodology);
+  const results = await runPortfolioRefreshTasksIndependently(
+    methodologies,
+    (methodology) => refreshMethodology(args, methodology),
+  );
+  const failures = results.filter((result) => result.error !== null);
+  for (const failure of failures) {
+    const message = failure.error instanceof Error ? failure.error.message : String(failure.error);
+    console.error(`[portfolio] ${failure.item.key} methodology failed: ${message}`);
+  }
+  if (failures.length) {
+    throw new Error(`Portfolio refresh failed for ${failures.map((failure) => failure.item.key).join(", ")}; other methodologies were still attempted.`);
   }
 }
 

--- a/frontend/src/app/api/portfolio-performance/route.ts
+++ b/frontend/src/app/api/portfolio-performance/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from "next/server";
 
-import { loadMarketPrices, loadPortfolioNav, type StoredPortfolioNavPoint } from "@/lib/portfolio-db";
+import {
+  loadMarketPrices,
+  loadPortfolioNav,
+  loadPortfolioRefreshRunSummary,
+  type StoredPortfolioNavPoint,
+} from "@/lib/portfolio-db";
 import {
   PORTFOLIO_PROVIDER,
   PORTFOLIO_RISK_FREE_NAME,
@@ -15,6 +20,10 @@ import {
   type PortfolioTrack,
   type PortfolioMethodology,
 } from "@/lib/portfolio-performance-engine";
+import {
+  portfolioRefreshHealth,
+  type PortfolioRefreshHealth,
+} from "@/lib/portfolio-refresh-policy";
 import { parseApiWorkspace, type Workspace } from "@/lib/workspace";
 import { tradingPortfolioKey } from "@/lib/trading-types";
 
@@ -111,6 +120,7 @@ function emptyResponse(
   track: PortfolioTrack,
   period: PortfolioPeriod,
   methodology: PortfolioMethodology,
+  refreshHealth: PortfolioRefreshHealth,
   message?: string,
 ) {
   const config = portfolioWorkspaceConfig(workspace);
@@ -144,6 +154,16 @@ function emptyResponse(
       minimum_risk_observations: PORTFOLIO_RISK_MIN_OBSERVATIONS,
       public_beta: true,
     },
+    refresh: {
+      state: refreshHealth.state,
+      expected_after: refreshHealth.expectedAfter,
+      latest_status: refreshHealth.latestStatus,
+      latest_started_at: refreshHealth.latestStartedAt,
+      latest_finished_at: refreshHealth.latestFinishedAt,
+      last_successful_at: refreshHealth.lastSuccessfulAt,
+      last_usable_at: refreshHealth.lastUsableAt,
+      provider_warning_count: refreshHealth.providerWarningCount,
+    },
     range: { start: null, end: null },
     by_model: [],
     by_valuator: [],
@@ -167,9 +187,16 @@ export async function GET(request: Request) {
   if (!workspace) return NextResponse.json({ error: "Invalid workspace." }, { status: 400 });
   const methodology = resolvePortfolioMethodology(url.searchParams.get("methodology"));
   if (!methodology) return NextResponse.json({ error: "Invalid portfolio methodology." }, { status: 400 });
+  let refreshHealth = portfolioRefreshHealth(null);
   try {
+    const refreshSummary = await loadPortfolioRefreshRunSummary({
+      workspace,
+      track,
+      methodologyVersion: methodology.version,
+    });
+    refreshHealth = portfolioRefreshHealth(refreshSummary);
     const rows = await loadPortfolioNav(workspace, track, methodology.version);
-    if (!rows.length) return NextResponse.json(emptyResponse(workspace, track, period, methodology));
+    if (!rows.length) return NextResponse.json(emptyResponse(workspace, track, period, methodology, refreshHealth));
     const dates = rows.map((row) => row.date).sort();
     const riskFreePrices = await loadMarketPrices({
       symbols: [PORTFOLIO_RISK_FREE_SYMBOL],
@@ -188,7 +215,7 @@ export async function GET(request: Request) {
         return a.label.localeCompare(b.label);
       });
     return NextResponse.json({
-      ...emptyResponse(workspace, track, period, methodology),
+      ...emptyResponse(workspace, track, period, methodology, refreshHealth),
       available: true,
       message: null,
       range: { start: startDate || dates[0], end: dates[dates.length - 1] },
@@ -197,6 +224,6 @@ export async function GET(request: Request) {
     });
   } catch (error) {
     console.warn("[portfolio-performance] DB read failed:", error);
-    return NextResponse.json(emptyResponse(workspace, track, period, methodology));
+    return NextResponse.json(emptyResponse(workspace, track, period, methodology, refreshHealth));
   }
 }

--- a/frontend/src/components/portfolio-returns-section.tsx
+++ b/frontend/src/components/portfolio-returns-section.tsx
@@ -8,6 +8,8 @@ type PortfolioTrack = "paper" | "backtest";
 type PortfolioPeriod = "1m" | "3m" | "6m" | "1y" | "all";
 type PortfolioMethodologyKey = "equal" | "score_blend";
 type PortfolioMethodologyView = "compare" | PortfolioMethodologyKey;
+type PortfolioRefreshHealthState = "fresh" | "running" | "partial" | "failed" | "stale" | "missing";
+type PortfolioRefreshRunStatus = "running" | "completed" | "partial" | "failed";
 type PortfolioStatus = "ok" | "insufficient_history" | "no_positions" | "stale_market_data";
 type PortfolioRiskStatus = "ok" | "insufficient_history" | "risk_free_unavailable" | "stale_market_data";
 
@@ -60,6 +62,16 @@ type PortfolioPerformancePayload = {
     minimum_risk_observations: number;
     public_beta: boolean;
   };
+  refresh: {
+    state: PortfolioRefreshHealthState;
+    expected_after: string;
+    latest_status: PortfolioRefreshRunStatus | null;
+    latest_started_at: string | null;
+    latest_finished_at: string | null;
+    last_successful_at: string | null;
+    last_usable_at: string | null;
+    provider_warning_count: number;
+  };
   range: { start: string | null; end: string | null };
   by_model: PortfolioReturnRow[];
   by_valuator: PortfolioReturnRow[];
@@ -101,6 +113,34 @@ function returnTone(value: number | null): string {
     return "text-[color:var(--text-primary)]";
   }
   return value > 0 ? "text-[color:var(--success)]" : "text-[color:var(--danger)]";
+}
+
+function formatRefreshTimestamp(value: string | null): string {
+  if (!value) return "Never";
+  const date = new Date(value);
+  if (!Number.isFinite(date.getTime())) return "Unknown";
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const year = date.getUTCFullYear();
+  const hour = String(date.getUTCHours()).padStart(2, "0");
+  const minute = String(date.getUTCMinutes()).padStart(2, "0");
+  return `${day}/${month}/${year} ${hour}:${minute} UTC`;
+}
+
+function refreshStateLabel(state: PortfolioRefreshHealthState): string {
+  if (state === "fresh") return "Fresh";
+  if (state === "running") return "Refreshing";
+  if (state === "partial") return "Partial";
+  if (state === "failed") return "Failed";
+  if (state === "stale") return "Stale";
+  return "No history";
+}
+
+function refreshStateTone(state: PortfolioRefreshHealthState): string {
+  if (state === "fresh") return "text-[color:var(--success)]";
+  if (state === "running") return "text-[color:var(--info)]";
+  if (state === "partial" || state === "missing") return "text-[color:var(--warning)]";
+  return "text-[color:var(--danger)]";
 }
 
 function statusLabel(row: PortfolioReturnRow): string | null {
@@ -391,6 +431,52 @@ function ComparisonTable({
   );
 }
 
+function RefreshHealthCard({
+  label,
+  payload,
+}: {
+  label: string;
+  payload: PortfolioPerformancePayload | null;
+}) {
+  const refresh = payload?.refresh;
+  const state = refresh?.state || "missing";
+  const latestAttemptAt = refresh?.latest_finished_at || refresh?.latest_started_at || null;
+  return (
+    <article className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-3">
+      <div className="flex items-center justify-between gap-3">
+        <h4 className="text-xs font-semibold text-[color:var(--text-primary)]">{label}</h4>
+        <span className={`text-[10px] font-bold uppercase tracking-[0.12em] ${refreshStateTone(state)}`}>
+          {refreshStateLabel(state)}
+        </span>
+      </div>
+      <dl className="mt-2 space-y-1 text-[11px] text-[color:var(--text-muted)]">
+        <div className="flex flex-wrap justify-between gap-x-3 gap-y-1">
+          <dt>Last successful</dt>
+          <dd className="tabular-nums text-[color:var(--text-secondary)]">{formatRefreshTimestamp(refresh?.last_successful_at || null)}</dd>
+        </div>
+        <div className="flex flex-wrap justify-between gap-x-3 gap-y-1">
+          <dt>Latest attempt</dt>
+          <dd className="tabular-nums text-[color:var(--text-secondary)]">
+            {refresh?.latest_status ? `${refresh.latest_status} · ${formatRefreshTimestamp(latestAttemptAt)}` : "Not recorded"}
+          </dd>
+        </div>
+        {refresh?.provider_warning_count ? (
+          <div className="flex flex-wrap justify-between gap-x-3 gap-y-1 text-[color:var(--warning)]">
+            <dt>Provider warnings</dt>
+            <dd className="tabular-nums">{refresh.provider_warning_count}</dd>
+          </div>
+        ) : null}
+        {(state === "stale" || state === "missing") && refresh?.expected_after ? (
+          <div className="flex flex-wrap justify-between gap-x-3 gap-y-1 text-[color:var(--danger)]">
+            <dt>Expected refresh</dt>
+            <dd className="tabular-nums">{formatRefreshTimestamp(refresh.expected_after)}</dd>
+          </div>
+        ) : null}
+      </dl>
+    </article>
+  );
+}
+
 export function PortfolioReturnsSection() {
   const { workspace, api } = useWorkspace();
   const [track, setTrack] = useState<PortfolioTrack>("paper");
@@ -470,6 +556,16 @@ export function PortfolioReturnsSection() {
   const unavailableMessage = methodologyView === "compare"
     ? equalData?.message || scoreBlendData?.message
     : selectedData?.message;
+  const refreshEntries = [
+    { label: "Equal Weight", payload: equalData },
+    { label: "60/40 Score", payload: scoreBlendData },
+  ];
+  const refreshIssues = refreshEntries.filter(({ payload }) => (
+    !payload || ["partial", "failed", "stale", "missing"].includes(payload.refresh.state)
+  ));
+  const hasCriticalRefreshIssue = refreshIssues.some(({ payload }) => (
+    !payload || payload.refresh.state === "failed" || payload.refresh.state === "stale"
+  ));
 
   return (
     <section className="mb-6 rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-overlay)] p-4 sm:p-5">
@@ -514,6 +610,24 @@ export function PortfolioReturnsSection() {
             : selectedData?.methodology.construction}
         </p>
       </div>
+
+      {!loading ? (
+        <section className="mt-4" aria-label="Portfolio refresh health">
+          <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+            <h3 className="text-xs font-semibold uppercase tracking-[0.14em] text-[color:var(--text-secondary)]">Data refresh health</h3>
+            <p className="text-[11px] text-[color:var(--text-muted)]">Schedule-aware for the selected {track === "paper" ? "Paper" : "Backtest"} track</p>
+          </div>
+          {refreshIssues.length ? (
+            <div className={`mb-2 rounded-lg border bg-[color:var(--surface)] px-3 py-2 text-xs ${hasCriticalRefreshIssue ? "border-[color:var(--danger)] text-[color:var(--danger)]" : "border-[color:var(--warning)] text-[color:var(--warning)]"}`} role="alert">
+              Refresh attention: {refreshIssues.map(({ label, payload }) => `${label} is ${refreshStateLabel(payload?.refresh.state || "missing").toLowerCase()}`).join("; ")}. Stored returns remain visible, but compare the newest period only after both are Fresh.
+            </div>
+          ) : null}
+          <div className="grid gap-2 md:grid-cols-2">
+            <RefreshHealthCard label="Equal Weight" payload={equalData} />
+            <RefreshHealthCard label="60/40 Score" payload={scoreBlendData} />
+          </div>
+        </section>
+      ) : null}
 
       {loading ? (
         <div className="mt-4 grid gap-3 lg:grid-cols-2">

--- a/frontend/src/lib/portfolio-db.ts
+++ b/frontend/src/lib/portfolio-db.ts
@@ -8,6 +8,10 @@ import type {
   PortfolioSnapshotDefinition,
   PortfolioTrack,
 } from "@/lib/portfolio-performance-engine";
+import type {
+  PortfolioRefreshRunStatus,
+  PortfolioRefreshRunSummary,
+} from "@/lib/portfolio-refresh-policy";
 import type { Workspace } from "@/lib/workspace";
 
 export type PortfolioReportInput = {
@@ -86,6 +90,63 @@ export async function acquirePortfolioRefreshLock(lockKey: string, owner: string
 export async function releasePortfolioRefreshLock(lockKey: string, owner: string): Promise<void> {
   const sql = requireSql();
   await sql`DELETE FROM portfolio_refresh_locks WHERE lock_key = ${lockKey} AND owner = ${owner};`;
+}
+
+export async function loadPortfolioRefreshRunSummary(args: {
+  workspace: Workspace;
+  track: PortfolioTrack;
+  methodologyVersion: string;
+}): Promise<PortfolioRefreshRunSummary | null> {
+  const sql = requireSql();
+  const rows = (await sql`
+    SELECT latest.status AS latest_status,
+           latest.started_at::text AS latest_started_at,
+           latest.finished_at::text AS latest_finished_at,
+           CASE
+             WHEN jsonb_typeof(latest.provider_warnings) = 'array'
+             THEN jsonb_array_length(latest.provider_warnings)
+             ELSE 0
+           END AS provider_warning_count,
+           aggregates.last_successful_at::text AS last_successful_at,
+           aggregates.last_usable_at::text AS last_usable_at
+      FROM (
+        SELECT max(finished_at) FILTER (WHERE status = 'completed') AS last_successful_at,
+               max(finished_at) FILTER (WHERE status IN ('completed', 'partial')) AS last_usable_at
+          FROM portfolio_refresh_runs
+         WHERE workspace = ${args.workspace}
+           AND track = ${args.track}
+           AND methodology_version = ${args.methodologyVersion}
+      ) aggregates
+      LEFT JOIN LATERAL (
+        SELECT status, started_at, finished_at, provider_warnings
+          FROM portfolio_refresh_runs
+         WHERE workspace = ${args.workspace}
+           AND track = ${args.track}
+           AND methodology_version = ${args.methodologyVersion}
+         ORDER BY started_at DESC
+         LIMIT 1
+      ) latest ON true;
+  `) as Array<{
+    latest_status: PortfolioRefreshRunStatus | null;
+    latest_started_at: string | null;
+    latest_finished_at: string | null;
+    last_successful_at: string | null;
+    last_usable_at: string | null;
+    provider_warning_count: number;
+  }>;
+  const row = rows[0];
+  if (!row?.latest_status) return null;
+  const isoTimestamp = (value: string | null): string | null => (
+    value ? new Date(value).toISOString() : null
+  );
+  return {
+    latestStatus: row.latest_status,
+    latestStartedAt: isoTimestamp(row.latest_started_at),
+    latestFinishedAt: isoTimestamp(row.latest_finished_at),
+    lastSuccessfulAt: isoTimestamp(row.last_successful_at),
+    lastUsableAt: isoTimestamp(row.last_usable_at),
+    providerWarningCount: Number(row.provider_warning_count || 0),
+  };
 }
 
 export async function listPortfolioReportInputs(args: {

--- a/frontend/src/lib/portfolio-refresh-policy.test.ts
+++ b/frontend/src/lib/portfolio-refresh-policy.test.ts
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { planPaperCutoffs } from "./portfolio-refresh-policy";
+import {
+  latestExpectedPortfolioRefreshAt,
+  planPaperCutoffs,
+  portfolioRefreshHealth,
+  runPortfolioRefreshTasksIndependently,
+  type PortfolioRefreshRunSummary,
+} from "./portfolio-refresh-policy";
 
 test("an explicit Paper cutoff can repair a partially initialized track", () => {
   assert.deepEqual(planPaperCutoffs({
@@ -38,4 +44,80 @@ test("ongoing Paper refreshes retry existing cutoffs and add new month ends", ()
     defaultInitialCutoff: "2026-08-19",
     newMonthlyCutoffs: ["2026-08-31", "2026-08-31"],
   }), ["2026-07-31", "2026-08-18", "2026-08-31"]);
+});
+
+function refreshSummary(overrides: Partial<PortfolioRefreshRunSummary> = {}): PortfolioRefreshRunSummary {
+  return {
+    latestStatus: "completed",
+    latestStartedAt: "2026-08-26T01:30:00.000Z",
+    latestFinishedAt: "2026-08-26T02:00:00.000Z",
+    lastSuccessfulAt: "2026-08-26T02:00:00.000Z",
+    lastUsableAt: "2026-08-26T02:00:00.000Z",
+    providerWarningCount: 0,
+    ...overrides,
+  };
+}
+
+test("freshness schedule waits for grace and skips Sunday and Monday", () => {
+  assert.equal(
+    latestExpectedPortfolioRefreshAt(new Date("2026-08-26T05:00:00.000Z")),
+    "2026-08-25T01:30:00.000Z",
+  );
+  assert.equal(
+    latestExpectedPortfolioRefreshAt(new Date("2026-08-26T08:00:00.000Z")),
+    "2026-08-26T01:30:00.000Z",
+  );
+  assert.equal(
+    latestExpectedPortfolioRefreshAt(new Date("2026-08-31T12:00:00.000Z")),
+    "2026-08-29T01:30:00.000Z",
+  );
+});
+
+test("refresh health distinguishes fresh partial failed running stale and missing", () => {
+  const now = new Date("2026-08-26T08:00:00.000Z");
+  assert.equal(portfolioRefreshHealth(refreshSummary(), now).state, "fresh");
+  assert.equal(portfolioRefreshHealth(refreshSummary({
+    latestStatus: "partial",
+    lastSuccessfulAt: "2026-08-25T02:00:00.000Z",
+    providerWarningCount: 2,
+  }), now).state, "partial");
+  assert.equal(portfolioRefreshHealth(refreshSummary({
+    latestStatus: "failed",
+    latestStartedAt: "2026-08-26T03:00:00.000Z",
+    latestFinishedAt: "2026-08-26T03:05:00.000Z",
+    lastSuccessfulAt: "2026-08-26T02:00:00.000Z",
+    lastUsableAt: "2026-08-26T02:00:00.000Z",
+  }), now).state, "failed");
+  assert.equal(portfolioRefreshHealth(refreshSummary({
+    latestStatus: "running",
+    latestStartedAt: "2026-08-26T07:00:00.000Z",
+    latestFinishedAt: null,
+    lastSuccessfulAt: "2026-08-26T02:00:00.000Z",
+    lastUsableAt: "2026-08-26T02:00:00.000Z",
+  }), now).state, "running");
+  assert.equal(portfolioRefreshHealth(refreshSummary({
+    latestStatus: "running",
+    latestStartedAt: "2026-08-26T03:00:00.000Z",
+    latestFinishedAt: null,
+    lastSuccessfulAt: "2026-08-26T02:00:00.000Z",
+    lastUsableAt: "2026-08-26T02:00:00.000Z",
+  }), now).state, "stale");
+  assert.equal(portfolioRefreshHealth(refreshSummary({
+    latestStartedAt: "2026-08-25T01:30:00.000Z",
+    latestFinishedAt: "2026-08-25T02:00:00.000Z",
+    lastSuccessfulAt: "2026-08-25T02:00:00.000Z",
+    lastUsableAt: "2026-08-25T02:00:00.000Z",
+  }), now).state, "stale");
+  assert.equal(portfolioRefreshHealth(null, now).state, "missing");
+});
+
+test("methodology refresh failures do not prevent later methodologies from running", async () => {
+  const attempted: string[] = [];
+  const results = await runPortfolioRefreshTasksIndependently(["equal", "score_blend"], async (methodology) => {
+    attempted.push(methodology);
+    if (methodology === "equal") throw new Error("equal failed");
+  });
+  assert.deepEqual(attempted, ["equal", "score_blend"]);
+  assert.equal(results[0].error instanceof Error, true);
+  assert.equal(results[1].error, null);
 });

--- a/frontend/src/lib/portfolio-refresh-policy.ts
+++ b/frontend/src/lib/portfolio-refresh-policy.ts
@@ -14,3 +14,109 @@ export function planPaperCutoffs(args: {
     ...args.newMonthlyCutoffs,
   ])).sort();
 }
+
+export type PortfolioRefreshRunStatus = "running" | "completed" | "partial" | "failed";
+
+export type PortfolioRefreshRunSummary = {
+  latestStatus: PortfolioRefreshRunStatus | null;
+  latestStartedAt: string | null;
+  latestFinishedAt: string | null;
+  lastSuccessfulAt: string | null;
+  lastUsableAt: string | null;
+  providerWarningCount: number;
+};
+
+export type PortfolioRefreshHealthState = "fresh" | "running" | "partial" | "failed" | "stale" | "missing";
+
+export type PortfolioRefreshHealth = PortfolioRefreshRunSummary & {
+  state: PortfolioRefreshHealthState;
+  expectedAfter: string;
+};
+
+// Mirrors `.github/workflows/portfolio-performance.yml`: 01:30 UTC, Tuesday-Saturday.
+const REFRESH_HOUR_UTC = 1;
+const REFRESH_MINUTE_UTC = 30;
+const REFRESH_GRACE_HOURS = 6;
+const RUNNING_TIMEOUT_HOURS = 3;
+const HOUR_MS = 60 * 60 * 1000;
+
+function timestampMs(value: string | null): number {
+  if (!value) return 0;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function latestExpectedPortfolioRefreshAt(now: Date = new Date()): string {
+  const eligibleBefore = now.getTime() - (REFRESH_GRACE_HOURS * HOUR_MS);
+  const cursor = new Date(eligibleBefore);
+  cursor.setUTCHours(REFRESH_HOUR_UTC, REFRESH_MINUTE_UTC, 0, 0);
+  if (cursor.getTime() > eligibleBefore) cursor.setUTCDate(cursor.getUTCDate() - 1);
+  while (cursor.getUTCDay() < 2 || cursor.getUTCDay() > 6) {
+    cursor.setUTCDate(cursor.getUTCDate() - 1);
+  }
+  return cursor.toISOString();
+}
+
+export function portfolioRefreshHealth(
+  summary: PortfolioRefreshRunSummary | null,
+  now: Date = new Date(),
+): PortfolioRefreshHealth {
+  const expectedAfter = latestExpectedPortfolioRefreshAt(now);
+  const empty: PortfolioRefreshRunSummary = {
+    latestStatus: null,
+    latestStartedAt: null,
+    latestFinishedAt: null,
+    lastSuccessfulAt: null,
+    lastUsableAt: null,
+    providerWarningCount: 0,
+  };
+  if (!summary) return { ...empty, state: "missing", expectedAfter };
+
+  const latestStartedMs = timestampMs(summary.latestStartedAt);
+  const latestFinishedMs = timestampMs(summary.latestFinishedAt);
+  const lastSuccessfulMs = timestampMs(summary.lastSuccessfulAt);
+  const lastUsableMs = timestampMs(summary.lastUsableAt);
+  const expectedMs = timestampMs(expectedAfter);
+  const latestAttemptIsNewer = latestStartedMs > lastUsableMs;
+
+  if (summary.latestStatus === "running" && latestAttemptIsNewer) {
+    const state = now.getTime() - latestStartedMs <= RUNNING_TIMEOUT_HOURS * HOUR_MS
+      ? "running"
+      : "stale";
+    return { ...summary, state, expectedAfter };
+  }
+  if (summary.latestStatus === "failed" && latestAttemptIsNewer) {
+    return { ...summary, state: "failed", expectedAfter };
+  }
+  if (
+    summary.latestStatus === "partial"
+    && latestFinishedMs >= lastSuccessfulMs
+    && latestFinishedMs >= expectedMs
+  ) {
+    return { ...summary, state: "partial", expectedAfter };
+  }
+  if (!lastUsableMs) return { ...summary, state: "missing", expectedAfter };
+  if (lastUsableMs < expectedMs) return { ...summary, state: "stale", expectedAfter };
+  return { ...summary, state: "fresh", expectedAfter };
+}
+
+export type PortfolioRefreshTaskResult<T> = {
+  item: T;
+  error: unknown | null;
+};
+
+export async function runPortfolioRefreshTasksIndependently<T>(
+  items: readonly T[],
+  refresh: (item: T) => Promise<void>,
+): Promise<Array<PortfolioRefreshTaskResult<T>>> {
+  const results: Array<PortfolioRefreshTaskResult<T>> = [];
+  for (const item of items) {
+    try {
+      await refresh(item);
+      results.push({ item, error: null });
+    } catch (error) {
+      results.push({ item, error });
+    }
+  }
+  return results;
+}


### PR DESCRIPTION
## Summary

- Isolate portfolio refresh failures across methodologies, workspaces, and scheduled Paper/Backtest stages while preserving a failing workflow signal after every target is attempted.
- Derive schedule-aware Fresh/Running/Partial/Failed/Stale health from existing `portfolio_refresh_runs`, including last successful and latest-attempt timestamps.
- Surface per-method refresh health and explicit lag warnings beside the Equal Weight vs 60/40 comparison.

## Preview

URL: https://pr-146-hedge-in-a-box-site.fly.dev/analysis/hit-rate

## Test plan

- [x] `npm run test:portfolio` (44 tests)
- [x] Targeted ESLint on all changed TypeScript/TSX files
- [x] `npm run build`
- [x] Parse `.github/workflows/portfolio-performance.yml` as YAML
- [x] Preview workflow passed, including Neon branch bootstrap
- [x] Verify refresh metadata for Analysis and Nasdaq-100 across Paper/Backtest and Equal/60-40
- [x] Verify both Track Record routes return HTTP 200 and the deployed bundle contains the refresh cards/banner copy
- [ ] Interactive visual inspection: unavailable because the in-app browser runtime could not initialize in this session

## Preview evidence

- Analysis Backtest: Equal and 60/40 are independently `fresh` after completed refreshes.
- Analysis Paper: Equal is truthfully `partial` with one provider warning; 60/40 is `missing` until its first forward refresh.
- Nasdaq-100 Paper: Equal is `fresh`; 60/40 is `missing` until its first forward refresh.
- Nasdaq-100 Backtest: Equal is `fresh`; 60/40 is `missing` in the current preview data and is surfaced as such.

## Notes for reviewer

- No migration is required: `portfolio_refresh_runs` already stores status, warnings, and timestamps.
- Freshness mirrors the scheduled `30 1 * * 2-6` UTC cadence, allows a six-hour completion grace, and skips Sunday/Monday false alarms.
- A running attempt older than three hours is shown as Stale.
- Partial runs count as usable data but remain visibly Partial; `last_successful_at` remains completed-only.
- Each failed methodology records its own failed refresh run. The process exits non-zero only after all selected methodologies were attempted.
- Workflow loops similarly attempt every workspace, and scheduled Backtest uses `always()` so a Paper failure cannot suppress it.