### PR TITLE
Show dashboard tab loading feedback

### DIFF
--- a/frontend/src/app/(app)/dashboard/[ticker]/loading.tsx
+++ b/frontend/src/app/(app)/dashboard/[ticker]/loading.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { DashboardSkeleton } from "@/components/dashboard-chrome";
+import { useTickerContext } from "@/components/shell/ticker-context";
+
+const SECTION_LABELS: Record<string, string> = {
+  summary: "Summary",
+  info: "Info",
+  overview: "Overview",
+  valuation: "Valuation",
+  financials: "Financials",
+  market: "Market",
+  "web-search": "Web Search",
+  scenarios: "Bull vs Bear",
+  "sec-qa": "SEC Q&A",
+  "wall-st": "Wall St.",
+  "technical-analysis": "Technical Analysis",
+  "dream-team": "Dream Team",
+  download: "Download",
+  artifacts: "Artifacts",
+};
+
+export default function DashboardTabLoading() {
+  const { activeSection } = useTickerContext();
+  const sectionLabel = activeSection ? SECTION_LABELS[activeSection] : undefined;
+  const message = sectionLabel ? `Loading ${sectionLabel}...` : "Loading dashboard...";
+
+  return <DashboardSkeleton message={message} />;
+}

--- a/frontend/src/components/dashboard-chrome.tsx
+++ b/frontend/src/components/dashboard-chrome.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { Check, ChevronDown } from "lucide-react";
+import { Check, ChevronDown, LoaderCircle } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import type { ReportListItem } from "@/lib/dashboard-types";
@@ -30,10 +30,15 @@ function scoreToneClass(value?: number | null): string {
 }
 
 export function DashboardSkeleton({ message }: { message?: string }) {
+  const loadingMessage = message || "Loading dashboard...";
+
   return (
-    <div>
-      <div className="mb-3 text-xs uppercase tracking-[0.14em] text-zinc-500">{message || "Loading dashboard..."}</div>
-      <div className="grid gap-4 md:grid-cols-3">
+    <div role="status" aria-busy="true" aria-live="polite">
+      <div className="mb-3 inline-flex items-center gap-2 text-xs uppercase tracking-[0.14em] text-zinc-500">
+        <LoaderCircle size={14} className="animate-spin" aria-hidden />
+        <span>{loadingMessage}</span>
+      </div>
+      <div className="grid gap-4 md:grid-cols-3" aria-hidden>
         {Array.from({ length: 6 }).map((_, i) => (
           <div key={i} className="h-32 animate-pulse rounded-xl border border-white/10 bg-white/5" />
         ))}

--- a/frontend/src/components/shell/topbar.tsx
+++ b/frontend/src/components/shell/topbar.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { Suspense, useEffect, useState } from "react";
-import Link from "next/link";
+import Link, { useLinkStatus } from "next/link";
 import { useSearchParams } from "next/navigation";
-import { BarChart3, Calculator, CandlestickChart, Download, FileQuestion, FileText, Globe2, Info, Landmark, Menu, Scale, Store, Users } from "lucide-react";
+import { BarChart3, Calculator, CandlestickChart, Download, FileQuestion, FileText, Globe2, Info, Landmark, LoaderCircle, Menu, Scale, Store, Users } from "lucide-react";
 import type { ComponentType } from "react";
 
 import { AuthMenu } from "@/components/shell/auth-menu";
@@ -33,6 +33,19 @@ const SECTIONS: SectionItem[] = [
 type TopbarProps = {
   onMobileMenu?: () => void;
 };
+
+function SectionPillContent({ item }: { item: SectionItem }) {
+  const { pending } = useLinkStatus();
+  const Icon = item.icon;
+
+  return (
+    <span className="inline-flex items-center gap-1.5" aria-busy={pending || undefined}>
+      {pending ? <LoaderCircle size={12} className="animate-spin" aria-hidden /> : <Icon size={12} />}
+      <span>{item.label}</span>
+      {pending ? <span className="sr-only"> loading</span> : null}
+    </span>
+  );
+}
 
 export function Topbar({ onMobileMenu }: TopbarProps) {
   const { activeTicker, activeSection } = useTickerContext();
@@ -144,19 +157,18 @@ function SectionPills({
         {SECTIONS.map((s) => {
           const active = activeSection === s.slug;
           const href = `${workspacePath(workspace, `/dashboard/${encodeURIComponent(activeTicker)}/${s.slug}`)}${suffix}`;
-          const Icon = s.icon;
           return (
             <Link
               key={s.slug}
               href={href}
+              aria-current={active ? "page" : undefined}
               className={`inline-flex shrink-0 items-center gap-1.5 rounded-lg border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] transition ${
                 active
                   ? "border-emerald-400/60 bg-emerald-500/20 text-emerald-100"
                   : "border-white/15 bg-white/5 text-zinc-300 hover:border-white/30 hover:text-zinc-100"
               }`}
             >
-              <Icon size={12} />
-              <span>{s.label}</span>
+              <SectionPillContent item={s} />
             </Link>
           );
         })}


### PR DESCRIPTION
## Summary

- add a route-level loading boundary for every ticker dashboard tab so navigation enters the destination immediately while server data resolves
- show destination-specific skeleton copy and a pending spinner on the clicked tab pill
- make the shared dashboard loading state accessible with status and busy semantics

## Preview

URL: https://pr-148-hedge-in-a-box-site.fly.dev

## Test plan

- [x] Targeted ESLint on the three changed frontend files
- [x] `npm run build` (Next.js 16.2.4 production build)
- [x] Local authenticated route smoke on AAPL across Summary, Info, Overview, Valuation, Financials, Market, Web Search, Bull vs Bear, SEC Q&A, Wall St., Technical Analysis, Dream Team, and Download; all returned HTTP 200 with the app shell
- [x] Preview deploy check passed; `/api/health` returned 200 and the preview exposed 464 Analysis reports
- [x] Preview runtime smoke on WIX Summary, Info, Overview, and Market returned HTTP 200; rendered responses included the loading skeleton, and deployed chunks included both `useLinkStatus` and the shared dashboard loading state

## Notes for reviewer

The delay was most visible on Info because it waits for the dashboard payload plus live Yahooquery and performance calls before its server component completes. Overview and Dream Team also add live server work, while most other tabs await `loadTickerData`. Summary and Valuation already fetch in the client. The new `[ticker]/loading.tsx` is intentionally shared so every current and future server-rendered dashboard tab gets the same immediate transition behavior.

The preview made the latency concrete: the WIX Info response took about 32 seconds and a cold Summary request about 61 seconds, while the server streamed the skeleton. In-app visual click-through was unavailable in this environment because the browser connection is missing `sandboxPolicy`; preview HTML, route responses, and deployed client chunks were verified instead.