### PR TITLE
fix: keep Nasdaq portfolio tracking forward-only

### DIFF
--- a/.github/workflows/portfolio-performance.yml
+++ b/.github/workflows/portfolio-performance.yml
@@ -91,11 +91,19 @@ jobs:
           fi
           WORKSPACE="${INPUT_WORKSPACE:-all}"
           if [ "$WORKSPACE" = "all" ]; then
-            WORKSPACES="analysis nasdaq100"
+            if [ "$TRACK" = "backtest" ]; then
+              WORKSPACES="analysis"
+            else
+              WORKSPACES="analysis nasdaq100"
+            fi
           elif [ "$WORKSPACE" = "analysis" ] || [ "$WORKSPACE" = "nasdaq100" ]; then
             WORKSPACES="$WORKSPACE"
           else
             echo "::error::workspace must be all, analysis, or nasdaq100"
+            exit 1
+          fi
+          if [ "$TRACK" = "backtest" ] && [ "$WORKSPACE" = "nasdaq100" ]; then
+            echo "::error::Nasdaq 100 portfolio tracking supports Paper only; Backtest is available in Analysis."
             exit 1
           fi
           if [ -n "${INPUT_THROUGH:-}" ] && ! [[ "$INPUT_THROUGH" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
@@ -150,7 +158,7 @@ jobs:
         run: |
           set -euo pipefail
           FAILURES=()
-          for TARGET_WORKSPACE in analysis nasdaq100; do
+          for TARGET_WORKSPACE in analysis; do
             if ! flyctl ssh console --app "$FLY_APP" --command \
               "sh -lc 'cd /app/frontend && npm run portfolio:refresh -- --workspace $TARGET_WORKSPACE --track backtest --start-cutoff 2026-04-30'"; then
               echo "::error::$TARGET_WORKSPACE/backtest refresh failed; remaining workspaces will still run."

--- a/docs/nasdaq100-workspace.md
+++ b/docs/nasdaq100-workspace.md
@@ -37,16 +37,16 @@ The command refuses to mark coverage complete unless every constituent group
 in the run's frozen universe snapshot has a saved report in the current release
 or another active release from the preceding seven days.
 
-The scheduled Portfolio Performance workflow refreshes both Analysis and
-Nasdaq 100. Nasdaq refreshes exit cleanly while there is no active release;
-after the first complete cohort they begin collecting Paper and Backtest NAV,
-QQQ benchmark history, and the `^IRX` 13-week Treasury yield used by Sharpe.
-The same tracks can also be refreshed manually:
+The scheduled Portfolio Performance workflow refreshes Analysis and Nasdaq 100.
+Nasdaq refreshes exit cleanly while there is no active release; after the first
+complete cohort they begin collecting forward-only Paper NAV, QQQ benchmark
+history, and the `^IRX` 13-week Treasury yield used by Sharpe. Nasdaq does not
+publish a Backtest track because no point-in-time Nasdaq release history existed
+before the forward cohort. Paper can also be refreshed manually:
 
 ```powershell
 Set-Location frontend
 npm run portfolio:refresh -- --workspace nasdaq100 --track paper
-npm run portfolio:refresh -- --workspace nasdaq100 --track backtest --start-cutoff 2026-04-30
 ```
 
 The workflow-dispatch form accepts `all`, `analysis`, or `nasdaq100`. Risk

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint",
     "test:middleware": "tsx --test src/middleware.test.ts",
     "portfolio:refresh": "tsx scripts/refresh-portfolio-performance.ts",
-    "test:portfolio": "tsx --test src/lib/discovery-engine.test.ts src/lib/nasdaq-execution-policy.test.ts src/lib/nasdaq-run-policy.test.ts src/lib/portfolio-performance-engine.test.ts src/lib/portfolio-refresh-policy.test.ts src/lib/trading-access-policy.test.ts src/lib/trading-db.test.ts src/lib/trading-signature.test.ts src/lib/workspace.test.ts"
+    "test:portfolio": "tsx --test src/lib/discovery-engine.test.ts src/lib/nasdaq-execution-policy.test.ts src/lib/nasdaq-run-policy.test.ts src/lib/portfolio-performance-engine.test.ts src/lib/portfolio-performance-route.test.ts src/lib/portfolio-refresh-policy.test.ts src/lib/trading-access-policy.test.ts src/lib/trading-db.test.ts src/lib/trading-signature.test.ts src/lib/workspace.test.ts"
   },
   "dependencies": {
     "@neondatabase/serverless": "^1.1.0",

--- a/frontend/scripts/refresh-portfolio-performance.ts
+++ b/frontend/scripts/refresh-portfolio-performance.ts
@@ -26,6 +26,7 @@ import {
   buildHoldingsForSnapshot,
   computePortfolioNavSeries,
   firstExecutionDateForCandidates,
+  isPortfolioTrackSupported,
   latestPriceOnOrBefore,
   PORTFOLIO_METHODOLOGIES,
   PORTFOLIO_PROVIDER,
@@ -95,6 +96,9 @@ function parseCliArgs(): CliArgs {
   const rawWorkspace = valueFor("--workspace") || "analysis";
   if (rawWorkspace !== "analysis" && rawWorkspace !== "nasdaq100") {
     throw new Error("--workspace must be analysis or nasdaq100.");
+  }
+  if (!isPortfolioTrackSupported(rawWorkspace, track)) {
+    throw new Error("Nasdaq 100 portfolio tracking supports Paper only; Backtest is available in Analysis.");
   }
   const throughDate = valueFor("--through") || new Date().toISOString().slice(0, 10);
   const startCutoff = valueFor("--start-cutoff") || "2026-04-30";
@@ -325,6 +329,7 @@ async function refreshMethodology(args: CliArgs, methodology: PortfolioMethodolo
         explicitCutoff: args.paperCutoff,
         existingCutoffDates,
         defaultInitialCutoff: previousNyCalendarDay(now),
+        methodologyLaunchCutoff: methodology.paperLaunchCutoff,
         newMonthlyCutoffs: latestCutoffDate
           ? monthlyCutoffDates(addDays(latestCutoffDate, 1), previousMonthEnd(now))
           : [],
@@ -364,6 +369,7 @@ async function refreshMethodology(args: CliArgs, methodology: PortfolioMethodolo
         existingCutoffDates: [],
         defaultInitialCutoff: previousNyCalendarDay(now),
         completedUniverseCutoff,
+        methodologyLaunchCutoff: methodology.paperLaunchCutoff,
         newMonthlyCutoffs: [],
       });
       console.log(`[portfolio] Nasdaq 100 initial Paper cutoff aligned to ${cutoffs[0]}, after full-cohort reporting.`);

--- a/frontend/src/app/api/portfolio-performance/route.ts
+++ b/frontend/src/app/api/portfolio-performance/route.ts
@@ -12,6 +12,7 @@ import {
   PORTFOLIO_RISK_FREE_SYMBOL,
   PORTFOLIO_RISK_MIN_OBSERVATIONS,
   PORTFOLIO_TRADING_DAYS_PER_YEAR,
+  isPortfolioTrackSupported,
   portfolioWorkspaceConfig,
   resolvePortfolioMethodology,
   summarizePortfolioPeriod,
@@ -185,6 +186,11 @@ export async function GET(request: Request) {
   if (rawStartDate && !startDate) return NextResponse.json({ error: "Invalid start date." }, { status: 400 });
   const workspace = parseApiWorkspace(url.searchParams.get("workspace"));
   if (!workspace) return NextResponse.json({ error: "Invalid workspace." }, { status: 400 });
+  if (!isPortfolioTrackSupported(workspace, track)) {
+    return NextResponse.json({
+      error: "Nasdaq 100 portfolio tracking supports Paper only; Backtest is available in Analysis.",
+    }, { status: 400 });
+  }
   const methodology = resolvePortfolioMethodology(url.searchParams.get("methodology"));
   if (!methodology) return NextResponse.json({ error: "Invalid portfolio methodology." }, { status: 400 });
   let refreshHealth = portfolioRefreshHealth(null);

--- a/frontend/src/components/portfolio-returns-section.tsx
+++ b/frontend/src/components/portfolio-returns-section.tsx
@@ -479,7 +479,8 @@ function RefreshHealthCard({
 
 export function PortfolioReturnsSection() {
   const { workspace, api } = useWorkspace();
-  const [track, setTrack] = useState<PortfolioTrack>("paper");
+  const [selectedTrack, setSelectedTrack] = useState<PortfolioTrack>("paper");
+  const track: PortfolioTrack = workspace === "nasdaq100" ? "paper" : selectedTrack;
   const [period, setPeriod] = useState<PortfolioPeriod>("all");
   const [methodologyView, setMethodologyView] = useState<PortfolioMethodologyView>("compare");
   const [dataByMethodology, setDataByMethodology] = useState<Record<PortfolioMethodologyKey, PortfolioPerformancePayload | null>>({
@@ -583,13 +584,15 @@ export function PortfolioReturnsSection() {
           </div>
         </div>
         <div className="flex flex-wrap gap-2">
-          <div className="inline-flex rounded-lg border border-[color:var(--border-strong)] bg-[color:var(--surface)] p-1" aria-label="Portfolio track">
-            {(["paper", "backtest"] as const).map((value) => (
-              <button key={value} type="button" onClick={() => setTrack(value)} disabled={loading && track !== value} className={`rounded-md px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.12em] transition disabled:cursor-not-allowed disabled:text-[color:var(--text-disabled)] ${track === value ? "bg-[color:var(--accent)] text-[color:var(--text-on-accent)]" : "text-[color:var(--text-secondary)] hover:text-[color:var(--text-primary)]"}`}>
-                {value === "paper" ? "Paper" : "Backtest"}
-              </button>
-            ))}
-          </div>
+          {workspace === "analysis" ? (
+            <div className="inline-flex rounded-lg border border-[color:var(--border-strong)] bg-[color:var(--surface)] p-1" aria-label="Portfolio track">
+              {(["paper", "backtest"] as const).map((value) => (
+                <button key={value} type="button" onClick={() => setSelectedTrack(value)} disabled={loading && track !== value} className={`rounded-md px-3 py-1.5 text-xs font-semibold uppercase tracking-[0.12em] transition disabled:cursor-not-allowed disabled:text-[color:var(--text-disabled)] ${track === value ? "bg-[color:var(--accent)] text-[color:var(--text-on-accent)]" : "text-[color:var(--text-secondary)] hover:text-[color:var(--text-primary)]"}`}>
+                  {value === "paper" ? "Paper" : "Backtest"}
+                </button>
+              ))}
+            </div>
+          ) : null}
           <select aria-label="Return period" value={period} onChange={(event) => setPeriod(event.target.value as PortfolioPeriod)} disabled={loading} className="rounded-lg border border-[color:var(--border-strong)] bg-[color:var(--surface)] px-3 py-2 text-xs font-semibold text-[color:var(--text-primary)] disabled:cursor-not-allowed disabled:text-[color:var(--text-disabled)]">
             {PERIODS.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
           </select>

--- a/frontend/src/lib/portfolio-performance-engine.test.ts
+++ b/frontend/src/lib/portfolio-performance-engine.test.ts
@@ -8,6 +8,7 @@ import {
   computePortfolioNavSeries,
   firstBenchmarkDateAfter,
   firstExecutionDateForCandidates,
+  isPortfolioTrackSupported,
   PORTFOLIO_RISK_MIN_OBSERVATIONS,
   PORTFOLIO_SCORE_BLEND_METHODOLOGY_VERSION,
   PORTFOLIO_TRADING_DAYS_PER_YEAR,
@@ -153,6 +154,13 @@ test("workspace config keeps Analysis on SP500TR and Nasdaq 100 on the QQQ adjus
   assert.equal(nasdaq.benchmarkSymbol, "QQQ");
   assert.equal(nasdaq.benchmarkName, "Invesco QQQ — total-return proxy");
   assert.match(nasdaq.universe, /active releases/i);
+});
+
+test("Backtest remains supported in Analysis but Nasdaq 100 is Paper-only", () => {
+  assert.equal(isPortfolioTrackSupported("analysis", "paper"), true);
+  assert.equal(isPortfolioTrackSupported("analysis", "backtest"), true);
+  assert.equal(isPortfolioTrackSupported("nasdaq100", "paper"), true);
+  assert.equal(isPortfolioTrackSupported("nasdaq100", "backtest"), false);
 });
 
 test("NAV starts flat at the execution close and rebalances only on the next snapshot date", () => {

--- a/frontend/src/lib/portfolio-performance-engine.ts
+++ b/frontend/src/lib/portfolio-performance-engine.ts
@@ -27,6 +27,7 @@ export type PortfolioMethodology = {
   label: string;
   shortLabel: string;
   construction: string;
+  paperLaunchCutoff: string | null;
   equalWeightFraction: number;
   scoreWeightFraction: number;
   maxEqualWeightMultiple: number | null;
@@ -40,6 +41,7 @@ export const PORTFOLIO_METHODOLOGIES: readonly PortfolioMethodology[] = [
     label: "Equal Weight",
     shortLabel: "Equal",
     construction: "Top 20 positive scores, equally weighted at each monthly rebalance.",
+    paperLaunchCutoff: null,
     equalWeightFraction: 1,
     scoreWeightFraction: 0,
     maxEqualWeightMultiple: null,
@@ -51,6 +53,7 @@ export const PORTFOLIO_METHODOLOGIES: readonly PortfolioMethodology[] = [
     label: "60/40 Score Blend",
     shortLabel: "60/40",
     construction: "60% equal weight and 40% proportional to positive score, capped at 2x equal weight.",
+    paperLaunchCutoff: "2026-08-25",
     equalWeightFraction: 0.6,
     scoreWeightFraction: 0.4,
     maxEqualWeightMultiple: 2,
@@ -64,6 +67,10 @@ export function resolvePortfolioMethodology(value?: string | null): PortfolioMet
   return PORTFOLIO_METHODOLOGIES.find((methodology) => (
     methodology.key === normalized || methodology.version.toLowerCase() === normalized
   )) || null;
+}
+
+export function isPortfolioTrackSupported(workspace: Workspace, track: PortfolioTrack): boolean {
+  return workspace === "analysis" || track === "paper";
 }
 export type PortfolioDataStatus = "ok" | "no_positions" | "stale_market_data";
 export type PortfolioRiskStatus =

--- a/frontend/src/lib/portfolio-performance-route.test.ts
+++ b/frontend/src/lib/portfolio-performance-route.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { GET } from "../app/api/portfolio-performance/route";
+
+test("Nasdaq 100 Backtest API requests are rejected before data access", async () => {
+  const response = await GET(new Request(
+    "http://localhost/api/portfolio-performance?workspace=nasdaq100&track=backtest&methodology=equal",
+  ));
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(await response.json(), {
+    error: "Nasdaq 100 portfolio tracking supports Paper only; Backtest is available in Analysis.",
+  });
+});

--- a/frontend/src/lib/portfolio-refresh-policy.test.ts
+++ b/frontend/src/lib/portfolio-refresh-policy.test.ts
@@ -37,6 +37,38 @@ test("a new full-universe Paper track starts after its final report date", () =>
   }), ["2026-08-24"]);
 });
 
+test("a methodology launch cutoff prevents a new Paper track from being backdated", () => {
+  assert.deepEqual(planPaperCutoffs({
+    explicitCutoff: null,
+    existingCutoffDates: [],
+    defaultInitialCutoff: "2026-08-25",
+    completedUniverseCutoff: "2026-08-24",
+    methodologyLaunchCutoff: "2026-08-25",
+    newMonthlyCutoffs: [],
+  }), ["2026-08-25"]);
+});
+
+test("complete-universe coverage remains the floor when it follows methodology launch", () => {
+  assert.deepEqual(planPaperCutoffs({
+    explicitCutoff: null,
+    existingCutoffDates: [],
+    defaultInitialCutoff: "2026-08-25",
+    completedUniverseCutoff: "2026-08-27",
+    methodologyLaunchCutoff: "2026-08-25",
+    newMonthlyCutoffs: [],
+  }), ["2026-08-27"]);
+});
+
+test("an explicit Paper cutoff cannot predate methodology launch", () => {
+  assert.throws(() => planPaperCutoffs({
+    explicitCutoff: "2026-08-24",
+    existingCutoffDates: [],
+    defaultInitialCutoff: "2026-08-25",
+    methodologyLaunchCutoff: "2026-08-25",
+    newMonthlyCutoffs: [],
+  }), /predates methodology launch cutoff 2026-08-25/);
+});
+
 test("ongoing Paper refreshes retry existing cutoffs and add new month ends", () => {
   assert.deepEqual(planPaperCutoffs({
     explicitCutoff: null,

--- a/frontend/src/lib/portfolio-refresh-policy.ts
+++ b/frontend/src/lib/portfolio-refresh-policy.ts
@@ -3,11 +3,21 @@ export function planPaperCutoffs(args: {
   existingCutoffDates: string[];
   defaultInitialCutoff: string;
   completedUniverseCutoff?: string | null;
+  methodologyLaunchCutoff?: string | null;
   newMonthlyCutoffs: string[];
 }): string[] {
-  if (args.explicitCutoff) return [args.explicitCutoff];
+  if (args.explicitCutoff) {
+    if (args.methodologyLaunchCutoff && args.explicitCutoff < args.methodologyLaunchCutoff) {
+      throw new Error(`Paper cutoff ${args.explicitCutoff} predates methodology launch cutoff ${args.methodologyLaunchCutoff}.`);
+    }
+    return [args.explicitCutoff];
+  }
   if (!args.existingCutoffDates.length) {
-    return [args.completedUniverseCutoff || args.defaultInitialCutoff];
+    const launchFloor = args.methodologyLaunchCutoff || args.defaultInitialCutoff;
+    return [[launchFloor, args.completedUniverseCutoff]
+      .filter((value): value is string => Boolean(value))
+      .sort()
+      .at(-1) as string];
   }
   return Array.from(new Set([
     ...args.existingCutoffDates,


### PR DESCRIPTION
## Summary

- Add a methodology-specific Paper launch cutoff so the 60/40 series cannot be backdated before its 2026-08-25 signal cutoff in Analysis or Nasdaq 100.
- Make Nasdaq 100 forward-only: hide Backtest in the UI, reject it in the API/CLI, and stop scheduled Nasdaq Backtest refreshes while preserving Analysis Backtest.
- Document the supported tracks and add regression coverage for launch floors, workspace support, and the API rejection path.

## Preview

URL: https://pr-147-hedge-in-a-box-site.fly.dev

## Test plan

- [x] `npm run test:portfolio` (49 tests)
- [x] Targeted ESLint on all changed TypeScript/TSX files
- [x] `npm run build`
- [x] Parse `.github/workflows/portfolio-performance.yml` as YAML
- [x] Verify the refresh CLI rejects `nasdaq100/backtest` before database access
- [x] Verify `/nasdaq100/hit-rate` hides Backtest and `/analysis/hit-rate` retains it on the preview
- [x] Verify preview API rejects Nasdaq Backtest with 400 while Analysis Backtest remains available
- [x] Run the Nasdaq 60/40 Paper refresh through 2026-08-25 and verify cutoff 2026-08-25 is deferred with zero snapshots until a later complete benchmark session exists

## Preview evidence

- `/nasdaq100/hit-rate`: HTTP 200; rendered HTML contains neither the Portfolio track selector nor a Backtest button.
- `/analysis/hit-rate`: HTTP 200; rendered HTML retains the Portfolio track selector and Backtest button.
- Nasdaq Backtest API: HTTP 400 with the explicit Paper-only workspace error.
- Analysis Backtest API: HTTP 200, `available=true`, fresh through 2026-08-26.
- Nasdaq 60/40 Paper: selected launch cutoff 2026-08-25, logged `no benchmark session after 2026-08-25`, created zero snapshots, and exposes no NAV range yet.

## Notes for reviewer

- Equal Weight Paper and all existing Paper snapshots remain unchanged.
- The 60/40 launch cutoff is `2026-08-25`, producing the first eligible execution session on or after `2026-08-26` once complete prices exist.
- Existing Nasdaq Backtest rows are not deleted by this PR; they become unreachable and scheduled refresh no longer extends them.
- Analysis Backtest remains fully supported in the UI, API, CLI, and scheduled workflow.
- User-facing Paper one-point messaging was explicitly left out of scope.
- Interactive browser inspection was unavailable because the browser runtime lacks its sandbox policy; preview verification used rendered route HTML and live API responses.